### PR TITLE
core: docker: Extend ignored paths

### DIFF
--- a/core/.dockerignore
+++ b/core/.dockerignore
@@ -3,5 +3,7 @@
 **/.mypy_cache
 **/.pytest_cache
 **/*.pyc
+**/*.egg-info
 **/node_modules
 **/dist
+**/build


### PR DESCRIPTION
Exclude `**/*.egg-info` and `**/build` folders, both created by python at modules install.