### PR TITLE
core: try to create a new tmux session if user_terminal does not exist

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -82,7 +82,7 @@ SERVICES=(
     'pardal',"$SERVICES_PATH/pardal/main.py"
     'ping',"$SERVICES_PATH/ping/main.py"
     'user_terminal',"cat /etc/motd"
-    'ttyd',"ttyd -p 8088 /usr/bin/tmux attach -t user_terminal"
+    'ttyd','ttyd -p 8088 sh -c "/usr/bin/tmux attach -t user_terminal || /usr/bin/tmux new -s user_terminal"'
     'nginx',"nice --18 nginx -g \"daemon off;\" -c $TOOLS_PATH/nginx/nginx.conf"
     'log_zipper',"$SERVICES_PATH/log_zipper/main.py '/shortcuts/system_logs/**/*.log' --max-age-minutes 60"
     'bag_of_holding',"$SERVICES_PATH/bag_of_holding/main.py"


### PR DESCRIPTION
fix #2035 