### PR TITLE
ardupilot-manager: Get stream from upload process

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -2,7 +2,7 @@ import asyncio
 import pathlib
 import subprocess
 from copy import deepcopy
-from typing import Any, List, Optional, Set
+from typing import Any, Iterable, List, Optional, Set
 
 import psutil
 from commonwealth.mavlink_comm.VehicleManager import VehicleManager
@@ -435,11 +435,11 @@ class ArduPilotManager(metaclass=Singleton):
     def get_available_firmwares(self, vehicle: Vehicle, platform: Platform) -> List[Firmware]:
         return self.firmware_manager.get_available_firmwares(vehicle, platform)
 
-    def install_firmware_from_file(self, firmware_path: pathlib.Path, board: FlightController) -> None:
-        self.firmware_manager.install_firmware_from_file(firmware_path, board)
+    def install_firmware_from_file(self, firmware_path: pathlib.Path, board: FlightController) -> Iterable[str]:
+        yield from self.firmware_manager.install_firmware_from_file(firmware_path, board)
 
-    def install_firmware_from_url(self, url: str, board: FlightController) -> None:
-        self.firmware_manager.install_firmware_from_url(url, board)
+    def install_firmware_from_url(self, url: str, board: FlightController) -> Iterable[str]:
+        yield from self.firmware_manager.install_firmware_from_url(url, board)
 
-    def restore_default_firmware(self, board: FlightController) -> None:
-        self.firmware_manager.restore_default_firmware(board)
+    def restore_default_firmware(self, board: FlightController) -> Iterable[str]:
+        yield from self.firmware_manager.restore_default_firmware(board)

--- a/core/services/ardupilot_manager/firmware/FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareInstall.py
@@ -4,7 +4,7 @@ import pathlib
 import platform as system_platform
 import shutil
 import stat
-from typing import Optional, Union
+from typing import Generator, Optional, Union
 
 from ardupilot_fw_decoder import BoardSubType, BoardType, Decoder
 from elftools.elf.elffile import ELFFile
@@ -129,15 +129,17 @@ class FirmwareInstaller:
         new_firmware_path: pathlib.Path,
         board: FlightController,
         firmware_dest_path: Optional[pathlib.Path] = None,
-    ) -> None:
+    ) -> Generator[str, None, None]:
         """Install given firmware."""
         if not new_firmware_path.is_file():
             raise InvalidFirmwareFile("Given path is not a valid file.")
 
         firmware_format = FirmwareDownloader._supported_firmware_formats[board.platform.type]
         if firmware_format == FirmwareFormat.ELF:
+            yield "Adding run permission to firmware file.\n"
             self.add_run_permission(new_firmware_path)
 
+        yield "Validating firmware.\n"
         self.validate_firmware(new_firmware_path, board.platform)
 
         if board.type == PlatformType.Serial:
@@ -145,12 +147,12 @@ class FirmwareInstaller:
             if not board.path:
                 raise ValueError("Board path not available.")
             firmware_uploader.set_autopilot_port(pathlib.Path(board.path))
-            firmware_uploader.upload(new_firmware_path)
-            return
+            yield from firmware_uploader.upload(new_firmware_path)
         if firmware_format == FirmwareFormat.ELF:
             # Using copy() instead of move() since the last can't handle cross-device properly (e.g. docker binds)
             if not firmware_dest_path:
                 raise FirmwareInstallFail("Firmware file destination not provided.")
+            yield "Copying firmware file to default location.\n"
             shutil.copy(new_firmware_path, firmware_dest_path)
             return
 

--- a/core/services/ardupilot_manager/firmware/FirmwareUpload.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareUpload.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import threading
 import time
+from typing import Generator
 
 from loguru import logger
 
@@ -44,7 +45,7 @@ class FirmwareUploader:
     def set_baudrate_flightstack(self, baudrate: int) -> None:
         self._baudrate_flightstack = baudrate
 
-    def upload(self, firmware_path: pathlib.Path) -> None:
+    def upload(self, firmware_path: pathlib.Path) -> Generator[str, None, None]:
         logger.info("Starting upload of firmware to board.")
         # pylint: disable=consider-using-with
         process = subprocess.Popen(
@@ -65,6 +66,7 @@ class FirmwareUploader:
             if process.stdout is not None:
                 for line in iter(process.stdout.readline, b""):
                     logger.debug(line)
+                    yield f"{line}\n"
                     if process.poll() is not None:
                         break
             while process.poll() is None:

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -16,6 +16,7 @@ from commonwealth.utils.apis import (
 from commonwealth.utils.general import is_running_as_root
 from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import Body, FastAPI, File, UploadFile, status
+from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
@@ -127,7 +128,10 @@ def get_available_firmwares(vehicle: Vehicle, board_name: Optional[str] = None) 
 async def install_firmware_from_url(url: str, board_name: Optional[str] = None) -> Any:
     try:
         await autopilot.kill_ardupilot()
-        autopilot.install_firmware_from_url(url, target_board(board_name))
+        return StreamingResponse(
+            autopilot.install_firmware_from_url(url, target_board(board_name)),
+            headers={"Content-Type": "application/text/plain"},
+        )
     finally:
         await autopilot.start_ardupilot()
 
@@ -140,11 +144,14 @@ async def install_firmware_from_file(binary: UploadFile = File(...), board_name:
         with open(custom_firmware, "wb") as buffer:
             shutil.copyfileobj(binary.file, buffer)
         await autopilot.kill_ardupilot()
-        autopilot.install_firmware_from_file(custom_firmware, target_board(board_name))
-        os.remove(custom_firmware)
+        return StreamingResponse(
+            autopilot.install_firmware_from_file(custom_firmware, target_board(board_name)),
+            headers={"Content-Type": "application/text/plain"},
+        )
     except InvalidFirmwareFile as error:
         raise StackedHTTPException(status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, error=error) from error
     finally:
+        os.remove(custom_firmware)
         binary.file.close()
         await autopilot.start_ardupilot()
 
@@ -191,7 +198,10 @@ async def stop() -> Any:
 async def restore_default_firmware(board_name: Optional[str] = None) -> Any:
     try:
         await autopilot.kill_ardupilot()
-        autopilot.restore_default_firmware(target_board(board_name))
+        return StreamingResponse(
+            autopilot.restore_default_firmware(target_board(board_name)),
+            headers={"Content-Type": "application/text/plain"},
+        )
     finally:
         await autopilot.start_ardupilot()
 

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -53,6 +53,7 @@ http {
             rewrite ^/ardupilot-manager$ /ardupilot-manager/ redirect;
             rewrite ^/ardupilot-manager/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:8000;
+            proxy_buffering off;
         }
 
         location /beacon {


### PR DESCRIPTION
I was playing with streaming info from a (fast)API during the weekend and thought about implementing this old demand (#500) on BlueOS, which would also help users regarding the firmware upload problems.

For some reason, this doesn't work on BlueOS. I don't know if it's a problem with CORS, or maybe NGINX, or maybe the HTTP headers, but there's something blocking the operation, so instead of receiving the stream message by message, the frontend is receiving the entire stream (all messages) at once in the end of the HTTP response.

As it's not a priority, I will leave it here if someone in interested in trying fixing it. Maybe it's some silly problem I didn't realize. Maybe not.

Fix #500 