### PR TITLE
core: services: cable_guy: Use temporary cache on get_interfaces

### DIFF
--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -8,6 +8,7 @@ from typing import Any, List
 
 import uvicorn
 from commonwealth.utils.apis import PrettyJSONResponse
+from commonwealth.utils.decorators import temporary_cache
 from commonwealth.utils.logs import InterceptHandler
 from fastapi import Body, FastAPI, HTTPException, status
 from fastapi.staticfiles import StaticFiles
@@ -55,6 +56,7 @@ app = FastAPI(
 
 @app.get("/ethernet", response_model=List[EthernetInterface], summary="Retrieve ethernet interfaces.")
 @version(1, 0)
+@temporary_cache(timeout_seconds=10)
 def retrieve_interfaces() -> Any:
     """REST API endpoint to retrieve the configured ethernet interfaces."""
     return manager.get_interfaces()


### PR DESCRIPTION
Improve the CPU usage, network interfaces will not change all the time,
10 seconds is a valid time to wait for new interfaces.

Fix #621 

Cpu usage is up to 20% now 