### PR TITLE
Bridges updates,  part two

### DIFF
--- a/core/libs/bridges/bridges/bridges.py
+++ b/core/libs/bridges/bridges/bridges.py
@@ -1,12 +1,20 @@
 import logging
 import shlex
 import time
+from enum import Enum
 from shutil import which
 from subprocess import PIPE, Popen
 
 from serial.tools.list_ports_linux import SysFS
 
 from bridges.serialhelper import Baudrate
+
+
+class Status(Enum):
+    STARTING = "STARTING"
+    RUNNING = "RUNNING"
+    STOPPING = "STOPPING"
+    DEAD = "DEAD"
 
 
 # pylint: disable=too-many-arguments
@@ -23,6 +31,7 @@ class Bridge:
         automatic_disconnect: bool = True,
     ) -> None:
         bridges = which("bridges")
+        self.status = Status.STARTING
         automatic_disconnect_clients = "" if automatic_disconnect else "--no-udp-disconnection"
         is_server = ip == "0.0.0.0"
         port = udp_listen_port if is_server else udp_target_port
@@ -39,19 +48,25 @@ class Bridge:
             _stdout, strerr = self.process.communicate()
             error = strerr.decode("utf-8") if strerr else "Empty error"
             raise RuntimeError(f'Failed to initialize bridge, code: {self.process.returncode}, message: "{error}".')
+        self.status = Status.RUNNING
 
     def stop(self) -> None:
+        self.status = Status.STOPPING
         if not self.process:
             raise RuntimeError("Bridges process doesn't exist.")
         self.process.kill()
         time.sleep(1.0)
         if self.process.poll() is None:
             raise RuntimeError("Failed to kill bridges process.")
+        self.status = Status.DEAD
 
     def commmunicate(self) -> tuple[bytes, bytes]:
         if not self.process:
+            self.status = Status.DEAD
             raise RuntimeError("Bridges process doesn't exist.")
-        return self.process.communicate(command)
+        output = self.process.communicate(command)
+        self.status = Status.RUNNING
+        return output
 
     def __del__(self) -> None:
         self.stop()

--- a/core/libs/bridges/bridges/bridges.py
+++ b/core/libs/bridges/bridges/bridges.py
@@ -48,5 +48,10 @@ class Bridge:
         if self.process.poll() is None:
             raise RuntimeError("Failed to kill bridges process.")
 
+    def commmunicate(self) -> tuple[bytes, bytes]:
+        if not self.process:
+            raise RuntimeError("Bridges process doesn't exist.")
+        return self.process.communicate(command)
+
     def __del__(self) -> None:
         self.stop()

--- a/core/services/bridget/bridget.py
+++ b/core/services/bridget/bridget.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from pathlib import Path
 from typing import Dict, List
@@ -94,6 +95,12 @@ class Bridget:
         if bridge is None:
             raise RuntimeError("Bridge doesn't exist.")
         bridge.stop()
+
+    async def do_house_keeping(self) -> None:
+        while True:
+            await asyncio.sleep(5)
+            for _, bridge in self._bridges.items():
+                bridge.commmunicate()
 
     def stop(self) -> None:
         logging.debug("Stopping Bridget and removing all bridges.")

--- a/core/services/bridget/main.py
+++ b/core/services/bridget/main.py
@@ -1,14 +1,15 @@
 #! /usr/bin/env python3
+import asyncio
 import logging
 from typing import Any, List
 
-import uvicorn
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from fastapi import FastAPI, status
 from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
+from uvicorn import Config, Server
 
 from bridget import BridgeFrontendSpec, Bridget
 
@@ -76,5 +77,11 @@ async def read_items() -> Any:
 
 
 if __name__ == "__main__":
+    loop = asyncio.new_event_loop()
+
     # Running uvicorn with log disabled so loguru can handle it
-    uvicorn.run(app, host="0.0.0.0", port=27353, log_config=None)
+    config = Config(app=app, loop=loop, host="0.0.0.0", port=27353, log_config=None)
+    server = Server(config)
+
+    loop.create_task(controller.do_house_keeping())
+    loop.run_until_complete(server.serve())


### PR DESCRIPTION
requires #2322

This improves management of brigdes, including `communicate` to check the status of the process and to consume data, as well as adding a status flag and textual output available to the frontend