### PR TITLE
core: services: versionchooser: chooser: Fix print format

### DIFF
--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -95,7 +95,7 @@ class VersionChooser:
             response_list = await self.client.images.import_image(data)
             response = response_list[0]
         except Exception as error:
-            logger.critical("Error: %s: %s", type(error), error)
+            logger.critical(f"Error: {type(error)}: {error}")
             return web.Response(status=500, text=f"Error: {type(error)}: {error}")
 
         if "errorDetail" in response:
@@ -167,7 +167,7 @@ class VersionChooser:
             bootstrap = await self.client.containers.get(self.bootstrap_name)  # type: ignore
             logger.info("Got bootstrap..")
         except Exception as error:
-            logger.critical("Warning: %s: %s", type(error), error)
+            logger.critical(f"Warning: {type(error)}: {error}")
 
         backup_name = "bootstrap-backup"
         try:
@@ -177,7 +177,7 @@ class VersionChooser:
             # We are going to remove backup even if it's running somehow
             await backup.delete(force=True, noprune=False)  # type: ignore
         except Exception as error:
-            logger.critical("warning: %s: %s", type(error), error)
+            logger.critical(f"Warning: {type(error)}: {error}")
 
         if bootstrap:
             logger.info(f"Setting current {await self.get_bootstrap_version()} as {backup_name}")
@@ -248,7 +248,7 @@ class VersionChooser:
                 return web.Response(status=500, text="Invalid version file")
 
             except Exception as error:
-                logger.critical("Error: %s: %s", type(error), error)
+                logger.critical(f"Error: {type(error)}: {error}")
                 return web.Response(status=500, text=f"Error: {type(error)}: {error}")
 
     async def delete_version(self, image: str, tag: str) -> web.StreamResponse:


### PR DESCRIPTION
This fix the format of the warning message

How python linter works ? Are they valid ? Do they exist ? Do they work ?
One day we will know. 

![200](https://github.com/bluerobotics/BlueOS/assets/1215497/4231adf8-027c-4576-b92b-464d386cd119)

Tested

![image](https://github.com/bluerobotics/BlueOS/assets/1215497/ae038478-653c-475d-ad07-70fc7e458015)

