### PR TITLE
CI: specify pi user on pimod

### DIFF
--- a/deploy/pimod/blueos.Pifile
+++ b/deploy/pimod/blueos.Pifile
@@ -20,5 +20,5 @@ RUN bash -c '
 RUN bash -c '
   curl -O https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$VERSION/install/install.sh
   chmod +x install.sh
-  ./install.sh --ci-run
+  USER=pi ./install.sh --ci-run
 '


### PR DESCRIPTION
it is not set in pimod who knows why

passing job here:
https://github.com/Williangalvani/blueos-docker/actions/runs/7416124592/job/20181038839