### PR TITLE
core: do not compile unnecessarily

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -19,6 +19,15 @@ RUN /home/pi/tools/install-static-binaries.sh
 # BlueOS-docker base image
 FROM bluerobotics/blueos-base:v0.1.0
 
+# Define arguments for target platform
+# These arguments are defined automatically by buildx when using `--platform`
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+# Set these arguments as environment variables
+ENV TARGETARCH=${TARGETARCH}
+ENV TARGETVARIANT=${TARGETVARIANT}
+
 # Install necessary tools
 COPY tools /home/pi/tools
 RUN /home/pi/tools/install-system-tools.sh

--- a/core/libs/install-libs.sh
+++ b/core/libs/install-libs.sh
@@ -7,23 +7,30 @@ BUILD_PACKAGES=(
     g++
 )
 
-apt update
-apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
+echo "Target architecture: $TARGETARCH"
+echo "Target variant: $TARGETVARIANT"
+# Install build packages if not on armv7 or amd64, which are the only platforms that have pre-built wheels
+if ! { [ "$TARGETARCH" == "arm" ] && [ "$TARGETVARIANT" == "v7" ]; } && [ "$TARGETARCH" != "amd64" ]; then
+    apt update
+    apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
+fi
 
 # Piwheels is a Python package repository providing Arm platform wheels (pre-compiled binary Python packages)
 # specifically for the Raspberry Pi, making pip installations much faster.
 # Packages are natively compiled on Raspberry Pi 3 and 4 hardware
-if [[ "$(uname -m)" == "arm"* ]]; then
-    echo "Configuring pip to use piwheels"
-    echo "[global]" >> /etc/pip.conf
-    echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
-fi
+# Add it regardless of the platform, as it is a fallback index, and will only be used if the package is not found on the main index.
+echo "Configuring pip to use piwheels"
+echo "[global]" >> /etc/pip.conf
+echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
 
 CURRENT_PATH=$(dirname "$0")
 
 # Install libraries
-python3 $CURRENT_PATH/bridges/setup.py install
-python3 $CURRENT_PATH/commonwealth/setup.py install
+
+# install pykson = {git = "https://github.com/patrickelectric/pykson.git", rev = "fcab71c1eadd6c6b730ca21a5eecb3bf9c374507"}
+pip3 install https://codeload.github.com/patrickelectric/pykson/zip/fcab71c1eadd6c6b730ca21a5eecb3bf9c374507
+pip3 install -e $CURRENT_PATH/bridges
+pip3 install -e $CURRENT_PATH/commonwealth
 
 apt -y remove ${BUILD_PACKAGES[*]}
 apt -y autoremove

--- a/core/services/install-services.sh
+++ b/core/services/install-services.sh
@@ -7,8 +7,11 @@ BUILD_PACKAGES=(
     g++
 )
 
-apt update
-apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
+# Install build packages if not on armv7, which we have all pre-built wheels for
+if ! { [ "$TARGETARCH" == "arm" ] && [ "$TARGETVARIANT" == "v7" ]; }; then
+    apt update
+    apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
+fi
 
 # Wifi service:
 ## Bind path for wpa
@@ -35,7 +38,7 @@ python -m pip install appdirs==1.4.4 loguru==0.5.3 pydantic==1.10.12
 
 for SERVICE in "${SERVICES[@]}"; do
     echo "Installing service: $SERVICE"
-    cd "/home/pi/services/$SERVICE/" && python3 setup.py install
+    cd "/home/pi/services/$SERVICE/" && pip3 install .
 done
 
 apt -y remove ${BUILD_PACKAGES[*]}


### PR DESCRIPTION
For a faster build.

This replaces "setup.py install" with "pip install", which will use the additional index-url.
it also stops installing pre-requisites when we don't need to build anything.