### PR TITLE
Improve calibration  information

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
@@ -51,6 +51,20 @@
                 >
                   mdi-emoticon-sad-outline
                 </v-icon>
+                <v-icon
+                  v-if="imu_temperature_is_calibrated[imu.param]"
+                  v-tooltip="'Sensor thermometer is calibrated and good to use'"
+                  color="green"
+                >
+                  mdi-thermometer-check
+                </v-icon>
+                <v-icon
+                  v-else
+                  v-tooltip="'Sensor thermometer needs to be calibrated'"
+                  color="red"
+                >
+                  mdi-thermometer-off
+                </v-icon>
               </td>
             </tr>
             <tr
@@ -212,6 +226,20 @@ export default Vue.extend({
         const is_at_default_scale = scale_params.every((param) => param?.value === 1.0)
         results[imu.param] = offset_params.isEmpty() || scale_params.isEmpty()
         || !is_at_default_offsets || !is_at_default_scale
+      }
+      return results
+    },
+    imu_temperature_is_calibrated(): Dictionary<boolean> {
+      const results = {} as Dictionary<boolean>
+      for (const imu of this.imus) {
+        let param_radix = imu.param.split('_ID')[0]
+        // CALTEMP parameters contains ID for the first sensor, _ID does not, so we need to add it
+        if (!/\d$/.test(param_radix)) {
+          param_radix += '1'
+        }
+        const name = `${param_radix}_CALTEMP`
+        const parameter = autopilot_data.parameter(name)
+        results[imu.param] = parameter !== undefined && parameter.value !== -300
       }
       return results
     },

--- a/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
@@ -36,7 +36,22 @@
               </td>
               <td>{{ imu.busType }} {{ imu.bus }}</td>
               <td>{{ `0x${imu.address}` }}</td>
-              <td>{{ imu_is_calibrated[imu.param] ? 'Calibrated' : 'Needs Calibration' }}</td>
+              <td>
+                <v-icon
+                  v-if="imu_is_calibrated[imu.param]"
+                  v-tooltip="'Sensor is callibrated and good to use'"
+                  color="green"
+                >
+                  mdi-emoticon-happy-outline
+                </v-icon>
+                <v-icon
+                  v-else
+                  v-tooltip="'Sensor needs to be calibrated'"
+                  color="red"
+                >
+                  mdi-emoticon-sad-outline
+                </v-icon>
+              </td>
             </tr>
             <tr
               v-for="compass in compasses"
@@ -48,7 +63,22 @@
               </td>
               <td>{{ compass.busType }} {{ compass.bus }}</td>
               <td>{{ `0x${compass.address}` }}</td>
-              <td>{{ compass_is_calibrated[compass.param] ? 'Calibrated' : 'Needs Calibration' }}</td>
+              <td>
+                <v-icon
+                  v-if="compass_is_calibrated[compass.param]"
+                  v-tooltip="'Sensor is callibrated and good to use'"
+                  color="green"
+                >
+                  mdi-emoticon-happy-outline
+                </v-icon>
+                <v-icon
+                  v-else
+                  v-tooltip="'Sensor needs to be calibrated'"
+                  color="red"
+                >
+                  mdi-emoticon-sad-outline
+                </v-icon>
+              </td>
             </tr>
             <tr
               v-for="baro in baros"


### PR DESCRIPTION
Sensor may contain calibration for the sensor itself and also for the termal sensor on it.
This improves the interface to provide such information on the ui in a friendly way.

![image](https://github.com/bluerobotics/BlueOS/assets/1215497/c96ed65a-7f09-4c90-b3e1-5b5a1f0b913f)
![image](https://github.com/bluerobotics/BlueOS/assets/1215497/18a6ebe5-1994-464e-9dba-e202232c899b)
![image](https://github.com/bluerobotics/BlueOS/assets/1215497/7d8bcf4a-4572-45bd-bab9-188b1830d424)
