### PR TITLE
core: frontend: update some service paths

### DIFF
--- a/core/frontend/src/views/FileBrowserView.vue
+++ b/core/frontend/src/views/FileBrowserView.vue
@@ -16,7 +16,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      service_path: '/file-browser',
+      service_path: '/file-browser/',
     }
   },
 })

--- a/core/frontend/src/views/TerminalView.vue
+++ b/core/frontend/src/views/TerminalView.vue
@@ -16,7 +16,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      service_path: '/terminal',
+      service_path: '/terminal/',
     }
   },
 })


### PR DESCRIPTION
This makes it so we don't rely on nginx rewrite directives to reach the service. this fixes an issue when serving blueos from non-standard ports