### PR TITLE
Bridget: check if ports are in use by autopilot when creating a new bridge

### DIFF
--- a/core/frontend/src/types/system-information/serial.ts
+++ b/core/frontend/src/types/system-information/serial.ts
@@ -24,6 +24,8 @@ export interface SerialPortInfo {
     by_path_created_ms_ago: number | null
     // Udev information from the device
     udev_properties: JSONValue | null,
+    // Is the port in use? by whom?
+    current_user: string | null,
 }
 
 /** Base structure that provides serial port information */


### PR DESCRIPTION
This also makes the option not-selectable
<img width="679" alt="image" src="https://github.com/bluerobotics/BlueOS/assets/4013804/7be87373-f20a-401f-b2a5-01e4ddf7f49c">

Also switches to linux2rest for fetching ports, to fix #2238 

fix #2197