### PR TITLE
core: services: ardupilot_manager: main: Turn raise_lock generic

### DIFF
--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -75,7 +75,7 @@ def target_board(board_name: Optional[str]) -> FlightController:
     return autopilot.current_board
 
 
-def raise_lock() -> None:
+def raise_lock(*raise_args: str, **kwargs: int) -> None:
     """Raise a 423 HTTP Error status
 
     Raises:


### PR DESCRIPTION
Fix error message from raise_lock

![image](https://github.com/bluerobotics/BlueOS/assets/1215497/664b022d-c206-4737-b708-b270522ee952)
