### PR TITLE
core: services: beacon: Fix V2->V3 settings migration

### DIFF
--- a/core/services/beacon/settings.py
+++ b/core/services/beacon/settings.py
@@ -172,7 +172,7 @@ class SettingsV3(SettingsV2):
         try:
             if not any(interface["name"] == "uap0" for interface in data["interfaces"]):
                 data["interfaces"].append(
-                    Interface(name="uap0", domain_names=["blueos-hotspot"], advertise=["_http"], ip="ips[0]").as_dict()
+                    Interface(name="uap0", domain_names=["blueos-hotspot"], advertise=["_http"], ip="ips[0]")._data
                 )
         except Exception as e:
             logger.error(f"unable to update SettingsV2 to SettingsV3: {e}")

--- a/core/services/beacon/settings.py
+++ b/core/services/beacon/settings.py
@@ -41,7 +41,11 @@ class Interface(JsonObject):
 
     def get_ip_strs(self) -> List[str]:
         """
-        get ip as a string. this also translates 'ips[n]' to the n-th ip in that interface
+        returns a list of the interface IPs (IPv4 only) as a list of strings:
+        - if self.ip is "ips[*]", it returns all ips of that interface
+        - if self.ip is "ips[n]", it returns the n-th ip of that interface
+        - if self.ip is a single ipv4 (like "192.168.2.2"), it returns that ip as a string
+        - if self.ip is (mistakenly) an IPv6 or any other non-IPv4 format, it raises an InvalidIpAddress error
         """
         address = str(self.ip)
         # Check for 'ips[n]'
@@ -71,7 +75,7 @@ class Interface(JsonObject):
 
     def get_ips(self) -> List[bytes]:
         """
-        returns the ip as 4 bytes
+        returns a list of the interface IPs (IPv4 only) as a list of 4 bytes
         """
         return [socket.inet_aton(ip) for ip in self.get_ip_strs()]
 


### PR DESCRIPTION
Closes #1917 

### Details:
The settings expect the Interfaces to be:

```JSON
{
  "name": "uap0",
  "domain_names": ["blueos-hotspot"],
  "advertise": ["_http"],
  "ip": "ips[0]"
}
```

`as_dict` is not implemented in JsonObject, but `JsonObject`'s `._data` is what we need:
![image](https://github.com/bluerobotics/BlueOS/assets/5920286/674b45a0-df9f-42ce-847e-a5761bf57e6e)
