### PR TITLE
Try to recover the system if available size in critical

### DIFF
--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -20,7 +20,7 @@ from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
 
 SERVICE_NAME = "commander"
-LOG_FOLDER_PATH = "/var/logs/blueos"
+LOG_FOLDER_PATH = os.environ.get("BLUEOS_LOG_FOLDER_PATH", "/var/logs/blueos")
 
 limit_ram_usage()
 

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -15,6 +15,22 @@ MAV_COMPONENT_ID_ONBOARD_COMPUTER4=194
 # Enable Rust backtrace for all programs
 RUST_BACKTRACE=1
 
+# Set BlueOS log folder
+BLUEOS_LOG_FOLDER_PATH="/var/logs/blueos"
+
+# The system may start with full disk, in this case resulting in an unstable behavior.
+# As an attempt to recover the system, lets delete the log files before current boot
+AVAILABLE_SPACE_MB=$(($(stat -f / --format="%a*%S/1024**2")))
+CRITICAL_SPACE_LIMIT_MB=100
+echo "Available disk space: ${AVAILABLE_SPACE_MB}MB"
+(( AVAILABLE_SPACE_MB < CRITICAL_SPACE_LIMIT_MB )) && (
+    LOG_FOLDER_SIZE=$(($(du -sm ${BLUEOS_LOG_FOLDER_PATH} | awk '{print $1}')))
+    echo "Not enough free space for the system to run, limit is: ${CRITICAL_SPACE_LIMIT_MB}MB"
+    echo "Going to delete the logs folder as an attempt to recover: ${LOG_FOLDER_SIZE}MB"
+    rm -rf "$BLUEOS_LOG_FOLDER_PATH/*"
+    echo "Done!"
+)
+
 # Update docker binds, if we need to restart, exit!
 blueos_startup_update
 
@@ -112,7 +128,7 @@ function create_service {
     fi
 
     # Set all necessary environment variables for the new tmux session
-    for NAME in $(compgen -v | grep MAV_); do
+    for NAME in $(compgen -v | grep -e MAV_ -e BLUEOS_); do
         VALUE=${!NAME}
         tmux setenv -t $SESSION_NAME -g $NAME $VALUE
     done


### PR DESCRIPTION
Once the system gets in a critical state where the disk is full, it gets in a condition that recover is almost impossible. The system is unstable, the backend services and frontend may not work or be available for the user to recover at all. As a last resource, we delete BlueOS logs if the filesystem. 

Fix https://github.com/bluerobotics/BlueOS/issues/2323