### PR TITLE
install: remove random-seeds for a safer build

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -212,8 +212,11 @@ sed -i "\%^exit 0%idocker start blueos-bootstrap" /etc/rc.local || echo "Failed 
 echo "Starting network configuration."
 curl -fsSL $ROOT/install/network/avahi.sh | bash
 
+# Following https://systemd.io/BUILDING_IMAGES/
 echo "Restarting machine-id."
 rm /etc/machine-id && touch /etc/machine-id
+echo "Restarting random-seeds."
+rm -rf /var/lib/systemd/random-seed /loader/random-seed
 
 echo "Installation finished successfully."
 echo "You can access after the reboot:"


### PR DESCRIPTION
As a follow-up from #2083, based on [systemd](https://systemd.io/BUILDING_IMAGES/) we should also remove the random seeds.