### PR TITLE
Folder extensions

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -50,6 +50,10 @@
                 "bind": "/usr/blueos/userdata",
                 "mode": "rw"
             },
+            "/usr/blueos/extensions": {
+                "bind": "/usr/blueos/extensions",
+                "mode": "rw"
+            },
             "/etc/resolv.conf.host": {
                 "bind": "/etc/resolv.conf.host",
                 "mode": "ro"

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -71,6 +71,7 @@ RUN mkdir -p /shortcuts
 RUN ln -s /root/.config /shortcuts/configs
 RUN ln -s /var/logs/blueos/services /shortcuts/system_logs
 RUN ln -s /usr/blueos/userdata /shortcuts/userdata
+RUN ln -s /usr/blueos/extensions /shortcuts/extensions
 RUN ln -s /root/.config/ardupilot-manager /shortcuts/ardupilot_logs
 RUN ln -s / /shortcuts/system_root
 

--- a/core/tools/blueos_startup_update/blueos_startup_update
+++ b/core/tools/blueos_startup_update/blueos_startup_update
@@ -29,6 +29,10 @@ DELTA_JSON = {
                 "bind": "/usr/blueos/userdata",
                 "mode": "rw"
             },
+            "/usr/blueos/extensions": {
+                "bind": "/usr/blueos/extensions",
+                "mode": "rw"
+            },
             "/etc/resolv.conf.host": {
                 "bind": "/etc/resolv.conf.host",
                 "mode": "ro"


### PR DESCRIPTION
This PR able blueos-core to access /usr/blueos/extensions folder.

- Resolves #2003
- Enables the use of the standard discussed in #1640
