### PR TITLE
core: frontend: NetworkSpeedTest: Remove network result status

### DIFF
--- a/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
+++ b/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
@@ -76,16 +76,6 @@
           align="center"
           v-text="state"
         />
-        <v-alert
-          v-if="result"
-          dense
-          align-center
-          justify-center
-          flex-wrap
-          :type="result.type"
-        >
-          {{ result.message }}
-        </v-alert>
         <v-card-actions class="justify-center">
           <v-btn
             color="primary"
@@ -120,11 +110,6 @@ enum State {
   Done = 'Test done',
 }
 
-interface NetworkTestResult {
-  type: string;
-  message: string;
-}
-
 export default Vue.extend({
   name: 'NetworkSpeedTest',
   components: {
@@ -134,7 +119,6 @@ export default Vue.extend({
     return {
       max_speed: 100,
       state: State.None,
-      result: undefined as NetworkTestResult | undefined,
       speed: 0,
       download_speed: undefined as number | undefined,
       upload_speed: undefined as number | undefined,
@@ -205,31 +189,6 @@ export default Vue.extend({
           this.checkUploadSpeed()
           break
         case State.Done:
-          if (this.download_speed === undefined || this.upload_speed === undefined) {
-            break
-          }
-
-          if (this.download_speed >= 40 && this.upload_speed >= 40) {
-            this.result = {
-              type: 'success',
-              message: 'Great upload and download speed.',
-            }
-          } else if (this.download_speed < 40 && this.upload_speed < 40) {
-            this.result = {
-              type: 'error',
-              message: 'Download and upload speed are below threshold, check your hardware interface.',
-            }
-          } else if (this.upload_speed < 40) {
-            this.result = {
-              type: 'warning',
-              message: 'Upload speed below threshold, video may contain artifacts, check your hardware interface.',
-            }
-          } else if (this.download_speed < 40) {
-            this.result = {
-              type: 'warning',
-              message: 'Download speed below threshold, connection may be unstable, check your hardware interface.',
-            }
-          }
           break
         default:
           break


### PR DESCRIPTION
Since we are going to support boats and more vehicles, it's hard to have results for each one based one

now:
![image](https://github.com/bluerobotics/BlueOS/assets/1215497/ca7c580b-37b3-4fed-ab32-50b5eaea208e)

Before:
![image](https://github.com/bluerobotics/BlueOS/assets/1215497/69bbc945-1316-4fdf-9d01-bfa4537d3bfd)

Fix #1977 