### PR TITLE
Switch to using an ssh key for accessing the host computer

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -34,6 +34,10 @@
                 "bind": "/run/udev",
                 "mode": "ro"
             },
+            "/home/pi/.ssh": {
+                "bind": "/home/pi/.ssh",
+                "mode": "rw"
+            },
             "/etc/machine-id": {
                 "bind": "/etc/machine-id",
                 "mode": "ro"

--- a/core/libs/commonwealth/commonwealth/utils/commands.py
+++ b/core/libs/commonwealth/commonwealth/utils/commands.py
@@ -1,7 +1,16 @@
 import subprocess
+from pathlib import Path
+
+from loguru import logger
 
 
-def run_command(command: str, check: bool = True) -> "subprocess.CompletedProcess['str']":
+class KeyNotFound(Exception):
+    """Raised when the SSH key is not found."""
+
+
+def run_command_with_password(command: str, check: bool = True) -> "subprocess.CompletedProcess['str']":
+    # attempt to run the command with sshpass
+    # used as a fallback if the ssh key is not found
     user = "pi"
     password = "raspberry"
 
@@ -21,3 +30,41 @@ def run_command(command: str, check: bool = True) -> "subprocess.CompletedProces
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+
+def run_command_with_ssh_key(command: str, check: bool = True) -> "subprocess.CompletedProcess['str']":
+    # attempt to run the command with the ssh key
+    user = "pi"
+    id_file = f"/home/{user}/.ssh/id_rsa"
+    if not Path(id_file).exists():
+        raise KeyNotFound
+
+    return subprocess.run(
+        [
+            "sshpass",
+            "ssh",
+            "-i",
+            id_file,
+            "-o",
+            "StrictHostKeyChecking=no",
+            f"{user}@localhost",
+            command,
+        ],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_command(command: str, check: bool = True) -> "subprocess.CompletedProcess['str']":
+    # runs the given command on the host computer.
+    # we first try with the ssh key, which is the default behavior.
+    # we need to fallback to sshpass as some systems will try to call this function before the ssh key is generated.
+    # this is the case for the first boot of this image after updating.
+    # not including the sshpass step causes blueos_startup_update to fail hard. crashing BlueOS as a whole.
+    try:
+        return run_command_with_ssh_key(command, check)
+    except Exception as error:
+        logger.warning(f"Failed to run command with SSH key. {error}, trying with sshpass:\n{command}")
+        return run_command_with_password(command, check)

--- a/core/tools/blueos_startup_update/blueos_startup_update
+++ b/core/tools/blueos_startup_update/blueos_startup_update
@@ -32,6 +32,10 @@ DELTA_JSON = {
             "/etc/resolv.conf.host": {
                 "bind": "/etc/resolv.conf.host",
                 "mode": "ro"
+            },
+            "/home/pi/.ssh": {
+                "bind": "/home/pi/.ssh",
+                "mode": "rw"
             }
         }
     }

--- a/core/tools/scripts/red-pill
+++ b/core/tools/scripts/red-pill
@@ -2,4 +2,4 @@ echo "You took the red pill."
 echo "You stay in Wonderland, and I show you how deep the rabbit hole goes."
 echo "Remember, all I'm offering is the truth. Nothing more."
 echo "Exiting from docker, welcome to the real world."
-sshpass -p raspberry ssh -o StrictHostKeyChecking=no pi@localhost
+ssh -i /root/.config/.ssh/id_rsa -o StrictHostKeyChecking=no pi@localhost


### PR DESCRIPTION
This adds the mount  `/home/pi/.ssh` into core.
if an id_rsa file already exists, it is used. if not, we create a new one.

we then switch commander to use the ssh key instead of the password.

The old sshpass behavior is kept as a fallback, as some things (cough blueos_startup_update) run before commander does the ssh setup.

helps #854 and #952 

