### PR TITLE
core: frontend: Extensions Manager: fix buttons 'escaping' extension cards

### DIFF
--- a/core/frontend/src/components/kraken/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/InstalledExtensionCard.vue
@@ -133,7 +133,7 @@
       </v-expansion-panel>
     </v-expansion-panels>
 
-    <v-card-actions>
+    <v-card-actions class="card-actions">
       <v-btn @click="$emit('uninstall', extension)">
         Uninstall
       </v-btn>
@@ -290,3 +290,8 @@ export default Vue.extend({
   },
 })
 </script>
+<style scoped>
+.card-actions {
+  flex-wrap: wrap;
+}
+</style>


### PR DESCRIPTION
before
<img width="673" alt="image" src="https://github.com/bluerobotics/BlueOS/assets/4013804/96b3d5fe-7137-45b7-853f-13c789f81fdf">


after
<img width="631" alt="image" src="https://github.com/bluerobotics/BlueOS/assets/4013804/3cdb69cb-3426-4633-b910-5c34c9631406">
