### PR TITLE
core: vehicle-setup: fix ArduSub lights mappings

### DIFF
--- a/core/frontend/src/components/vehiclesetup/PwmSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/PwmSetup.vue
@@ -165,9 +165,9 @@ const rover_function_map = {
 
 const param_value_map = {
   Submarine: {
-    RCIN8: 'Lights 1',
-    RCIN9: 'Lights 2',
-    RCIN10: 'Video Switch',
+    RCIN9: 'Lights 1',
+    RCIN10: 'Lights 2',
+    RCIN11: 'Video Switch',
   },
 } as Dictionary<Dictionary<string>>
 

--- a/core/frontend/src/components/vehiclesetup/overview/LightsInfo.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/LightsInfo.vue
@@ -37,7 +37,7 @@ export default Vue.extend({
     lights() {
       const servo_params = autopilot_data.parameterRegex('SERVO.*_FUNCTION')
       const light_params = servo_params.filter(
-        (parameter) => parameter.value === SERVO_FUNCTION.RCIN8 || parameter.value === SERVO_FUNCTION.RCIN9,
+        (parameter) => parameter.value === SERVO_FUNCTION.RCIN9 || parameter.value === SERVO_FUNCTION.RCIN10,
       )
       return light_params.map((parameter) => parameter.name)
     },

--- a/core/frontend/src/components/vehiclesetup/viewers/GenericViewer.vue
+++ b/core/frontend/src/components/vehiclesetup/viewers/GenericViewer.vue
@@ -215,11 +215,11 @@ export default Vue.extend({
     },
     lights1_are_present() {
       const servo_params = autopilot_data.parameterRegex('^SERVO(\\d+)_FUNCTION$')
-      return servo_params.some((parameter) => parameter.value === SUB_SERVO_FUNCTION.RCIN8)
+      return servo_params.some((parameter) => parameter.value === SUB_SERVO_FUNCTION.RCIN9)
     },
     lights2_are_present() {
       const servo_params = autopilot_data.parameterRegex('^SERVO(\\d+)_FUNCTION$')
-      return servo_params.some((parameter) => parameter.value === SUB_SERVO_FUNCTION.RCIN9)
+      return servo_params.some((parameter) => parameter.value === SUB_SERVO_FUNCTION.RCIN10)
     },
     gripper_is_present() {
       const mavlink = autopilot_data.parameter('GRIP_ENABLE')?.value === 1


### PR DESCRIPTION
Found this issue while trying to adjust some stuff and it wasn't working properly.

Cross-referenced with [the ArduSub RC Input docs](https://www.ardusub.com/developers/rc-input-and-output.html#rc-inputs) and realised the BlueOS ones were off by one.