### PR TITLE
core: frontend: extensions manager: use flex container to display extension cards

### DIFF
--- a/core/frontend/src/components/kraken/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/InstalledExtensionCard.vue
@@ -15,7 +15,7 @@
       </v-btn>
     </v-card-title>
     <span class="mt-0 mb-4 ml-4 text--disabled">{{ extension.docker }}</span>
-    <v-card-text width="50%">
+    <v-card-text>
       <v-simple-table>
         <template #default>
           <tbody>
@@ -290,3 +290,8 @@ export default Vue.extend({
   },
 })
 </script>
+<style scoped>
+.card-actions {
+  flex-wrap: wrap;
+}
+</style>

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -103,31 +103,26 @@
         v-if="tab === 1"
         class="pa-6"
       >
-        <v-row
-          dense
-        >
-          <v-col
+        <div v-if="tab === 1" class="installed-extensions-container">
+          <installed-extension-card
             v-for="extension in installed_extensions"
             :key="extension.docker"
-            class="pa-2 col-6"
-          >
-            <installed-extension-card
-              :extension="extension"
-              :loading="extension.loading"
-              :metrics="metricsFor(extension)"
-              :container="getContainer(extension)"
-              :versions="remoteVersions(extension)"
-              :extension-data="remoteVersions(extension)"
-              @edit="openEditDialog"
-              @showlogs="showLogs(extension)"
-              @uninstall="uninstall(extension)"
-              @disable="disable(extension)"
-              @enable="enableAndStart(extension)"
-              @restart="restart(extension)"
-              @update="update"
-            />
-          </v-col>
-        </v-row>
+            :extension="extension"
+            :loading="extension.loading"
+            :metrics="metricsFor(extension)"
+            :container="getContainer(extension)"
+            :versions="remoteVersions(extension)"
+            :extension-data="remoteVersions(extension)"
+            class="installed-extension-card"
+            @edit="openEditDialog"
+            @showlogs="showLogs(extension)"
+            @uninstall="uninstall(extension)"
+            @disable="disable(extension)"
+            @enable="enableAndStart(extension)"
+            @restart="restart(extension)"
+            @update="update"
+          />
+        </div>
         <v-container
           v-if="Object.keys(installed_extensions).isEmpty()"
           class="text-center"
@@ -614,6 +609,18 @@ export default Vue.extend({
 </script>
 
 <style>
+.installed-extensions-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.installed-extension-card {
+  margin: 10px;
+  flex: 1 1 400px;
+}
+
 .jv-code {
   padding: 0px !important;
 }


### PR DESCRIPTION
fix #1538 

after:

<img width="1233" alt="image" src="https://github.com/bluerobotics/BlueOS/assets/4013804/8321c97a-685b-4112-a967-a13d4d9e6956">
