### PR TITLE
bootstrap: lock all dependencies

### DIFF
--- a/bootstrap/bootstrap/setup.py
+++ b/bootstrap/bootstrap/setup.py
@@ -7,5 +7,16 @@ setup(
     version="0.0.1",
     description="Blue Robotics Ardusub BlueOS Docker System Bootstrap",
     license="MIT",
-    install_requires=["docker == 5.0.0", "six == 1.15.0", "requests == 2.26.0", "loguru == 0.5.3"],
+    install_requires=[
+        "docker==5.0.0",
+        "loguru==0.5.3",
+        "requests==2.26.0",
+        # indirect dependencies
+        "six==1.15.0",
+        "idna==3.4",
+        "urllib3==1.26.16",
+        "certifi==2023.7.22",
+        "charset-normalizer==2.0.12",
+        "websocket-client==1.6.3",
+    ],
 )


### PR DESCRIPTION
fixes an issue with latest websocket-client (which we don't even use afaik)