### PR TITLE
core: ping: fix typo in mavlink driver

### DIFF
--- a/core/services/ping/ping1d_mavlink.py
+++ b/core/services/ping/ping1d_mavlink.py
@@ -55,7 +55,7 @@ class Ping1DMavlinkDriver:
             "horizontal_fov": 0.52,
             "vertical_fov": 0.52,
             "quaternion": [0, 0, 0, 0],
-            "signal_quality": min(1, confidence),  # 0 means undefined per MAVLink spec
+            "signal_quality": max(1, confidence),  # 0 means undefined per MAVLink spec
         }
 
     ## Send distance_sensor message to autopilot


### PR DESCRIPTION
raised here: https://github.com/bluerobotics/BlueOS/pull/1940/files#r1306488880