### PR TITLE
Bridges update

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -86,6 +86,7 @@ RUN ln -s /usr/blueos/userdata /shortcuts/userdata
 RUN ln -s /usr/blueos/extensions /shortcuts/extensions
 RUN ln -s /root/.config/ardupilot-manager /shortcuts/ardupilot_logs
 RUN ln -s / /shortcuts/system_root
+RUN useradd -m -u 1000 -G dialout blueos
 
 # Start
 CMD /bin/bash -i /usr/bin/start-blueos-core && sleep infinity

--- a/core/frontend/src/components/bridges/BridgeCard.vue
+++ b/core/frontend/src/components/bridges/BridgeCard.vue
@@ -22,8 +22,15 @@
                   {{ get_display_name(bridgeSerialInfo) }}:{{ bridgeSerialInfo.bridge.baud }}
                 </span>
                 <v-icon>mdi-link</v-icon>
-                <span class="text-subtitle-1 ml-2">
-                  {{ bridgeSerialInfo.bridge.ip }}:{{ bridgeSerialInfo.bridge.udp_port }}
+                <span v-if="is_server" class="text-subtitle-1 ml-2">
+                  Server listening at {{ bridgeSerialInfo.bridge.udp_listen_port }}
+                </span>
+                <span v-else class="text-subtitle-1 ml-2">
+                  Sending to {{ bridgeSerialInfo.bridge.ip }}:{{ bridgeSerialInfo.bridge.udp_target_port }}<br>
+                  {{ bridgeSerialInfo.bridge.udp_listen_port
+                    ? 'Receiving at ' + bridgeSerialInfo.bridge.udp_listen_port
+                    : ''
+                  }}
                 </span>
               </v-card-text>
             </v-card>

--- a/core/frontend/src/components/bridges/BridgeCard.vue
+++ b/core/frontend/src/components/bridges/BridgeCard.vue
@@ -78,6 +78,11 @@ export default Vue.extend({
       required: true,
     },
   },
