### PR TITLE
bootstrap: add missing 'return False'  in is_running()

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -210,8 +210,10 @@ class Bootstrapper:
                 if "core" in response.json()["repository"]:
                     self.core_last_response_time = time.time()
                     return True
+                return False
             except Exception as e:
                 print(f"Could not talk to version chooser for {time.time() - self.core_last_response_time}: {e}")
+                return False
         return True
 
     def remove(self, container: str) -> None:

--- a/bootstrap/test_bootstrap.py
+++ b/bootstrap/test_bootstrap.py
@@ -218,3 +218,12 @@ class BootstrapperTests(TestCase):  # type: ignore
         bootstrapper.run()
         self.mock_response.json.return_value = {"repository": ["core"]}
         assert bootstrapper.is_running("core")
+
+    @pytest.mark.timeout(10)
+    def test_bootstrap_start_invalid_json(self) -> None:
+        self.fs.create_file(Bootstrapper.DEFAULT_FILE_PATH, contents=SAMPLE_JSON)
+        self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents="biscoito")
+        bootstrapper = Bootstrapper(FakeClient(), FakeLowLevelAPI())
+        bootstrapper.run()
+        self.mock_response.json.return_value = {"repository": ["core"]}
+        assert bootstrapper.is_running("core")

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -270,7 +270,6 @@ class Helper:
 
     @staticmethod
     @temporary_cache(timeout_seconds=1)  # a temporary cache helps us deal with changes in metadata
-    # pylint: disable=too-many-branches
     def detect_service(port: int) -> ServiceInfo:
         info = ServiceInfo(valid=False, title="Unknown", documentation_url="", versions=[], port=port)
 


### PR DESCRIPTION
not tested yet, but a docker is up at  williangalvani/blueos-bootstrap:addreturn