### PR TITLE
core: allow disabling services using environment variables

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -104,6 +104,13 @@ function create_service {
     local command="$2"  # Store the command as a string
     local memory_limit_mb=$3
 
+    # Check if the service is disabled
+    if [[ $BLUEOS_DISABLE_SERVICES == *"$1"* ]]; then
+        echo "Service $1 is disabled"
+        tmux send-keys -t $SESSION_NAME "echo 'Service $1 is disabled'; sleep infinity" C-m
+        return
+    fi
+
     # Set all necessary environment variables for the new tmux session
     for NAME in $(compgen -v | grep MAV_); do
         VALUE=${!NAME}


### PR DESCRIPTION
this can be used with a command line such as
```
docker run --net=host -e "BLUEOS_DISABLE_SERVICES=cable_guy,beacon,kraken,wifi,bridget,commander,nmea_injector,iperf3,versionchooser,ping,log_zipper" --rm -it williangalvani/blueos-docker:individual_services
```

This makes it safer to run the dockers in x86 environments without messing up your networking and whatnot