### PR TITLE
core: services: beacon: Add blueos-ethernet for beacon

### DIFF
--- a/core/services/beacon/default-settings.json
+++ b/core/services/beacon/default-settings.json
@@ -9,7 +9,7 @@
     "interfaces": [
       {
         "name": "eth0",
-        "domain_names": ["blueos", "companion"],
+        "domain_names": ["blueos", "blueos-ethernet", "companion"],
         "advertise": ["_mavlink", "_http"],
         "ip": "ips[*]"
       },


### PR DESCRIPTION
Make it easy to configure softwares to connect on cable by default. 