### PR TITLE
core: bag-of-holdings: Disable CORS policy

### DIFF
--- a/core/tools/nginx/cors.conf
+++ b/core/tools/nginx/cors.conf
@@ -1,0 +1,6 @@
+if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Methods' '*';
+    add_header 'Access-Control-Allow-Headers' '*';
+    return 204;
+}

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -52,18 +52,21 @@ http {
         }
 
         location /ardupilot-manager {
+            include cors.conf;
             rewrite ^/ardupilot-manager$ /ardupilot-manager/ redirect;
             rewrite ^/ardupilot-manager/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:8000;
         }
 
         location /bag {
+            include cors.conf;
             rewrite ^/bag$ /bag/ redirect;
             rewrite ^/bag/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9101;
         }
 
         location /beacon {
+            include cors.conf;
             rewrite ^/beacon$ /beacon/ redirect;
             rewrite ^/beacon/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9111;
@@ -72,18 +75,21 @@ http {
         }
 
         location /bridget {
+            include cors.conf;
             rewrite ^/bridget$ /bridget/ redirect;
             rewrite ^/bridget/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:27353;
         }
 
         location /cable-guy {
+            include cors.conf;
             rewrite ^/cable-guy$ /cable-guy/ redirect;
             rewrite ^/cable-guy/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9090;
         }
 
         location /commander {
+            include cors.conf;
             rewrite ^/commander$ /commander/ redirect;
             rewrite ^/commander/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9100;
@@ -105,18 +111,21 @@ http {
         }
 
         location /helper {
+            include cors.conf;
             rewrite ^/helper$ /helper/ redirect;
             rewrite ^/helper/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:81;
         }
 
         location /kraken {
+            include cors.conf;
             rewrite ^/kraken$ /kraken/ redirect;
             rewrite ^/kraken/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9134;
         }
 
         location /nmea-injector {
+            include cors.conf;
             rewrite ^/nmea-injector$ /nmea-injector/ redirect;
             rewrite ^/nmea-injector/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:2748;
@@ -131,9 +140,7 @@ http {
             # Hide the header from the upstream application
             proxy_hide_header Access-Control-Allow-Origin;
 
-            # Add the desired header value
-            add_header Access-Control-Allow-Origin *;
-
+            include cors.conf;
             rewrite ^/mavlink2rest$ /mavlink2rest/ redirect;
             rewrite ^/mavlink2rest/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:6040;
@@ -143,12 +150,14 @@ http {
         }
 
         location /mavlink-camera-manager {
+            include cors.conf;
             rewrite ^/mavlink-camera-manager$ /mavlink-camera-manager/ redirect;
             rewrite ^/mavlink-camera-manager/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:6020;
         }
 
         location /network-test {
+            include cors.conf;
             rewrite ^/network-test$ /network-test/ redirect;
             rewrite ^/network-test/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9120;
@@ -158,6 +167,7 @@ http {
         }
 
         location /system-information {
+            include cors.conf;
             rewrite ^/system-information$ /system-information/ redirect;
             rewrite ^/system-information/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:6030;
@@ -176,6 +186,7 @@ http {
         }
 
         location /version-chooser {
+            include cors.conf;
             rewrite ^/version-chooser$ /version-chooser/ redirect;
             rewrite ^/version-chooser/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:8081;
@@ -185,12 +196,14 @@ http {
         }
 
         location /wifi-manager {
+            include cors.conf;
             rewrite ^/wifi-manager$ /wifi-manager/ redirect;
             rewrite ^/wifi-manager/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9000;
         }
 
         location /ping {
+            include cors.conf;
             rewrite ^/ping$ /ping/ redirect;
             rewrite ^/ping/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9110;


### PR DESCRIPTION
This patch allows external applications, like Cockpit, to use the service to store configuration data.