### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.12.8

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.12.7
+VERSION=t3.12.8
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/mavlink/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
* src: stream: pipeline: Fix wrong frame duration
* src: stream: rtsp: shmsrc needs to do-timestamp

[Full change log here](https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.12.8).