+  computed: {
+    is_server(): boolean {
+      return this.bridgeSerialInfo.bridge.ip === '0.0.0.0'
+    },
+  },
   methods: {
     get_display_name(bridgeSerialInfo: BridgeWithSerialInfo): string {
       return bridgeSerialInfo.serial_info?.name ?? bridgeSerialInfo.bridge.serial_path

--- a/core/frontend/src/components/bridges/BridgeCreationDialog.vue
+++ b/core/frontend/src/components/bridges/BridgeCreationDialog.vue
@@ -84,7 +84,30 @@
             label="Serial baudrate"
             :rules="[validate_required_field, is_baudrate]"
           />
-
+          <v-tabs
+            v-model="tab"
+            fixed-tabs
+          >
+            <v-tab @click="bridge.udp_listen_port = 15000">
+              Server Mode
+            </v-tab>
+            <v-tab @click="bridge.udp_listen_port = 0">
+              Client Mode
+            </v-tab>
+          </v-tabs>
+          <span v-if="mode === 'server'">
+            Server mode will bind to the given port at the BlueOS device.
+            This means it will receive data from the topside computer at port
+            <B>{{ bridge.udp_listen_port }}</B>, and will send data back
+            to the topside computer at the port where the data originated at the topside computer.
+          </span>
+          <span v-else-if="mode === 'client'">
+            Client mode will send data to the given IP address and port.
+            This means it will send data to the topside computer at IP
+            <B>{{ bridge.ip }}</B> and port <B>{{ bridge.udp_target_port }}</B>.
+            It will receive data back from the topside computer at
+            <b>{{ bridge.udp_listen_port ? `port ${bridge.udp_listen_port}` : 'an automatically assigned port' }}</b>.
+          </span>
           <v-text-field
             v-model="bridge.ip"
             :rules="[validate_required_field, is_ip_address]"
@@ -92,10 +115,20 @@
           />
 
           <v-text-field
-            v-model="bridge.udp_port"
+            v-model="bridge.udp_listen_port"
             :counter="50"
-            label="UDP port"
+            :label="`Vehicle/Server port ${bridge.udp_listen_port == 0 ? '(Automatic)' : '' }`"
+            :rules="[validate_required_field, is_socket_auto_port]"
+            type="number"
+          />
+
+          <v-text-field
+            v-if="mode === 'client'"
+            v-model="bridge.udp_target_port"
+            :counter="50"
+            :label="`Topside/Target port`"
             :rules="[validate_required_field, is_socket_port]"
+            type="number"
           />
         </v-form>
       </v-card-text>
@@ -140,7 +173,6 @@ import back_axios from '@/utils/api'
 import {
   isBaudrate,
   isFilepath,
-  isIntegerString,
   isIpAddress,
   isNotEmpty,
   isSocketPort,
@@ -166,11 +198,13 @@ export default Vue.extend({
 
   data() {
     return {
+      tab: 0,
       bridge: {
         serial_path: '',
         baud: null as (number | null),
         ip: '0.0.0.0',
-        udp_port: '15000',
+        udp_target_port: 15000,
+        udp_listen_port: 15000,
       },
     }
   },
@@ -183,6 +217,17 @@ export default Vue.extend({
         (baud) => ({ value: parseInt(baud[1], 10), text: baud[1] }),
       )
     },
+    mode(): string {
+      switch (this.tab) {
+        case 0:
+          return 'server'
+        case 1:
+          return 'client'
+        default:
+          return 'server'
+      }
+    },
+
     available_serial_ports(): SerialPortInfo[] {
       const system_serial_ports: SerialPortInfo[] | undefined = system_information.serial?.ports
       if (!system_serial_ports) {
@@ -244,6 +289,13 @@ export default Vue.extend({
       const int_input = parseInt(input, 10)
       return isSocketPort(int_input) ? true : 'Invalid port.'
     },
+    is_socket_auto_port(input: string): (true | string) {
+      const int_input = parseInt(input, 10)
+      if (this.mode === 'client' && int_input === 0) {
+        return true
+      }
+      return this.is_socket_port(input)
+    },
     is_baudrate(input: number): (true | string) {
       return isBaudrate(input) ? true : 'Invalid baudrate.'
     },
@@ -255,6 +307,8 @@ export default Vue.extend({
 
       bridget.setUpdatingBridges(true)
       this.showDialog(false)
+      this.bridge.udp_listen_port = parseInt(String(this.bridge.udp_listen_port), 10)
+      this.bridge.udp_target_port = parseInt(String(this.bridge.udp_target_port), 10)
 
       await back_axios({
         method: 'post',

--- a/core/frontend/src/components/bridges/BridgeCreationDialog.vue
+++ b/core/frontend/src/components/bridges/BridgeCreationDialog.vue
@@ -283,9 +283,6 @@ export default Vue.extend({
       return isFilepath(input) ? true : 'Invalid path.'
     },
     is_socket_port(input: string): (true | string) {
-      if (!isIntegerString(input)) {
-        return 'Please use an integer value.'
-      }
       const int_input = parseInt(input, 10)
       return isSocketPort(int_input) ? true : 'Invalid port.'
     },

--- a/core/frontend/src/components/bridges/Bridget.vue
+++ b/core/frontend/src/components/bridges/Bridget.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card
-    width="500"
+    width="700"
     elevation="0"
     class="mb-12 pa-6 bridges-list"
   >

--- a/core/frontend/src/types/bridges.ts
+++ b/core/frontend/src/types/bridges.ts
@@ -5,7 +5,8 @@ export interface Bridge {
   serial_path: string
   baud: Baudrate
   ip: string
-  udp_port: number
+  udp_listen_port: number
+  udp_target_port: number
 }
 
 export interface BridgeWithSerialInfo {

--- a/core/libs/bridges/bridges/bridges.py
+++ b/core/libs/bridges/bridges/bridges.py
@@ -18,12 +18,19 @@ class Bridge:
         serial_port: SysFS,
         baud: Baudrate,
         ip: str,
-        udp_port: int,
+        udp_target_port: int,
+        udp_listen_port: int,
         automatic_disconnect: bool = True,
     ) -> None:
         bridges = which("bridges")
         automatic_disconnect_clients = "" if automatic_disconnect else "--no-udp-disconnection"
-        command_line = f"{bridges} -u {ip}:{udp_port} -p {serial_port.device}:{baud} {automatic_disconnect_clients}"
+        is_server = ip == "0.0.0.0"
+        port = udp_listen_port if is_server else udp_target_port
+
+        command_line = f"{bridges} -u {ip}:{port} -p {serial_port.device}:{baud} {automatic_disconnect_clients}"
+        if not is_server and udp_listen_port != 0:
+            command_line += f" --listen-port {udp_listen_port}"
+
         logging.info(f"Launching bridge link with command '{command_line}'.")
         # pylint: disable=consider-using-with
         self.process = Popen(shlex.split(command_line), stdout=PIPE, stderr=PIPE)

--- a/core/services/bridget/bridget.py
+++ b/core/services/bridget/bridget.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Dict, List
 
 import requests
@@ -9,6 +10,8 @@ from pydantic import BaseModel, conint
 from serial.tools.list_ports_linux import SysFS
 
 from settings import BridgeSettingsSpecV2, SettingsV2
+
+USERDATA = Path("/usr/blueos/userdata/")
 
 
 class BridgeFrontendSpec(BaseModel):
@@ -44,7 +47,9 @@ class Bridget:
 
     def __init__(self) -> None:
         self._bridges: Dict[BridgeFrontendSpec, Bridge] = {}
-        self._settings_manager = Manager("bridget", SettingsV2)
+        # We use userdata because our regular settings folder is under /root, which regular users
+        # don't have access to.
+        self._settings_manager = Manager("bridget", SettingsV2, USERDATA / "settings" / "bridget")
         self._settings_manager.load()
         for bridge_settings_spec in self._settings_manager.settings.specsv2:
             try:

--- a/core/services/bridget/main.py
+++ b/core/services/bridget/main.py
@@ -10,7 +10,7 @@ from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
 
-from bridget import BridgeSpec, Bridget
+from bridget import BridgeFrontendSpec, Bridget
 
 SERVICE_NAME = "bridget"
 
@@ -36,7 +36,7 @@ def get_serial_ports() -> Any:
     return ports
 
 
-@app.get("/bridges", response_model=List[BridgeSpec])
+@app.get("/bridges", response_model=List[BridgeFrontendSpec])
 @version(1, 0)
 def get_bridges() -> Any:
     bridges = controller.get_bridges()
@@ -46,7 +46,7 @@ def get_bridges() -> Any:
 
 @app.post("/bridges", status_code=status.HTTP_201_CREATED)
 @version(1, 0)
-def add_bridge(bridge: BridgeSpec) -> Any:
+def add_bridge(bridge: BridgeFrontendSpec) -> Any:
     logger.debug(f"Adding bridge '{bridge}'.")
     controller.add_bridge(bridge)
     logger.debug(f"Bridge '{bridge}' added.")
@@ -54,7 +54,7 @@ def add_bridge(bridge: BridgeSpec) -> Any:
 
 @app.delete("/bridges", status_code=status.HTTP_200_OK)
 @version(1, 0)
-def remove_bridge(bridge: BridgeSpec) -> Any:
+def remove_bridge(bridge: BridgeFrontendSpec) -> Any:
     logger.debug(f"Removing bridge '{bridge}'.")
     controller.remove_bridge(bridge)
     logger.debug(f"Bridge '{bridge}' removed.")

--- a/core/services/bridget/settings.py
+++ b/core/services/bridget/settings.py
@@ -11,7 +11,7 @@ class BridgeSettingsSpecV1(pykson.JsonObject):
     udp_port = pykson.IntegerField()
 
     @staticmethod
-    def from_spec(spec: "BridgeSpec") -> "BridgeSettingsSpecV1":  # type: ignore
+    def from_spec(spec: "BridgeFrontendSpec") -> "BridgeSettingsSpecV1":  # type: ignore
         return BridgeSettingsSpecV1(
             serial_path=spec.serial_path,
             baudrate=spec.baud,
@@ -42,3 +42,57 @@ class SettingsV1(settings.BaseSettings):
             super().migrate(data)
 
         data["VERSION"] = SettingsV1.VERSION
+
+
+class BridgeSettingsSpecV2(pykson.JsonObject):
+    udp_target_port = pykson.IntegerField()
+    udp_listen_port = pykson.IntegerField()
+    serial_path = pykson.StringField()
+    baudrate = pykson.IntegerField()
+    ip = pykson.StringField()
+
+    @staticmethod
+    def from_spec(spec: "BridgeFrontendSpec") -> "BridgeSettingsSpecV2":  # type: ignore
+        return BridgeSettingsSpecV2(
+            serial_path=spec.serial_path,
+            baudrate=spec.baud,
+            ip=spec.ip,
+            udp_target_port=spec.udp_target_port,
+            udp_listen_port=spec.udp_listen_port,
+        )
+
+    def __eq__(self, other: object) -> Any:
+        if isinstance(other, BridgeSettingsSpecV2):
+            return self.serial_path == other.serial_path
+        return False
+
+
+class SettingsV2(SettingsV1):
+    VERSION = 2
+    specsv2 = pykson.ObjectListField(BridgeSettingsSpecV2)
+
+    def __init__(self, *args: str, **kwargs: int) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.VERSION = SettingsV2.VERSION
+
+    def migrate(self, data: Dict[str, Any]) -> None:
+        if data["VERSION"] == SettingsV2.VERSION:
+            return
+
+        if data["VERSION"] < SettingsV2.VERSION:
+            super().migrate(data)
+
+            data["VERSION"] = SettingsV2.VERSION
+            data["specsv2"] = []
+            for spec in data["specs"]:
+                server = spec["ip"] == "0.0.0.0"
+                data["specsv2"].append(
+                    {
+                        "serial_path": spec["serial_path"],
+                        "baudrate": spec["baudrate"],
+                        "ip": spec["ip"],
+                        "udp_target_port": 0 if server else spec["udp_port"],
+                        "udp_listen_port": spec["udp_port"] if server else 0,
+                    }
+                )

--- a/core/services/ping/ping1d_driver.py
+++ b/core/services/ping/ping1d_driver.py
@@ -44,7 +44,7 @@ class Ping1DDriver(PingDriver):
                 assert self.bridge is not None
                 self.bridge.stop()
                 await asyncio.sleep(5)
-                self.bridge = Bridge(self.ping.port, self.baud, "0.0.0.0", self.port, automatic_disconnect=False)
+                self.bridge = Bridge(self.ping.port, self.baud, "0.0.0.0", 0, self.port, automatic_disconnect=False)
 
     def save_settings(self) -> None:
         self.manager.load()  # re-load as other sensors could have changed it

--- a/core/services/ping/ping1d_driver.py
+++ b/core/services/ping/ping1d_driver.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 
 from bridges.bridges import Bridge
 from commonwealth.settings.manager import Manager
@@ -11,12 +12,14 @@ from settings import Ping1dSettingsSpecV1, SettingsV1
 
 SERVICE_NAME = "ping"
 
+USERDATA = Path("/usr/blueos/userdata/")
+
 
 class Ping1DDriver(PingDriver):
     def __init__(self, ping: PingDeviceDescriptor, port: int) -> None:
         super().__init__(ping, port)
         # load settings
-        self.manager = Manager(SERVICE_NAME, SettingsV1)
+        self.manager = Manager(SERVICE_NAME, SettingsV1, USERDATA / "settings" / SERVICE_NAME)
         # our settings file is a list for each sensor type.
         # check the list to find our current sensor in it
         connection_info = self.ping.get_hw_or_eth_info()

--- a/core/services/ping/pingdriver.py
+++ b/core/services/ping/pingdriver.py
@@ -64,7 +64,7 @@ class PingDriver:
         # Do a ping connection to set the baudrate
         PingDevice().connect_serial(self.ping.port.device, self.baud)
         set_low_latency(self.ping.port)
-        self.bridge = Bridge(self.ping.port, self.baud, "0.0.0.0", self.port, automatic_disconnect=False)
+        self.bridge = Bridge(self.ping.port, self.baud, "0.0.0.0", 0, self.port, automatic_disconnect=False)
 
     def stop(self) -> None:
         """Stops the driver"""

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -86,6 +86,9 @@ else
     echo "Waring: Using dockers's resolv.conf, this may cause DNS issues if the host's network configuration changes."
 fi
 
+# fix permissions for logging folders:
+find /var/logs/blueos -type d -exec chmod 777 {} \;
+
 # These services have priority because they do the fundamental for the vehicle to work,
 # and by initializing them first we reduce the time users have to wait to control the vehicle.
 # From tests with QGC and Pi3, the reboot time was ~1min42s when not using this strategy,

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -87,7 +87,11 @@ else
 fi
 
 # fix permissions for logging folders:
-find /var/logs/blueos -type d -exec chmod 777 {} \;
+# we need 777 in order for other users to be able to alter it
+find /var/logs/blueos -type d -exec chmod a+rw {} \;
+mkdir -p /usr/blueos/userdata/settings
+find /usr/blueos -type d -exec chmod a+rw {} \;
+find /usr/blueos -type f -exec chmod a+rw {} \;
 
 # These services have priority because they do the fundamental for the vehicle to work,
 # and by initializing them first we reduce the time users have to wait to control the vehicle.

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -108,7 +108,7 @@ SERVICES=(
     'wifi',0,"nice -19 $SERVICES_PATH/wifi/main.py --socket wlan0"
     # This services are not as important as the others
     'beacon',250,"$SERVICES_PATH/beacon/main.py"
-    'bridget',250,"nice -19 $RUN_AS_REGULAR_USER $SERVICES_PATH/bridget/main.py"
+    'bridget',0,"nice -19 $RUN_AS_REGULAR_USER $SERVICES_PATH/bridget/main.py"
     'commander',250,"$SERVICES_PATH/commander/main.py"
     'nmea_injector',250,"nice -19 $SERVICES_PATH/nmea_injector/nmea_injector/main.py"
     'helper',250,"$SERVICES_PATH/helper/main.py"
@@ -117,7 +117,7 @@ SERVICES=(
     'filebrowser',250,"nice -19 filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"
     'versionchooser',250,"$SERVICES_PATH/versionchooser/main.py"
     'pardal',250,"nice -19 $SERVICES_PATH/pardal/main.py"
-    'ping',250,"nice -19 $RUN_AS_REGULAR_USER $SERVICES_PATH/ping/main.py"
+    'ping',0,"nice -19 $RUN_AS_REGULAR_USER $SERVICES_PATH/ping/main.py"
     'user_terminal',0,"cat /etc/motd"
     'ttyd',250,'nice -19 ttyd -p 8088 sh -c "/usr/bin/tmux attach -t user_terminal || /usr/bin/tmux new -s user_terminal"'
     'nginx',250,"nice -18 nginx -g \"daemon off;\" -c $TOOLS_PATH/nginx/nginx.conf"

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -17,6 +17,7 @@ MAV_COMPONENT_ID_ONBOARD_COMPUTER4=194
 # Enable Rust backtrace for all programs
 RUST_BACKTRACE=1
 
+RUN_AS_REGULAR_USER="sudo -u blueos"
 # Set BlueOS log folder
 BLUEOS_LOG_FOLDER_PATH="/var/logs/blueos"
 
@@ -104,7 +105,7 @@ SERVICES=(
     'wifi',0,"nice -19 $SERVICES_PATH/wifi/main.py --socket wlan0"
     # This services are not as important as the others
     'beacon',250,"$SERVICES_PATH/beacon/main.py"
-    'bridget',250,"nice -19 $SERVICES_PATH/bridget/main.py"
+    'bridget',250,"nice -19 $RUN_AS_REGULAR_USER $SERVICES_PATH/bridget/main.py"
     'commander',250,"$SERVICES_PATH/commander/main.py"
     'nmea_injector',250,"nice -19 $SERVICES_PATH/nmea_injector/nmea_injector/main.py"
     'helper',250,"$SERVICES_PATH/helper/main.py"
@@ -113,7 +114,7 @@ SERVICES=(
     'filebrowser',250,"nice -19 filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"
     'versionchooser',250,"$SERVICES_PATH/versionchooser/main.py"
     'pardal',250,"nice -19 $SERVICES_PATH/pardal/main.py"
-    'ping',250,"nice -19 $SERVICES_PATH/ping/main.py"
+    'ping',250,"nice -19 $RUN_AS_REGULAR_USER $SERVICES_PATH/ping/main.py"
     'user_terminal',0,"cat /etc/motd"
     'ttyd',250,'nice -19 ttyd -p 8088 sh -c "/usr/bin/tmux attach -t user_terminal || /usr/bin/tmux new -s user_terminal"'
     'nginx',250,"nice -18 nginx -g \"daemon off;\" -c $TOOLS_PATH/nginx/nginx.conf"

--- a/core/tools/bridges/bootstrap.sh
+++ b/core/tools/bridges/bootstrap.sh
@@ -4,7 +4,7 @@
 set -e
 
 LOCAL_BINARY_PATH="/usr/bin/bridges"
-VERSION=0.9.0
+VERSION=0.10.1
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/bridges/releases/download/${VERSION}/bridges-armv7-unknown-linux-musleabihf"

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -21,4 +21,5 @@ parallel --halt now,fail=1 '/home/pi/tools/{}/bootstrap.sh' ::: "${TOOLS[@]}"
 /home/pi/tools/dnsmasq/bootstrap.sh
 /home/pi/tools/hotspot/bootstrap.sh
 /home/pi/tools/iperf3/bootstrap.sh
+/home/pi/tools/sudo/bootstrap.sh
 /home/pi/tools/nginx/bootstrap.sh

--- a/core/tools/sudo/bootstrap.sh
+++ b/core/tools/sudo/bootstrap.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Exit if something goes wrong
+set -e
+
+echo "Installing sudo."
+apt update
+apt install --no-install-recommends --no-install-suggests -y sudo


### PR DESCRIPTION
This splits udp port handling into udp target port and udp lister port.

client will always send data to `udp_target_port`.
server will always listen at `udp_listen_port`.
additionally, this now allows the client to pick the port it will bind to, using `udp_listen_port`.
this is useful for implementations where whatever is talking to us is sending/receiving packets naively, without an actual udp "connection". 

~depends on https://github.com/patrickelectric/bridges/pull/11~

fix #2305 
fix #2304