### PR TITLE
BlueOS: Update to use mavlink2rest to 0.11.18

### DIFF
--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink2rest"
 
-VERSION=t0.11.13
+VERSION=t0.11.18
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/mavlink/mavlink2rest/releases/download/${VERSION}/mavlink2rest-armv7-unknown-linux-musleabihf"


### PR DESCRIPTION
Change logs:
- https://github.com/mavlink/mavlink2rest/releases/tag/t0.11.18
- https://github.com/mavlink/mavlink2rest/releases/tag/t0.11.17
- https://github.com/mavlink/mavlink2rest/releases/tag/t0.11.16
- https://github.com/mavlink/mavlink2rest/releases/tag/t0.11.15
- https://github.com/mavlink/mavlink2rest/releases/tag/t0.11.14