### PR TITLE
core: services: Fix USB not being listed in Beacon

### DIFF
--- a/core/services/beacon/main.py
+++ b/core/services/beacon/main.py
@@ -111,12 +111,13 @@ class Beacon:
     def set_hostname(self, hostname: str) -> None:
         self.manager.settings.default.domain_names = [hostname]
         for interface in self.manager.settings.interfaces:
-            if interface.name.startswith("eth") or interface.name.startswith("usb"):
-                interface.domain_names = [hostname, self.DEFAULT_HOSTNAME]  # let's keep our default just in case
-            elif interface.name.startswith("wlan"):
-                interface.domain_names = [f"{hostname}-wifi"]
-            elif interface.name.startswith("uap"):
-                interface.domain_names = [f"{hostname}-hostspot"]
+            match InterfaceType.guess_from_name(interface.name):
+                case InterfaceType.WIRED | InterfaceType.USB:
+                    interface.domain_names = [hostname, self.DEFAULT_HOSTNAME]  # let's keep our default just in case
+                case InterfaceType.WIFI:
+                    interface.domain_names = [f"{hostname}-wifi"]
+                case InterfaceType.HOTSPOT:
+                    interface.domain_names = [f"{hostname}-hostspot"]
         self.manager.save()
 
     def get_hostname(self) -> str:

--- a/core/services/beacon/main.py
+++ b/core/services/beacon/main.py
@@ -117,7 +117,7 @@ class Beacon:
                 case InterfaceType.WIFI:
                     interface.domain_names = [f"{hostname}-wifi"]
                 case InterfaceType.HOTSPOT:
-                    interface.domain_names = [f"{hostname}-hostspot"]
+                    interface.domain_names = [f"{hostname}-hotspot"]
         self.manager.save()
 
     def get_hostname(self) -> str:

--- a/core/services/beacon/typedefs.py
+++ b/core/services/beacon/typedefs.py
@@ -7,6 +7,7 @@ class InterfaceType(str, Enum):
     WIRED = "WIRED"
     WIFI = "WIFI"
     HOTSPOT = "HOTSPOT"
+    USB = "USB"
     UNKNOWN = "UNKNOWN"
 
     @staticmethod
@@ -19,6 +20,8 @@ class InterfaceType(str, Enum):
             return InterfaceType.WIRED
         if name.startswith("eth"):
             return InterfaceType.WIRED
+        if name.startswith("usb"):
+            return InterfaceType.USB
         return InterfaceType.UNKNOWN
 
 


### PR DESCRIPTION
Add a new interface type in beacon to avoid USB interfaces to get listed as UNKNOWN interface type and change to use guess_from_name in set_hostname instead of replicating the same logic.

Probably linked to #2274 