### PR TITLE
core: start-companion-core: Increase nginx priority

### DIFF
--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -32,7 +32,7 @@ SERVICES=(
     'versionchooser',"$SERVICES_PATH/versionchooser/main.py"
     'ping',"$SERVICES_PATH/ping/main.py"
     'ttyd',"ttyd -p 8088 /usr/bin/tmux new-session \\\\; send-keys 'cat /etc/motd' C-m \\\\;"
-    'nginx',"nginx -g \"daemon off;\" -c $TOOLS_PATH/nginx/nginx.conf"
+    'nginx',"nice --18 nginx -g \"daemon off;\" -c $TOOLS_PATH/nginx/nginx.conf"
 )
 
 tmux -f /etc/tmux.conf start-server


### PR DESCRIPTION
Nginx is used to handle all backend communication and also the status of the backend to see if the connection is available.
Increases nginx priority to run over our services and help frontend to communicate with it.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>