### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.12.1

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.12.0
+VERSION=t3.12.1
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/mavlink/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
Most important changes:
- Fix untreated latency messages, which make the latency to be recalculated during the stream.
- Fix RTSP hot reload.


[Release notes](https://github.com/bluerobotics/mavlink-camera-manager/releases/tag/t3.12.1)