### PR TITLE
core: libs: commonwealth: general: Add timeout for lsof operation

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -37,8 +37,19 @@ def delete_everything(path: Path) -> None:
 
 
 def file_is_open(path: Path) -> bool:
-    result = subprocess.run(["lsof", path.resolve()], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
-    return result.returncode == 0
+    try:
+        kernel_functions_timeout = str(2)
+        result = subprocess.run(
+            ["lsof", "-t", "-n", "-P", "-S", kernel_functions_timeout, path.resolve()],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except Exception as error:
+        logger.error(f"Failed to check if file {path} is open, {error}")
+        return True
 
 
 @cache


### PR DESCRIPTION
This fixes the lsof operation that is blocking and using 100% of cpu in some cases.

```
2024-02-27 19:22:03.150 | DEBUG    | __main__:zip_files:29 - Deleted file: /shortcuts/system_logs/ardupilot-manager/logfile_02-22-2024_10:39:21.log
2024-02-27 19:22:08.175 | ERROR    | commonwealth.utils.general:file_is_open:46 - Failed to check if file /shortcuts/system_logs/ardupilot-manager/logfile_02-27-2024_11:30:22.log is open, Command '['lsof', PosixPath('/var/logs/blueos/services/ardupilot-manager/logfile_02-27-2024_11:30:22.log')]' timed out after 5 seconds
```