### PR TITLE
core: Dockerfile: Fix node version for frontend

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,5 +1,5 @@
 # Build frontend
-FROM node:current-buster-slim AS frontendBuilder
+FROM node:16-buster-slim AS frontendBuilder
 
 ARG VUE_APP_GIT_DESCRIBE
 


### PR DESCRIPTION
Without a fixed version, node versions will change and builds may break

current-buster-slim moved to node 17, breaking our current build. 

Fix #626 