### PR TITLE
core: frontend: remove left-over mentions of 'service-scanner' component

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -318,7 +318,6 @@
       <router-view />
       <div id="tour-center-hook" />
     </v-main>
-    <services-scanner />
     <ethernet-updater />
     <wifi-updater />
     <mavlink-updater />
@@ -332,7 +331,6 @@
     />
   </v-app>
   <div v-else>
-    <services-scanner />
     <router-view />
   </div>
 </template>


### PR DESCRIPTION
it got removed in #2065 