### PR TITLE
core: frontend: components: version-chooser: Allow browsers to save repository history

### DIFF
--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -82,6 +82,7 @@
         >
           <v-text-field
             v-model="selected_image"
+            name="BlueOS Remote Repository"
             label="Remote repository"
             :append-icon="selected_image != default_repository ? 'mdi-restore' : undefined"
             @click:append="selected_image = default_repository"


### PR DESCRIPTION
From a friendly stackoverflow:
> In most browsers, you can make your browser display values previously entered in input fields by giving a name to the input.

![image](https://github.com/bluerobotics/BlueOS/assets/1215497/ab09abbc-7d90-4d98-9f76-34ab0cd6f19b)
