### PR TITLE
Don't modify /etc/dhcpd.conf if it does not exist

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -162,11 +162,16 @@ echo "Going to install blueos-docker version ${VERSION}."
 echo "Downloading and installing udev rules."
 curl -fsSL $ROOT/install/udev/100.autopilot.rules -o /etc/udev/rules.d/100.autopilot.rules
 
-echo "Disabling automatic Link-local configuration in dhcpd.conf."
-# delete line if it already exists
-sed -i '/noipv4ll/d' /etc/dhcpcd.conf
-# add noipv4ll
-sed -i '$ a noipv4ll' /etc/dhcpcd.conf
+if [ -f /etc/dhcpcd.conf ]
+then
+    echo "Disabling automatic Link-local configuration in dhcpd.conf."
+    # delete line if it already exists
+    sed -i '/noipv4ll/d' /etc/dhcpcd.conf
+    # add noipv4ll
+    sed -i '$ a noipv4ll' /etc/dhcpcd.conf
+else
+    echo "Not modifying /etc/dhcpcd.conf - file does not exist"
+fi
 
 # Do necessary changes if running in a Raspiberry
 command -v raspi-config && (


### PR DESCRIPTION
If /etc/dhcpd.conf didn't exist, this would crash with "sed: can't read /etc/dhcpcd.conf: No such file or directory".

Prevents a crash of the install script when installing on top of a clean install of Raspberry Pi OS.