### PR TITLE
core: frontend: components: wizard: Fix action step state to not show as loading when apply is not clicked

### DIFF
--- a/core/frontend/src/components/wizard/ActionStepper.vue
+++ b/core/frontend/src/components/wizard/ActionStepper.vue
@@ -36,6 +36,7 @@ export interface Configuration {
   message: undefined | string
   done: boolean
   skip: boolean
+  started: boolean
 }
 
 export default Vue.extend({
@@ -59,6 +60,9 @@ export default Vue.extend({
         return 'mdi-check'
       }
       if (config.message === undefined) {
+        if (!config.started) {
+          return 'mdi-arrow-right-bold'
+        }
         return 'mdi-loading'
       }
       return 'mdi-alert'
@@ -71,6 +75,9 @@ export default Vue.extend({
         return 'success'
       }
       if (config.message === undefined) {
+        if (!config.started) {
+          return 'grey'
+        }
         return 'yellow'
       }
       return 'error'

--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -427,6 +427,7 @@ export default Vue.extend({
             message: undefined,
             done: false,
             skip: false,
+            started: false,
           },
           {
             title: 'Set vehicle hostname',
@@ -435,6 +436,7 @@ export default Vue.extend({
             message: undefined,
             done: false,
             skip: false,
+            started: false,
           },
           {
             title: 'Set vehicle image',
@@ -443,6 +445,7 @@ export default Vue.extend({
             message: undefined,
             done: false,
             skip: false,
+            started: false,
           },
           ...this.setup_configurations,
         ]
@@ -451,10 +454,12 @@ export default Vue.extend({
     async applyConfigurations() {
       this.apply_status = ApplyStatus.InProgress
       this.apply_status = await Promise.all(this.configurations.map(async (config) => {
+        config.started = true
         config.message = undefined
         if (!config.done && !config.skip) {
           config.message = await config.promise()
           config.done = config.message === undefined
+          config.started = false
         }
         return config
       })).then((configs) => configs.every((config) => config.done || config.skip))
@@ -478,6 +483,7 @@ export default Vue.extend({
           message: undefined,
           done: false,
           skip: false,
+          started: false,
         },
         {
           title: 'Disable Wi-Fi hotspot',
@@ -486,6 +492,7 @@ export default Vue.extend({
           message: undefined,
           done: false,
           skip: false,
+          started: false,
         },
         {
           title: 'Disable smart Wi-Fi hotspot',
@@ -494,6 +501,7 @@ export default Vue.extend({
           message: undefined,
           done: false,
           skip: false,
+          started: false,
         },
       ]
     },


### PR DESCRIPTION
It was weird to show the loading icon while the user does not click in start.
This is fixed by adding a new variable to control the started state.

![image](https://github.com/bluerobotics/BlueOS/assets/1215497/454215f9-fa2f-4ff3-88c1-cd4dbde7540b)
