### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.12.6 + Pass MAVLink System ID to MCM

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -87,7 +87,7 @@ fi
 PRIORITY_SERVICES=(
     'autopilot',250,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
     'cable_guy',250,"$SERVICES_PATH/cable_guy/main.py"
-    'video',700,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
+    'video',700,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
     'mavlink2rest',250,"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.12.5
+VERSION=t3.12.6
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/mavlink/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
Overall:
* MCM is now using the MAVLink System ID from the BlueOS system.
* Some improvements regarding GStreamer pipelines and Signalling server.
* Several Dependencies were updated.

[Full change log here](https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.12.6).