### PR TITLE
core: Use always in git describe

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -122,7 +122,7 @@ jobs:
           echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "buildx_args=\
-            --build-arg GIT_DESCRIBE_TAGS=$(git describe --tags --long) \
+            --build-arg GIT_DESCRIBE_TAGS=$(git describe --tags --long --always) \
             --build-arg VUE_APP_GIT_DESCRIBE=$(git describe --long --always --dirty --all) \
             --cache-from 'type=local,src=/tmp/.buildx-cache' \
             --cache-to 'type=local,dest=/tmp/.buildx-cache' \

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -59,7 +59,7 @@ RUN [ ! -d "/root/.config" ]
 ARG GIT_DESCRIBE_TAGS
 RUN [ -z "$GIT_DESCRIBE_TAGS" ] \
     && echo "GIT_DESCRIBE_TAGS argument not provided." \
-    && echo "Use: --build-arg GIT_DESCRIBE_TAGS=\$(git describe --tags --long)" \
+    && echo "Use: --build-arg GIT_DESCRIBE_TAGS=\$(git describe --tags --long --always)" \
     && exit 1 || exit 0
 
 # Update blueosrc with the necessary environment variables


### PR DESCRIPTION
From the helper:
```
       --always
           Show uniquely abbreviated commit object as fallback.
```

With that, people that fork the project will not be obligated to push a tag or something for the build to work, the hash will be used as fallback. 