### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.12.9

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.12.8
+VERSION=t3.12.9
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/mavlink/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
The RTSP was still not fixed on the Raspberry Pi (which has an older GStreamer):
* src: stream: rtsp: shmsrc needs to wait for connection

Full Changelog: https://github.com/mavlink/mavlink-camera-manager/compare/t3.12.8...t3.12.9