### PR TITLE
Fix mavlink updateMessage usage  and barometer data

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
@@ -224,8 +224,8 @@ export default Vue.extend({
     },
   },
   mounted() {
-    mavlink.setMessageRefreshRate({ messageName: 'SCALED_PRESSURE', refreshRate: 1 })
-    mavlink.setMessageRefreshRate({ messageName: 'SCALED_PRESSURE2', refreshRate: 1 })
+    mavlink.setMessageRefreshRate({ messageName: 'SCALED_PRESSURE$', refreshRate: 1 })
+    mavlink.setMessageRefreshRate({ messageName: 'SCALED_PRESSURE2$', refreshRate: 1 })
     mavlink.setMessageRefreshRate({ messageName: 'VFR_HUD', refreshRate: 1 })
   },
   methods: {

--- a/core/frontend/src/store/mavlink.ts
+++ b/core/frontend/src/store/mavlink.ts
@@ -67,9 +67,9 @@ class MavlinkStore extends VuexModule {
       // We should not use `message.messageName` as dictionary key since it's a regex,
       // the best approach is to use the message name as key
       const messageName = (message.messageData.message as any).type
-      Vue.set(this.available_messages, messageName, message)
-      const header = message.messageData.header
+      const { header } = message.messageData
       const identifier = `${header.system_id}_${header.component_id}`
+      Vue.set(this.available_messages, messageName, message)
       // make sure identifier exists
       if (!(identifier in this.available_identified_messages)) {
         Vue.set(this.available_identified_messages, identifier, {})

--- a/core/frontend/src/store/mavlink.ts
+++ b/core/frontend/src/store/mavlink.ts
@@ -64,14 +64,17 @@ class MavlinkStore extends VuexModule {
     if (message) {
       // TODO: Check if this is the best possible way to update `available_messages`
       // Reference: https://github.com/bluerobotics/blueos-docker/pull/508#discussion_r718729077
-      Vue.set(this.available_messages, message.messageName, message)
+      // We should not use `message.messageName` as dictionary key since it's a regex,
+      // the best approach is to use the message name as key
+      const messageName = (message.messageData.message as any).type
+      Vue.set(this.available_messages, messageName, message)
       const header = message.messageData.header
       const identifier = `${header.system_id}_${header.component_id}`
       // make sure identifier exists
       if (!(identifier in this.available_identified_messages)) {
         Vue.set(this.available_identified_messages, identifier, {})
       }
-      Vue.set(this.available_identified_messages[identifier], message.messageName, message)
+      Vue.set(this.available_identified_messages[identifier], messageName, message)
     }
   }
 }


### PR DESCRIPTION
- MAVLink use filter as a regex argument, we should use the messages names that we receive over the regex as key for the structure
- setMessageRefreshRate accepts a regex, not a literal. We need to enforce the string that we want using ^..$

This PR:
![Peek 24-01-2024 01-57](https://github.com/bluerobotics/BlueOS/assets/1215497/b9700562-4631-4745-8d81-f61a56b12f18)

Master:
![Peek 24-01-2024 01-59](https://github.com/bluerobotics/BlueOS/assets/1215497/f53ab931-e4a9-4e40-adf6-0d2b176e4aa3)

