### PR TITLE
core: Dockerfile: Use new blueos-base:v0.0.10

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -14,12 +14,12 @@ RUN --mount=type=cache,target=/home/pi/frontend/node_modules yarn --cwd /home/pi
 COPY frontend/src/assets/vehicles /home/pi/frontend/dist/vehicles
 
 # Download binaries
-FROM bluerobotics/blueos-base:v0.0.9 as downloadBinaries
+FROM bluerobotics/blueos-base:v0.0.10 as downloadBinaries
 COPY tools /home/pi/tools
 RUN /home/pi/tools/install-static-binaries.sh
 
 # BlueOS-docker base image
-FROM bluerobotics/blueos-base:v0.0.9
+FROM bluerobotics/blueos-base:v0.0.10
 
 # Install necessary tools
 COPY tools /home/pi/tools


### PR DESCRIPTION
[Release log](https://github.com/bluerobotics/blueos-docker-base/releases/tag/v.0.0.10)