### PR TITLE
core: frontend: fix ardupilotmanager "/" endpoint

### DIFF
--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -239,6 +239,9 @@ def available_boards() -> Any:
     return autopilot.available_boards(True)
 
 
+app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)
+
+
 @app.get("/")
 async def root() -> HTMLResponse:
     html_content = """
@@ -249,9 +252,6 @@ async def root() -> HTMLResponse:
     </html>
     """
     return HTMLResponse(content=html_content, status_code=200)
-
-
-app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
it needs to be defined after we declare everything else as a versioned api.

fix #2220