### PR TITLE
Fix bootstrap defaults file

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -30,17 +30,17 @@
                 "bind": "/var/logs/blueos",
                 "mode": "rw"
             },
-            '/run/udev': {
-                'bind': '/run/udev',
-                'mode': 'ro'
+            "/run/udev": {
+                "bind": "/run/udev",
+                "mode": "ro"
             },
-            '/etc/machine-id': {
-                'bind': '/etc/machine-id',
-                'mode': 'ro'
+            "/etc/machine-id": {
+                "bind": "/etc/machine-id",
+                "mode": "ro"
             },
-            '/etc/dhcpcd.conf': {
-                'bind': '/etc/dhcpcd.conf',
-                'mode': 'rw'
+            "/etc/dhcpcd.conf": {
+                "bind": "/etc/dhcpcd.conf",
+                "mode": "rw"
             },
             "/usr/blueos/userdata": {
                 "bind": "/usr/blueos/userdata",


### PR DESCRIPTION
master is throwing 
```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 33 column 13 (char 922)Starting 
```
when trying to rever to factory.