### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.12.2

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.12.1
+VERSION=t3.12.2
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/mavlink/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
The most relevant updates for BlueOS here are:
* Thread leaks related to WebRTC got fixed, improving stability when working with Cockpit and 3rd-party WebRTC software.
* The MAVLink part was rewritten, getting rid of the most common error in the logs (the would-block errors)

[Full change log here](https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.12.2).