### PR TITLE
ServiceMetadata: add extra query

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -460,7 +460,7 @@ export default Vue.extend({
             icon: service.metadata?.icon?.startsWith('/')
               ? `${address}${service.metadata.icon}`
               : service.metadata?.icon ?? 'mdi-puzzle',
-            route: service.metadata?.route ?? address,
+            route: this.addExtraQuery(service.metadata?.route ?? address, service.metadata?.extra_queries),
             new_page: service.metadata?.new_page ?? undefined,
             advanced: false,
             text: service.metadata?.description ?? 'Service text',
@@ -651,6 +651,14 @@ export default Vue.extend({
     this.bootstrap_version = await VCU.loadBootstrapCurrentVersion()
   },
   methods: {
+    addExtraQuery(url: string, extra_queries?: string) {
+      if (!extra_queries) {
+        return url
+      }
+      // adds additional query parameters to a url
+      const separator = url.includes('?') ? '&' : '?'
+      return url + separator + extra_queries
+    },
     getWidget(name: string) {
       return this.widgets.filter((widget) => widget.name === name)?.[0]?.component
     },

--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -9,6 +9,7 @@ export interface ServiceMetadata {
     route?: string
     new_page?: boolean
     sanitized_name?: string
+    extra_query?: string
 }
 
 export interface Service {

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -98,6 +98,7 @@ class ServiceMetadata(BaseModel):
     webpage: str
     route: Optional[str]
     new_page: Optional[bool]
+    extra_query: Optional[str]
     api: str
     sanitized_name: Optional[str]
 


### PR DESCRIPTION
This allows services to dynamically change their query arguments

I used it for setting mainlink and stun urls for cockpit, for example. I could just update register_service at start