### PR TITLE
Use python:3.11.7-slim-bullseye as base image

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -133,10 +133,10 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.docker }}-${{ hashFiles(format('{0}/Dockerfile', matrix.docker)) }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker }}-0-${{ hashFiles(format('{0}/Dockerfile', matrix.docker)) }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.docker }}-${{ hashFiles(format('{0}/Dockerfile', matrix.docker)) }}
-            ${{ runner.os }}-buildx-${{ matrix.docker }}
+            ${{ runner.os }}-buildx-${{ matrix.docker }}-0-${{ hashFiles(format('{0}/Dockerfile', matrix.docker)) }}
+            ${{ runner.os }}-buildx-${{ matrix.docker }}-0
 
       - name: Docker Buildx (build)
         run: |

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,5 +1,4 @@
-FROM debian:buster-slim
-RUN apt update && apt install -y python3 python3-setuptools python3-pip --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM python:3.11.7-slim-bullseye
 COPY startup.json.default bootstrap/ /bootstrap/
 COPY main.py /
 RUN python3 bootstrap/setup.py install


### PR DESCRIPTION
By default buster-slim comes with python 3.7 that is EOL already 