### PR TITLE
core: services: stop using python-based memory limiting

### DIFF
--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -14,7 +14,7 @@ from commonwealth.utils.apis import (
     StackedHTTPException,
 )
 from commonwealth.utils.decorators import single_threaded
-from commonwealth.utils.general import is_running_as_root, limit_ram_usage
+from commonwealth.utils.general import is_running_as_root
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import Body, FastAPI, File, HTTPException, UploadFile, status
 from fastapi.responses import HTMLResponse
@@ -30,9 +30,6 @@ from settings import SERVICE_NAME
 from typedefs import Firmware, FlightController, Parameters, Serial, SITLFrame, Vehicle
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
-
-# We need additional RAM in order to decompress the manifest file
-limit_ram_usage(400)
 
 parser = argparse.ArgumentParser(description="ArduPilot Manager service for Blue Robotics BlueOS")
 parser.add_argument("-s", "--sitl", help="run SITL instead of connecting any board", action="store_true")

--- a/core/services/bag_of_holding/main.py
+++ b/core/services/bag_of_holding/main.py
@@ -8,7 +8,6 @@ import appdirs
 import dpath
 import uvicorn
 from commonwealth.utils.apis import GenericErrorHandlingRoute
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import Body, FastAPI, HTTPException
 from fastapi import Path as FastPath
@@ -19,8 +18,6 @@ from pydantic import BaseModel
 
 SERVICE_NAME = "bag-of-holding"
 FILE_PATH = Path(appdirs.user_config_dir(SERVICE_NAME, "db.json"))
-
-limit_ram_usage()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)

--- a/core/services/beacon/main.py
+++ b/core/services/beacon/main.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 import psutil
 from commonwealth.settings.manager import Manager
 from commonwealth.utils.apis import PrettyJSONResponse
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import init_logger
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
@@ -24,8 +23,6 @@ from settings import ServiceTypes, SettingsV4
 from typedefs import InterfaceType, IpInfo, MdnsEntry
 
 SERVICE_NAME = "beacon"
-
-limit_ram_usage()
 
 
 class AsyncRunner:

--- a/core/services/bridget/main.py
+++ b/core/services/bridget/main.py
@@ -4,7 +4,6 @@ from typing import Any, List
 
 import uvicorn
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import FastAPI, status
 from fastapi.responses import HTMLResponse
@@ -14,8 +13,6 @@ from loguru import logger
 from bridget import BridgeSpec, Bridget
 
 SERVICE_NAME = "bridget"
-
-limit_ram_usage()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -8,7 +8,6 @@ from typing import Any, List
 
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.decorators import temporary_cache
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import Body, FastAPI
 from fastapi.responses import HTMLResponse
@@ -26,8 +25,6 @@ from api.manager import (
 )
 
 SERVICE_NAME = "cable-guy"
-
-limit_ram_usage()
 
 parser = argparse.ArgumentParser(description="CableGuy service for Blue Robotics BlueOS")
 parser.add_argument(

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -12,7 +12,7 @@ import appdirs
 import uvicorn
 from commonwealth.utils.apis import GenericErrorHandlingRoute
 from commonwealth.utils.commands import run_command
-from commonwealth.utils.general import delete_everything, limit_ram_usage
+from commonwealth.utils.general import delete_everything
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import FastAPI, HTTPException, status
 from fastapi.responses import HTMLResponse
@@ -21,8 +21,6 @@ from loguru import logger
 
 SERVICE_NAME = "commander"
 LOG_FOLDER_PATH = os.environ.get("BLUEOS_LOG_FOLDER_PATH", "/var/logs/blueos")
-
-limit_ram_usage()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)

--- a/core/services/kraken/main.py
+++ b/core/services/kraken/main.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any, Iterable
 
 from commonwealth.utils.apis import GenericErrorHandlingRoute
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import FastAPI, HTTPException, status
 from fastapi.responses import HTMLResponse, PlainTextResponse, StreamingResponse
@@ -31,8 +30,6 @@ class Extension(BaseModel):
 
 
 SERVICE_NAME = "kraken"
-
-limit_ram_usage()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)

--- a/core/services/log_zipper/main.py
+++ b/core/services/log_zipper/main.py
@@ -10,17 +10,11 @@ import pathlib
 import time
 from typing import List
 
-from commonwealth.utils.general import (
-    available_disk_space_mb,
-    delete_everything,
-    limit_ram_usage,
-)
+from commonwealth.utils.general import available_disk_space_mb, delete_everything
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from loguru import logger
 
 SERVICE_NAME = "log-zipper"
-
-limit_ram_usage()
 
 
 def zip_files(files: List[str], output_path: str) -> None:

--- a/core/services/nmea_injector/nmea_injector/main.py
+++ b/core/services/nmea_injector/nmea_injector/main.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any, List
 
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import FastAPI, status
 from fastapi.responses import HTMLResponse
@@ -16,8 +15,6 @@ from uvicorn import Config, Server
 from nmea_injector.TrafficController import NMEASocket, SocketKind, TrafficController
 
 SERVICE_NAME = "nmea-injector"
-
-limit_ram_usage()
 
 parser = argparse.ArgumentParser(description="NMEA Injector service for Blue Robotics BlueOS")
 parser.add_argument("-u", "--udp", type=int, help="change the default UDP input port")

--- a/core/services/pardal/main.py
+++ b/core/services/pardal/main.py
@@ -7,13 +7,10 @@ from typing import Generator
 
 import aiohttp
 from aiohttp import web
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from loguru import logger
 
 SERVICE_NAME = "pardal"
-
-limit_ram_usage()
 
 parser = argparse.ArgumentParser(description="Pardal, web service to help with speed and latency tests")
 parser.add_argument("-p", "--port", help="Port to run web server", action="store_true", default=9120)

--- a/core/services/ping/main.py
+++ b/core/services/ping/main.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any, List
 
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import FastAPI, status
 from fastapi.responses import HTMLResponse
@@ -19,8 +18,6 @@ from portwatcher import PortWatcher
 from typedefs import PingDeviceDescriptorModel
 
 SERVICE_NAME = "ping"
-
-limit_ram_usage()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)

--- a/core/services/versionchooser/main.py
+++ b/core/services/versionchooser/main.py
@@ -5,15 +5,12 @@ from typing import Any
 import aiodocker
 import connexion
 from aiohttp import web
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from loguru import logger
 
 from utils.chooser import STATIC_FOLDER, VersionChooser
 
 SERVICE_NAME = "version-chooser"
-
-limit_ram_usage()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -13,7 +13,6 @@ from commonwealth.utils.apis import (
     PrettyJSONResponse,
     StackedHTTPException,
 )
-from commonwealth.utils.general import limit_ram_usage
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import FastAPI, HTTPException, status
 from fastapi.staticfiles import StaticFiles
@@ -28,8 +27,6 @@ from WifiManager import WifiManager
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
 SERVICE_NAME = "wifi-manager"
-
-limit_ram_usage()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)


### PR DESCRIPTION
This only limits virtual memory:
https://linux.die.net/man/2/setrlimit#:~:text=RLIMIT_AS,resource%20is%20unlimited.

on top of it, it is also redundant with the ulimit limiter at [run-service.sh](https://github.com/bluerobotics/BlueOS/blob/master/core/run-service.sh)