### PR TITLE
core: ArdupilotManager: allow setting the SITL frame

### DIFF
--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -123,6 +123,12 @@ async def get_vehicle_type() -> Any:
     return await autopilot.vehicle_manager.get_vehicle_type()
 
 
+@app.post("/sitl_frame", summary="Set SITL Frame type.")
+@version(1, 0)
+async def set_sitl_frame(frame: SITLFrame) -> Any:
+    return autopilot.set_sitl_frame(frame)
+
+
 @app.get("/firmware_vehicle_type", response_model=str, summary="Get firmware vehicle type.")
 @version(1, 0)
 async def get_firmware_vehicle_type() -> Any:

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Union, cast
 import appdirs
 from loguru import logger
 
+from typedefs import SITLFrame
+
 SERVICE_NAME = "ardupilot-manager"
 
 
@@ -20,6 +22,7 @@ class Settings:
 
     blueos_files_folder = Path.joinpath(Path.home(), "blueos-files")
     defaults_folder = Path.joinpath(blueos_files_folder, "ardupilot-manager/default")
+    sitl_frame = SITLFrame.UNDEFINED
 
     def __init__(self) -> None:
         self.root: Dict[str, Union[int, Dict[str, Any]]] = {"version": 0, "content": {}}

--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -81,5 +81,6 @@ setuptools.setup(
         "pyelftools == 0.28",
         "psutil == 5.7.2",
         "pyserial == 3.5",
+        "pydantic == 1.10.12",
     ],
 )

--- a/core/services/install-services.sh
+++ b/core/services/install-services.sh
@@ -37,8 +37,8 @@ SERVICES=(
     wifi
 )
 
-# We need to install loguru and appdirs since they may be used inside setup.py
-python -m pip install appdirs==1.4.4 loguru==0.5.3
+# We need to install loguru, appdirs and pydantic since they may be used inside setup.py
+python -m pip install appdirs==1.4.4 loguru==0.5.3 pydantic==1.10.12
 
 for SERVICE in "${SERVICES[@]}"; do
     echo "Installing service: $SERVICE"


### PR DESCRIPTION
without this, all SITL instances try to use the "vectored" sub model, which doesn't work great with rover(and others) code.

fix #2094, we'd still need a ui update though