### PR TITLE
core: start-blueos-core: Remove memory limit for video manager

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -90,7 +90,7 @@ fi
 PRIORITY_SERVICES=(
     'autopilot',250,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
     'cable_guy',250,"$SERVICES_PATH/cable_guy/main.py"
-    'video',700,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
+    'video',0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
     'mavlink2rest',250,"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 


### PR DESCRIPTION
When setting up multiple cameras, GStreamer may reserve excessive memory, even if it's not fully utilized. This memory allocation is causing issues when multiple cameras are in use.. According to João, we shouldbe fine if we remove this limit.