### PR TITLE
core: services: beacon: fix domain change bug

### DIFF
--- a/core/services/beacon/main.py
+++ b/core/services/beacon/main.py
@@ -114,7 +114,7 @@ class Beacon:
     def set_hostname(self, hostname: str) -> None:
         self.manager.settings.default.domain_names = [hostname]
         for interface in self.manager.settings.interfaces:
-            if interface.name.startswith("eth"):
+            if interface.name.startswith("eth") or interface.name.startswith("usb"):
                 interface.domain_names = [hostname, self.DEFAULT_HOSTNAME]  # let's keep our default just in case
             elif interface.name.startswith("wlan"):
                 interface.domain_names = [f"{hostname}-wifi"]


### PR DESCRIPTION
Allow USB-OTG to match the user's configured domain name, like the other network interfaces.

I haven't tested this, but it's straightforward enough that I assume it should work 🤷‍♂️ 

Fixes #1827