### PR TITLE
CI: pre-push-hooks: use xargs syntax compatible with both Linux and Macos

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -66,7 +66,7 @@ echo "Running shellcheck..."
 #SC2046: Allow word splitting
 #SC2048: Allow word splitting
 #SC2086: Allow word splitting
-git ls-files '*.sh' | xargs --max-lines=1 shellcheck --exclude=SC2005,SC2015,SC2046,SC2048,SC2086
+git ls-files '*.sh' | xargs -L 1 shellcheck --exclude=SC2005,SC2015,SC2046,SC2048,SC2086
 
 echo "Running isort.."
 # Run isort for each python project


### PR DESCRIPTION
(using CI to test for linux)