### PR TITLE
core: frontend: add cache-busting

### DIFF
--- a/core/frontend/src/views/ExtensionView.vue
+++ b/core/frontend/src/views/ExtensionView.vue
@@ -20,6 +20,7 @@ export default Vue.extend({
   data() {
     return {
       detected_port: undefined as number | undefined,
+      cache_busting_time: Date.now(),
     }
   },
   computed: {
@@ -33,6 +34,7 @@ export default Vue.extend({
     },
     service_path(): string {
       return `${window.location.protocol}//${window.location.hostname}:${this.detected_port}`
+      + `?time=${this.cache_busting_time}`
     },
   },
   watch: {


### PR DESCRIPTION
should fix #1907 

the idea here is that the query makes the browser think "this could be a different page" and not use a cached version.