### PR TITLE
core: ardupilotmanager: fix support for autopilots on non-usb serial ports

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -69,7 +69,9 @@ class Detector:
         unique_serial_devices: List[SysFS] = []
         for port in sorted_serial_ports:
             # usb_device_path property will be the same for two serial connections using the same USB port
-            if port.usb_device_path not in [device.usb_device_path for device in unique_serial_devices]:
+            if (port.usb_device_path or port.name) not in [
+                (device.usb_device_path or device.name) for device in unique_serial_devices
+            ]:
                 unique_serial_devices.append(port)
         boards = [
             FlightController(


### PR DESCRIPTION
This works in my head. needs testing.