### PR TITLE
core: blueos_startup_update: set check=False when testing run_command()

### DIFF
--- a/core/tools/blueos_startup_update/blueos_startup_update
+++ b/core/tools/blueos_startup_update/blueos_startup_update
@@ -381,7 +381,7 @@ def ensure_user_data_structure_is_in_place() -> bool:
     return False
 
 def run_command_is_working():
-    output = run_command("uname -a")
+    output = run_command("uname -a", check=False)
     if output.returncode != 0:
         print(output)
         return False


### PR DESCRIPTION
The default is Check=True.
Check=True raises an exception when the return code is not zero (such as if the password was changed), that means we never actually return False. instead the script crashes and BlueOS is no more.