### PR TITLE
core: tools: mavlink2rest: Update to latest version

### DIFF
--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink2rest"
 
-VERSION=t0.11.13
+VERSION=update_mavlink_latest
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink2rest/releases/download/${VERSION}/mavlink2rest-armv7-unknown-linux-musleabihf"


### PR DESCRIPTION
This is a on-going test to be sure that API compatibility will not break, there are some tests on mavlink2rest to check some basic stuff, but I'm going to test more on BlueOS and see if something breaks.

Ref: https://github.com/mavlink/rust-mavlink/pull/164