### PR TITLE
core: frontend: add display:block to BrIframe

### DIFF
--- a/core/frontend/src/components/utils/BrIframe.vue
+++ b/core/frontend/src/components/utils/BrIframe.vue
@@ -48,3 +48,8 @@ export default Vue.extend({
   },
 })
 </script>
+<style scoped>
+iframe {
+  display: block;
+}
+</style>


### PR DESCRIPTION
Fix #1930 
needs testing, waiting for the image to build

thanks @rafaellehmkuhl for the help finding the [issue](https://stackoverflow.com/questions/21025319/iframe-creates-extra-space-below#:~:text=The%20iframe%20element%20is%20an,bottom%3B%20to%20the%20iframe%20element.&text=The%20easiest%20way%20to%20do,%22%22%20in%20the%20iframe%20params)