### PR TITLE
Fix conflict between kill_autopilot and auto_restart_autopilot

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -478,6 +478,7 @@ class ArduPilotManager(metaclass=Singleton):
                 raise ArdupilotProcessKillFail(f"Could not kill {process.name()}::{process.pid}.") from error
 
     async def kill_ardupilot(self) -> None:
+        self.should_be_running = False
         if not self.current_board or self.current_board.platform != Platform.SITL:
             try:
                 logger.info("Disarming vehicle.")
@@ -486,21 +487,18 @@ class ArduPilotManager(metaclass=Singleton):
             except Exception as error:
                 logger.warning(f"Could not disarm vehicle: {error}. Proceeding with kill.")
 
-        try:
-            # TODO: Add shutdown command on HAL_SITL and HAL_LINUX, changing terminate/prune
-            # logic with a simple "self.vehicle_manager.shutdown_vehicle()"
-            logger.info("Terminating Ardupilot subprocess.")
-            await self.terminate_ardupilot_subprocess()
-            logger.info("Ardupilot subprocess terminated.")
-            logger.info("Pruning Ardupilot's system processes.")
-            await self.prune_ardupilot_processes()
-            logger.info("Ardupilot's system processes pruned.")
+        # TODO: Add shutdown command on HAL_SITL and HAL_LINUX, changing terminate/prune
+        # logic with a simple "self.vehicle_manager.shutdown_vehicle()"
+        logger.info("Terminating Ardupilot subprocess.")
+        await self.terminate_ardupilot_subprocess()
+        logger.info("Ardupilot subprocess terminated.")
+        logger.info("Pruning Ardupilot's system processes.")
+        await self.prune_ardupilot_processes()
+        logger.info("Ardupilot's system processes pruned.")
 
-            logger.info("Stopping Mavlink manager.")
-            await self.mavlink_manager.stop()
-            logger.info("Mavlink manager stopped.")
-        finally:
-            self.should_be_running = False
+        logger.info("Stopping Mavlink manager.")
+        await self.mavlink_manager.stop()
+        logger.info("Mavlink manager stopped.")
 
     async def start_ardupilot(self) -> None:
         await self.setup()

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -176,13 +176,16 @@ async def install_firmware_from_file(
         custom_firmware = Path.joinpath(autopilot.settings.firmware_folder, "custom_firmware")
         with open(custom_firmware, "wb") as buffer:
             shutil.copyfileobj(binary.file, buffer)
+        logger.debug("Going to kill ardupilot")
         await autopilot.kill_ardupilot()
+        logger.debug("Installing firmware from file")
         autopilot.install_firmware_from_file(custom_firmware, target_board(board_name), parameters)
         os.remove(custom_firmware)
     except InvalidFirmwareFile as error:
         raise StackedHTTPException(status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, error=error) from error
     finally:
         binary.file.close()
+        logger.debug("Starting ardupilot again")
         await autopilot.start_ardupilot()
 
 

--- a/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
@@ -110,12 +110,15 @@ class AbstractRouter(metaclass=abc.ABCMeta):
     async def exit(self) -> None:
         if await self.is_running():
             if self._subprocess is not None:
-                logger.error("terminate")
+                logger.warning("Terminating process")
                 self._subprocess.terminate()
+                logger.warning("Termination done")
                 await asyncio.sleep(3)  # Non-blocking sleep
+                logger.warning("Checking if it's still running..")
                 if await self.is_running():
-                    logger.error("kill")
+                    logger.warning("Still running, going to kill it")
                     self._subprocess.kill()
+                    logger.warning("Killing done")
                     await asyncio.sleep(3)
                 await self._subprocess.wait()  # Wait for the subprocess to terminate
         else:


### PR DESCRIPTION
The main problem here is that `should_run` was not set as False on the start of the function, resulting on `auto_restart_autopilot` to conflict with the firmware installation procedure. 