### PR TITLE
core: ArdupilotManager: skip some tests on MacOS

### DIFF
--- a/core/services/ardupilot_manager/firmware/test_FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareDownload.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import pytest
 
@@ -47,6 +48,9 @@ def test_firmware_download() -> None:
 
     assert firmware_download.download(Vehicle.Sub, Platform.SITL), "Failed to download SITL."
 
+    # skipt these tests for MacOS
+    if platform.system() == "Darwin":
+        pytest.skip("Skipping test for MacOS")
     # It'll fail if running in an arch different of ARM
     if "x86" in os.uname().machine:
         assert firmware_download.download(Vehicle.Sub, Platform.Navigator), "Failed to download navigator binary."

--- a/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
@@ -1,4 +1,5 @@
 import pathlib
+import platform
 
 import pytest
 
@@ -19,9 +20,11 @@ def test_firmware_validation() -> None:
     temporary_file = downloader.download(Vehicle.Sub, Platform.Pixhawk4)
     installer.validate_firmware(temporary_file, Platform.Pixhawk4)
 
-    # New SITL firmwares should always work
-    temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
-    installer.validate_firmware(temporary_file, Platform.SITL)
+    # New SITL firmwares should always work, except for MacOS
+    # there are no SITL builds for MacOS
+    if platform.system() != "Darwin":
+        temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
+        installer.validate_firmware(temporary_file, Platform.SITL)
 
     # Raise when validating Navigator firmwares (as test platform is x86)
     temporary_file = downloader.download(Vehicle.Sub, Platform.Navigator)
@@ -29,6 +32,8 @@ def test_firmware_validation() -> None:
         installer.validate_firmware(temporary_file, Platform.Navigator)
 
     # Install SITL firmware
-    temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
-    board = FlightController(name="SITL", manufacturer="ArduPilot Team", platform=Platform.SITL)
-    installer.install_firmware(temporary_file, board, pathlib.Path(f"{temporary_file}_dest"))
+    if platform.system() != "Darwin":
+        # there are no SITL builds for MacOS
+        temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
+        board = FlightController(name="SITL", manufacturer="ArduPilot Team", platform=Platform.SITL)
+        installer.install_firmware(temporary_file, board, pathlib.Path(f"{temporary_file}_dest"))


### PR DESCRIPTION
Ardupilot manager tests fail my pre-push hooks here.
@rafaellehmkuhl can you confirm that there are no binaries for mac? have you ran into these failing tests before?