### PR TITLE
[Feature] - Add BlueOS specific custom aliases [WIP]

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -2,6 +2,6 @@ FROM debian:buster-slim
 RUN apt update && apt install -y python3 python3-setuptools python3-pip --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY startup.json.default bootstrap/ /bootstrap/
 COPY main.py /
-COPY ../install/alias/.bash_aliases_blueos /etc/blueos/.bash_aliases_blueos
+COPY blueos_aliases/.bash_aliases_blueos /etc/blueos/.bash_aliases_blueos
 RUN python3 bootstrap/setup.py install
 ENTRYPOINT /main.py

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -2,5 +2,6 @@ FROM debian:buster-slim
 RUN apt update && apt install -y python3 python3-setuptools python3-pip --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY startup.json.default bootstrap/ /bootstrap/
 COPY main.py /
+COPY ../install/alias/.bash_aliases_blueos /etc/blueos/.bash_aliases_blueos
 RUN python3 bootstrap/setup.py install
 ENTRYPOINT /main.py

--- a/bootstrap/blueos_aliases/.bash_aliases_blueos
+++ b/bootstrap/blueos_aliases/.bash_aliases_blueos
@@ -1,0 +1,12 @@
+sudo() {
+    if [[ $1 == "apt-get" && $2 == "upgrade" ]]; then
+        if [[ $3 != "--walk-the-plank" ]]; then
+            echo "WARNING: 'sudo apt-get upgrade' not allowed without --walk-the-plank\nThis method will upgrade the kernel and can break some compatibility"
+            return 1
+        else
+            command sudo apt-get upgrade
+        fi
+    else
+        command sudo "$@"
+    fi
+}

--- a/core/tools/blueos_startup_update/blueos_startup_update
+++ b/core/tools/blueos_startup_update/blueos_startup_update
@@ -354,6 +354,23 @@ def update_navigator_overlays() -> bool:
     # Patch applied and system needs to be restarted for it to take effect
     return True
 
+def install_blueos_bash_aliases() -> bool:
+    print("Installing BlueOS bash aliases...")
+
+    # Define the bash alias contents
+    directory = "~"
+    file_name = ".bashrc"
+    target_string = '''# BlueOS Aliases Starter\nif [ -f ~/.bash_aliases ]; then\n. ~/.bash_aliases_blueos\nfi'''
+    write=True
+    bash_alias=(verify_write_file(directory, file_name, target_string, write))
+
+    # Check if the aliases are already present in ~/.bashrc
+    if bash_alias:
+        print("INFO: BlueOS bash aliases in ~/.bashrc.")
+        return True
+    else:
+        print("WARNING: No BlueOS bash aliases.")
+        return False
 
 def verify_write_file(directory: str, file_name: str, target_string: str, write: bool = False):
     print("Verifying string on file...")
@@ -444,6 +461,7 @@ def main() -> int:
         update_cgroups,
         update_dwc2,
         update_navigator_overlays,
+        install_blueos_bash_aliases,
         ensure_user_data_structure_is_in_place,
         ensure_nginx_permissions,
         create_dns_conf_host_link,

--- a/core/tools/blueos_startup_update/blueos_startup_update
+++ b/core/tools/blueos_startup_update/blueos_startup_update
@@ -355,6 +355,29 @@ def update_navigator_overlays() -> bool:
     return True
 
 
+def verify_write_file(directory: str, file_name: str, target_string: str, write: bool = False):
+    print("Verifying string on file...")
+    file_path = os.path.join(os.path.expanduser(directory), file_name)
+    try:
+        with open(file_path, 'r') as file:
+            file_contents = file.read()
+            if target_string in file_contents:
+                print(f"The string:\n'{target_string}'\nis already present in {file_name}.")
+                return True
+
+            else:
+                if write:
+                    with open(file_path, 'a') as append_file:
+                        append_file.write("\n" + target_string + "\n")
+                        print(f"Added '{target_string}' to {file_name}.")
+                        return True
+                else:
+                    print(f"Not added, write parameter is False.")
+                    return False
+    except:
+        print(f"File {file_path} not found.")
+        return False
+
 def create_dns_conf_host_link() -> bool:
     """ This patch creates a hard link of /etc/resolv.conf as /etc/resolv.conf.host, to be used as
     a binding with an fixed file-descriptor, which is neccessary for docker bindings if the original

--- a/install/alias/blueos-alias.sh
+++ b/install/alias/blueos-alias.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+bash_alias_blueos='
+#BlueOS Aliases Starter
+if [ -f /etc/blueos/.bash_aliases ]; then
+    . /etc/blueos/.bash_aliases_blueos
+fi
+'
+
+if grep -Fxq "#BlueOS Aliases Starter" ~/.bashrc; then
+    echo "WARNING: Custom BlueOS bash aliases already exists in ~/.bashrc. Did not overwrite."
+else
+    echo "WARNING: Custom BlueOS bash aliases added"
+    echo -e "\n$bash_alias_blueos" >> ~/.bashrc
+fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -217,6 +217,11 @@ sed -i "\%^exit 0%idocker start blueos-bootstrap" /etc/rc.local || echo "Failed 
 echo "Starting network configuration."
 curl -fsSL $ROOT/install/network/avahi.sh | bash
 
+# Configure BlueOS aliases
+## This configures BlueOS specif bash aliases
+echo "Writing .bashrc settings to load blueos alieses."
+curl -fsSL $ROOT/install/alias/blueos-alias.sh | bash
+
 # Following https://systemd.io/BUILDING_IMAGES/
 echo "Restarting machine-id."
 rm -rf /etc/machine-id /var/lib/dbus/machine-id


### PR DESCRIPTION
The main idea is to have BlueOS focused aliases:
In this PR specifically it only adds a warn script when user try apt-get upgrade, this solves:[kernel upgrade issue](https://github.com/bluerobotics/BlueOS/issues/2234
)

But it can be expanded for BlueOS focused commands, such : 
- reset BlueOS services - restart containers if only have access from shell;
- use factory recovery - stops actual container and return factory;
- reset stable BlueOS kernel

*It should be synced with BlueOS version (bootstrap).


Requirements:
- [ ] maintanable source file;
- [ ] provide aliases for all Users;
- [ ] Update and follows BlueOS new versions;
- [ ] Work with previous BlueOS images;
- [ ] Be available on factory image;
