### PR TITLE
core: frontend: vite.config: Use blueos-avahi over blueos

### DIFF
--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -7,7 +7,7 @@ const { name } = require('./package.json')
 
 process.env.PROJECT_NAME = name
 process.env.VITE_BUILD_DATE = new Date().toLocaleString()
-const DEFAULT_ADDRESS = 'http://blueos.local/'
+const DEFAULT_ADDRESS = 'http://blueos-avahi.local/'
 const SERVER_ADDRESS = process.env.BLUEOS_ADDRESS ?? DEFAULT_ADDRESS
 
 const path = require('path')


### PR DESCRIPTION
-avahi is available over all network interfaces