### PR TITLE
frontend: Beacon: Add double check for wireless network

### DIFF
--- a/core/frontend/src/components/beacon/BeaconTrayMenu.vue
+++ b/core/frontend/src/components/beacon/BeaconTrayMenu.vue
@@ -73,10 +73,19 @@ export default Vue.extend({
       return beacon.available_domains.filter((entry) => entry.interface_type === InterfaceType.WIRED)
     },
     wireless_interface_domains(): Domain[] {
-      return beacon.available_domains.filter((entry) => entry.interface_type !== InterfaceType.WIRED)
+      return beacon.available_domains.filter(
+        (entry) => entry.interface_type === InterfaceType.WIFI || entry.interface_type === InterfaceType.HOTSPOT,
+      )
     },
     is_connected_to_wifi(): boolean {
-      return this.wireless_interface_domains.some((domain) => domain.ip === beacon.nginx_ip_address)
+      const is_on_wifi = this.wireless_interface_domains.some((domain) => domain.ip === beacon.nginx_ip_address)
+      const is_on_wired = this.wired_interface_domains.some((domain) => domain.ip === beacon.nginx_ip_address)
+
+      if (is_on_wifi && is_on_wired) {
+        console.debug('Unexpected behavior. There are both Wired and Wireless interfaces sharing the same IP address.')
+      }
+
+      return is_on_wifi && !is_on_wired
     },
   },
   mounted() {


### PR DESCRIPTION
* Adds a double check for check in `is_connected_to_wifi` potentially avoid unexpected behavior where both wired and wireless interfaces could have the same IP
* Change computed property `wireless_interface_domains` to instead of checking for interfaces with type different than WIRED to consider only WIFI and HOTSPOT as Wireless interfaces, since usb interfaces currently holds type unknown and would be classified as Wireless

Probably linked to #2362  