### PR TITLE
core: ardupilot-manager: improve Pixhawk support

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
@@ -20,6 +20,7 @@ class SerialBoardIdentifier(BaseModel):
 identifiers: List[SerialBoardIdentifier] = [
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="Pixhawk1", platform=Platform.Pixhawk1),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v2.x", platform=Platform.Pixhawk1),
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v3.x", platform=Platform.Pixhawk1),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="Pixhawk4", platform=Platform.Pixhawk4),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v5.x", platform=Platform.Pixhawk4),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v6X.x", platform=Platform.Pixhawk6X),


### PR DESCRIPTION
[Some Pixhawk boards use FMUv3](https://discuss.ardupilot.org/t/determining-pixhawk-fmu-version/54312).

I'm hopeful this would avoid issues like [this one](https://discuss.bluerobotics.com/t/pixhawk-1-compatible-board-2-4-8-could-not-load-firmware-file-for-validation/15259), but haven't actually confirmed to make sure.