### PR TITLE
bootstrap: Fix delta time calculation using monotonic clock

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -21,11 +21,11 @@ class Bootstrapper:
     HOST_CONFIG_PATH = os.environ.get("BLUEOS_CONFIG_PATH", "/tmp/blueos/.config")
     CORE_CONTAINER_NAME = "blueos-core"
     SETTINGS_NAME_CORE = "core"
-    core_last_response_time = time.time()
+    core_last_response_time = time.monotonic()
 
     def __init__(self, client: docker.DockerClient, low_level_api: docker.APIClient = None) -> None:
         self.client: docker.DockerClient = client
-        self.core_last_response_time = time.time()
+        self.core_last_response_time = time.monotonic()
         if low_level_api is None:
             self.low_level_api = docker.APIClient(base_url="unix://var/run/docker.sock")
         else:
@@ -219,7 +219,9 @@ class Bootstrapper:
             if Bootstrapper.SETTINGS_NAME_CORE in response.json()["repository"]:
                 return True
         except Exception as e:
-            logger.warning(f"Could not talk to version chooser for {time.time() - self.core_last_response_time}: {e}")
+            logger.warning(
+                f"Could not talk to version chooser for {time.monotonic() - self.core_last_response_time}: {e}"
+            )
         return False
 
     def remove(self, container: str) -> None:
@@ -250,15 +252,15 @@ class Bootstrapper:
                     continue
 
                 if self.is_version_chooser_online():
-                    self.core_last_response_time = time.time()
+                    self.core_last_response_time = time.monotonic()
                     continue
 
                 # Check if version chooser failed start before timeout
-                if time.time() - self.core_last_response_time < 300:
+                if time.monotonic() - self.core_last_response_time < 300:
                     continue
 
                 # Version choose failed, time to restarted core
-                self.core_last_response_time = time.time()
+                self.core_last_response_time = time.monotonic()
                 logger.warning("Core has not responded in 5 minutes, resetting to factory...")
                 self.overwrite_config_file_with_defaults()
                 try:

--- a/bootstrap/test_bootstrap.py
+++ b/bootstrap/test_bootstrap.py
@@ -52,11 +52,11 @@ class FakeContainer:
         self.name: str = name
         self.client: Any
         self.raise_if_stopped = raise_if_stopped
-        self.created_time = time.time()
+        self.created_time = time.monotonic()
         print(f"created container {self.name} at {self.created_time}")
 
     def age(self) -> float:
-        return time.time() - self.created_time
+        return time.monotonic() - self.created_time
 
     def set_client(self, client: Any) -> None:
         self.client = client
@@ -258,7 +258,7 @@ class BootstrapperTests(TestCase):  # type: ignore
 
     @pytest.mark.timeout(50)
     def test_bootstrap_core_timeout(self) -> None:
-        start_time = time.time()
+        start_time = time.monotonic()
         self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents=SAMPLE_JSON)
         self.fs.create_file(Bootstrapper.DEFAULT_FILE_PATH, contents=SAMPLE_JSON)
         fake_client = FakeClient()
@@ -278,7 +278,7 @@ class BootstrapperTests(TestCase):  # type: ignore
         # mock time so it passes faster
         # this new FakeContainer will not throw when it stops
         fake_client.set_active_dockers([FakeContainer(Bootstrapper.CORE_CONTAINER_NAME)])
-        mock_time = patch("time.time", return_value=start_time + 1000)
+        mock_time = patch("time.monotonic", return_value=start_time + 1000)
         mock_time.start()
         # this should timeout AND restart core
         bootstrapper.run()


### PR DESCRIPTION
`time.time()` use system clock to return current time. If the system time changes while in operation, with the timezone or connecting to the internet NTP server, our delta calculation will be wrong.

This pr uses `time.monotonic()` that:
> Return the value (in fractional seconds) of a monotonic clock, i.e. a clock that cannot go backwards. The clock is not affected by system clock updates. The reference point of the returned value is undefined, so that only the difference between the results of two calls is valid.

Fix #2260 #2248 #2105 

Detected from Tony log:
```
2023-12-07 08:16:14.876 | INFO     | bootstrap.bootstrap:start:180 - Starting bluerobotics/blueos-core
2023-12-07 08:16:16.935 | INFO     | bootstrap.bootstrap:start:197 - core (bluerobotics/blueos-core:1.1.1) started
2023-12-07 08:16:16.936 | WARNING  | bootstrap.bootstrap:run:245 - core is not running, starting..
2023-12-07 08:16:16.963 | WARNING  | bootstrap.bootstrap:is_version_chooser_online:222 - Could not talk to version chooser for 64728.144294023514: HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /version-chooser/v1.0/version/current (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xb5857470>: Failed to establish a new connection: [Errno 111] Connection refused'))
2023-12-07 08:16:16.964 | WARNING  | bootstrap.bootstrap:run:262 - Core has not responded in 5 minutes, resetting to factory...
```