### PR TITLE
core: severely bump memory caps for our core services

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -85,9 +85,9 @@ fi
 # From that 1min30s, the startup time is about ~25s, and originally, ~37s, meaning that the
 # remaining (~65 seconds) is the docker shutting down, and the Linux booting up.
 PRIORITY_SERVICES=(
-    'autopilot',250,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
-    'cable_guy',250,"$SERVICES_PATH/cable_guy/main.py"
-    'video',700,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
+    'autopilot',1000,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
+    'cable_guy',1000,"$SERVICES_PATH/cable_guy/main.py"
+    'video',1500,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
     'mavlink2rest',250,"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 


### PR DESCRIPTION
I'm opening this more for testing. I want to make sure the issues are gone 
would fix #2393 , #2378, and #2387

Opening as a draft as I believe the correct change is to change to cgroups, which I'll look into next (it seems it is doable)

I'll leave my desk pi running this over the weekend.