### PR TITLE
pyproject: Fix black version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ pytest-xdist = "^3.3.1"
 toml = "^0.10.2"
 
 [tool.poetry.dev-dependencies]
-black = "^22.1.0"
+black = "==22.3.0"
 isort = "^5.8"
 pylint = "^2.8"
 mypy = "1.4.1"


### PR DESCRIPTION
It's currently giving wrong error messages