### PR TITLE
core: frontend: views: Fix weird logo size when loading extensions

### DIFF
--- a/core/frontend/src/views/ExtensionView.vue
+++ b/core/frontend/src/views/ExtensionView.vue
@@ -4,7 +4,7 @@
     :source="service_path"
     :class="fullpage ? 'fullpage' : ''"
   />
-  <SpinningLogo v-else-if="detected_port === undefined" />
+  <SpinningLogo v-else-if="detected_port === undefined" size="15%" />
   <page-not-found v-else />
 </template>
 


### PR DESCRIPTION
I remember we commented about this annoying glitch, but I couldn't find an issue. The important thing is: now, the spinning logo doesn't change size when loading the extensions.