### PR TITLE
core: frontend: App: Fix v-stepper disappearing when the screen width is small

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -868,6 +868,11 @@ div.pirate-marker.v-icon {
   }
 }
 
+/* Fix v-stepper disappearing when the screen is small*/
+.v-stepper__label {
+  display: block !important;
+}
+
 html {
   overflow: auto
 }


### PR DESCRIPTION


Fix #2490 
![image](https://github.com/bluerobotics/BlueOS/assets/1215497/72ca20da-7e66-4a4d-b7a0-fbc0a83b936b)
