### PR TITLE
Revert "core: tools: linux2rest: Use latest version 0.4.8 <- 0.4.6"

### DIFF
--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -4,7 +4,7 @@
 set -e
 
 LOCAL_BINARY_PATH="/usr/bin/linux2rest"
-VERSION=v0.4.8
+VERSION=v0.4.6
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/linux2rest/releases/download/${VERSION}/linux2rest-armv7"


### PR DESCRIPTION
Reverts bluerobotics/BlueOS#2056

0.4.8 appears to have problems with cpu frequency and temperature sensor