### PR TITLE
core: frontend: mavlink2rest: Add missing HEARTBEAT message id

### DIFF
--- a/core/frontend/src/libs/MAVLink2Rest/MessageID.ts
+++ b/core/frontend/src/libs/MAVLink2Rest/MessageID.ts
@@ -2,6 +2,7 @@ import { Dictionary } from '@/types/common'
 
 // Maps message names to message IDs
 const messageId: Dictionary<number> = {
+  HEARTBEAT: 0,
   SYS_STATUS: 1,
   SYSTEM_TIME: 2,
   PING: 4,


### PR DESCRIPTION

![image](https://github.com/bluerobotics/BlueOS/assets/5920286/cd361ed9-f254-48a4-9b91-a78a16c0d208)
