### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.0.9

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 
-VERSION=t3.0.8
+VERSION=t3.0.9
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink-camera-manager/releases/download/${VERSION}/mavlink-camera-manager-armv7"


### PR DESCRIPTION
Select the biggest frame when running in BlueRovUDP default mode

Fix #541 

Docker: patrickelectric/companion-core:fix-camera

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>