### PR TITLE
Allow extension links to avoid iframes

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -187,7 +187,7 @@
 
             <v-list-item
               v-else
-              :to="menu.route"
+              :to="menu.new_page ? null : menu.route"
               :target="menu.new_page ? '_blank' : '_self'"
               :href="menu.extension ? menu.route : undefined"
             >
@@ -461,7 +461,7 @@ export default Vue.extend({
               ? `${address}${service.metadata.icon}`
               : service.metadata?.icon ?? 'mdi-puzzle',
             route: this.addExtraQuery(service.metadata?.route ?? address, service.metadata?.extra_query),
-            new_page: service.metadata?.new_page ?? undefined,
+            new_page: service.metadata?.avoid_iframes ?? service.metadata?.new_page,
             advanced: false,
             text: service.metadata?.description ?? 'Service text',
             extension: true,
@@ -673,6 +673,10 @@ export default Vue.extend({
       }
     },
     createExtensionAddress(service: Service): string {
+      if (service.metadata?.avoid_iframes) {
+        const base_url = window.location.origin.split(":").slice(0, 2).join(":")
+        return `${base_url}:${service.port}`
+      }
       let address = `/extension/${service?.metadata?.sanitized_name}`
       if (service?.metadata?.new_page) {
         address += '?full_page=true'

--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -674,7 +674,7 @@ export default Vue.extend({
     },
     createExtensionAddress(service: Service): string {
       if (service.metadata?.avoid_iframes) {
-        const base_url = window.location.origin.split(":").slice(0, 2).join(":")
+        const base_url = window.location.origin.split(':').slice(0, 2).join(':')
         return `${base_url}:${service.port}`
       }
       let address = `/extension/${service?.metadata?.sanitized_name}`

--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -10,6 +10,7 @@ export interface ServiceMetadata {
     new_page?: boolean
     sanitized_name?: string
     extra_query?: string
+    avoid_iframes?: boolean
 }
 
 export interface Service {

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -99,6 +99,7 @@ class ServiceMetadata(BaseModel):
     route: Optional[str]
     new_page: Optional[bool]
     extra_query: Optional[str]
+    avoid_iframes: Optional[bool]
     api: str
     sanitized_name: Optional[str]
 


### PR DESCRIPTION
some system go a long way trying to prevent being embedded into iframes. or are just plainly badly designed.
My router is an example. it does something with window.top.
This should also avoid other iframe related issues that I don't quite remember right now.


This can be tested with the `iframes` tag of the blueos-proxy extension