### PR TITLE
core: services: versionchooser: Allow updating bootstrap

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -274,6 +274,12 @@
           </a>
         </span>
         <span
+          v-if="bootstrap_version"
+          class="build_info"
+        >
+          Bootstrap Version: {{ bootstrap_version.split(':')[1] }}
+        </span>
+        <span
           id="current-version"
           class="build_info"
         >Build: {{ build_date }}</span>
@@ -328,6 +334,7 @@ import wifi from '@/store/wifi'
 import { Service } from '@/types/helper'
 import { convertGitDescribeToUrl } from '@/utils/helper_functions'
 import updateTime from '@/utils/update_time'
+import * as VCU from '@/utils/version_chooser'
 
 import Alerter from './components/app/Alerter.vue'
 import BackendStatusChecker from './components/app/BackendStatusChecker.vue'
@@ -400,6 +407,7 @@ export default Vue.extend({
       },
     ],
     selected_widgets: settings.user_top_widgets,
+    bootstrap_version: undefined as string|undefined,
   }),
   computed: {
     topWidgetsName(): string[] {
@@ -611,7 +619,7 @@ export default Vue.extend({
     },
   },
 
-  mounted() {
+  async mounted() {
     this.checkAddress()
     this.setupCallbacks()
     this.checkTour()
@@ -624,6 +632,7 @@ export default Vue.extend({
         this.context_menu_visible = false
       }
     })
+    this.bootstrap_version = await VCU.loadBootstrapCurrentVersion()
   },
   methods: {
     getWidget(name: string) {

--- a/core/frontend/src/components/version-chooser/VersionCard.vue
+++ b/core/frontend/src/components/version-chooser/VersionCard.vue
@@ -76,6 +76,54 @@
           Update to latest {{ image.tag }}
         </div>
       </v-btn>
+      <v-dialog
+        v-model="bootstrapDialog"
+        width="500"
+      >
+        <template #activator="{ on, attrs }">
+          <v-btn
+            v-if="showBootstrapUpdate"
+            color="warning"
+            class="mx-2 my-1"
+            :disabled="working"
+            dark
+            v-bind="attrs"
+            v-on="on"
+          >
+            Update Bootstrap
+          </v-btn>
+        </template>
+
+        <v-card>
+          <v-card-title
+            class="text-h5 red--text grey lighten-2"
+          >
+            Danger Zone
+          </v-card-title>
+
+          <v-card-text class="text-h6 ma-6">
+            Updating bootstrap is a <b>dangerous operation</b>, only do that when required and necessary.
+          </v-card-text>
+
+          <v-divider />
+
+          <v-card-actions>
+            <v-btn
+              color="primary"
+              @click="bootstrapDialog = false"
+            >
+              Abort
+            </v-btn>
+            <v-spacer />
+            <v-btn
+              color="warning"
+              @click="updateBootstrap"
+            >
+              I accept the risks
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
       <v-btn
         v-if="newBetaAvailable"
         color="primary"
@@ -136,6 +184,10 @@ export default Vue.extend({
       type: Boolean,
       default: false,
     },
+    bootstrapVersion: {
+      type: String as PropType<string | undefined>,
+      default: undefined,
+    },
     upToDate: {
       type: Boolean,
       default: false,
@@ -175,12 +227,23 @@ export default Vue.extend({
   },
   data() {
     return {
+      bootstrapDialog: false,
       settings,
     }
   },
   computed: {
     working(): boolean {
       return this.loading || this.deleting
+    },
+    isFromBR(): boolean {
+      return this.image.repository === 'bluerobotics/blueos-core'
+    },
+    showBootstrapUpdate(): boolean {
+      if (!this.bootstrapVersion) {
+        return false
+      }
+      return this.settings.is_pirate_mode && this.current && !this.updateAvailable && this.isFromBR
+        && this.bootstrapVersion !== `${this.image.repository.split('/')[0]}/blueos-bootstrap:${this.image.tag}`
     },
   },
   methods: {
@@ -195,6 +258,10 @@ export default Vue.extend({
     },
     imageCanBeDeleted() {
       return (this.image.tag !== 'factory' || this.image.repository !== DEFAULT_REMOTE_IMAGE) && !this.deleting
+    },
+    updateBootstrap() {
+      this.bootstrapDialog = false
+      this.$emit('update-bootstrap', `bluerobotics/blueos-bootstrap:${this.image.tag}`)
     },
   },
 })

--- a/core/frontend/src/types/frontend_services.ts
+++ b/core/frontend/src/types/frontend_services.ts
@@ -139,3 +139,10 @@ export const helper_service: Service = {
   company: 'Blue Robotics',
   version: '0.1.0',
 }
+
+export const version_chooser_service: Service = {
+  name: 'Version chooser service',
+  description: 'Manage versions of BlueOS and bootstrap',
+  company: 'Blue Robotics',
+  version: '0.1.0',
+}

--- a/core/frontend/src/types/version-chooser.ts
+++ b/core/frontend/src/types/version-chooser.ts
@@ -22,3 +22,16 @@ export enum VersionType {
   Beta = 'beta',
   Stable = 'stable',
 }
+
+// Used to get internal error or status from connexion
+export interface ServerResponse {
+  title: string,
+  status: number,
+  detail: string,
+  type: string,
+}
+
+export function isServerResponse(response: unknown): response is ServerResponse {
+  // eslint-disable-next-line no-extra-parens
+  return (response as ServerResponse).status !== undefined
+}

--- a/core/frontend/src/utils/version_chooser.ts
+++ b/core/frontend/src/utils/version_chooser.ts
@@ -5,7 +5,7 @@ import {
 } from '@/types/version-chooser'
 import back_axios from '@/utils/api'
 
-const API_URL = '/version-chooser/v1.0/version'
+const API_URL = '/version-chooser/v1.0'
 const DEFAULT_REMOTE_IMAGE = 'bluerobotics/blueos-core'
 
 function fixVersion(version: string): string | null {
@@ -127,7 +127,7 @@ function getLatestVersion(versions_query: VersionsQuery, current_version: Versio
 async function loadLocalVersions(): Promise<LocalVersionsQuery> {
   return back_axios({
     method: 'get',
-    url: `${API_URL}/available/local`,
+    url: `${API_URL}/version/available/local`,
   }).then((response) => {
     const available_versions = response.data as LocalVersionsQuery
     available_versions.local = available_versions.local.sort(compareVersions)
@@ -139,7 +139,7 @@ async function loadAvailableVersions(remote_image_name?: string): Promise<Versio
   remote_image_name = remote_image_name ?? DEFAULT_REMOTE_IMAGE
   return back_axios({
     method: 'get',
-    url: `${API_URL}/available/${remote_image_name}`,
+    url: `${API_URL}/version/available/${remote_image_name}`,
   }).then((response) => {
     const available_versions = response.data as VersionsQuery
     return sortImages(available_versions)
@@ -149,8 +149,16 @@ async function loadAvailableVersions(remote_image_name?: string): Promise<Versio
 async function loadCurrentVersion(): Promise<Version> {
   return back_axios({
     method: 'get',
-    url: `${API_URL}/current/`,
+    url: `${API_URL}/version/current/`,
   }).then((response) => response.data as Version)
+}
+
+async function loadBootstrapCurrentVersion(): Promise<string> {
+  return back_axios({
+    method: 'get',
+    url: `${API_URL}/bootstrap/current/`,
+    // eslint-disable-next-line no-extra-parens
+  }).then((response) => (typeof response.data === 'object' ? undefined : response.data))
 }
 
 export {
@@ -162,6 +170,7 @@ export {
   getVersionType,
   isSemVer,
   loadAvailableVersions,
+  loadBootstrapCurrentVersion,
   loadCurrentVersion,
   loadLocalVersions,
   sortImages,

--- a/core/services/versionchooser/main.py
+++ b/core/services/versionchooser/main.py
@@ -57,6 +57,16 @@ async def get_available_versions(repository: str, image: str) -> Any:
     return await versionChooser.get_available_versions(f"{repository}/{image}")
 
 
+async def get_bootstrap_version() -> Any:
+    return await versionChooser.get_bootstrap_version()
+
+
+async def set_bootstrap_version(request: web.Request) -> Any:
+    data = await request.json()
+    tag = data["tag"]
+    return await versionChooser.set_bootstrap_version(tag)
+
+
 async def load(request: web.Request) -> Any:
     data = await request.read()
     return await versionChooser.load(data)

--- a/core/services/versionchooser/openapi/versionchooser.yaml
+++ b/core/services/versionchooser/openapi/versionchooser.yaml
@@ -36,6 +36,31 @@ paths:
                   type: string
                   example: master
 
+  /bootstrap/current:
+    get:
+      operationId: main.get_bootstrap_version
+      summary: Return the current running version of BlueOS-bootstrap
+      responses:
+        '200':
+          description: The current running version of BlueOS-bootstrap
+    post:
+      operationId: main.set_bootstrap_version
+      summary: Sets the current version of BlueOS-bootstrap to a new tag
+      responses:
+        '200':
+          description: Successfully set a new version
+        '400':
+          description: Attempted to set an unavailable version
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tag:
+                  type: string
+                  example: master
+
   /version/restart:
     post:
       operationId: main.restart


### PR DESCRIPTION
Fix #1510 
![image](https://github.com/bluerobotics/BlueOS/assets/1215497/b0556665-3c0d-457b-831d-b2cfeda79187)
![image](https://github.com/bluerobotics/BlueOS/assets/1215497/de0f9d2c-ed3a-4488-8252-5e51807d56cf)

The button is only visible when the remote is the same as `bluerobotics`, and it'll only update to the version of the current BlueOS running.