### PR TITLE
core: nginx: do not cache version chooser

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -127,6 +127,8 @@ http {
             rewrite ^/version-chooser/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:8081;
             proxy_buffering off;
+            expires -1;
+            add_header Cache-Control no-store;
         }
 
         location /wifi-manager {


### PR DESCRIPTION
This can cause api mismatchs when the browser stores an older version of the frontend.

image up at williangalvani/companion-core:dont-cache-version-chooser

I'll test in the morning.