### PR TITLE
frontend: Allow extensions to go full-screen

### DIFF
--- a/core/frontend/src/components/utils/BrIframe.vue
+++ b/core/frontend/src/components/utils/BrIframe.vue
@@ -15,6 +15,7 @@
       height="100%"
       width="100%"
       frameBorder="0"
+      allow="fullscreen"
       @load="loadFinished"
     />
   </v-sheet>


### PR DESCRIPTION
Fix #2045 

Edit: didn't work. Apparently we also need to [set some headers](https://canhas.report/permissions-policy-iframes).