### PR TITLE
Allow uninstall from extension modal

### DIFF
--- a/core/frontend/src/components/kraken/ExtensionModal.vue
+++ b/core/frontend/src/components/kraken/ExtensionModal.vue
@@ -48,20 +48,11 @@
 
               <v-col class="text-center">
                 <v-btn
-                  v-if="installed === selected_version"
-                  class="mt-3"
-                  disabled
-                  color="primary"
-                >
-                  Installed
-                </v-btn>
-                <v-btn
-                  v-else
                   class="mt-3"
                   color="primary"
-                  @click="$emit('clicked', selected_version)"
+                  @click="$emit('clicked', extension.identifier, selected_version, isInstalled)"
                 >
-                  Install
+                  {{ isInstalled ? 'Uninstall' : 'Install' }}
                 </v-btn>
               </v-col>
             </v-row>
@@ -189,6 +180,9 @@ export default Vue.extend({
         return versions[this.selected_version].permissions
       }
       return 'No permissions required'
+    },
+    isInstalled(): boolean {
+      return this.selected_version === this.installed
     },
   },
   watch: {

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -14,7 +14,7 @@
       <extension-modal
         :extension="selected_extension"
         :installed="installedVersion()"
-        @clicked="installFromSelected"
+        @clicked="performActionFromModal"
       />
     </v-dialog>
     <v-dialog
@@ -524,6 +524,18 @@ export default Vue.extend({
           this.extraction_percentage = 0
           this.status_text = ''
         })
+    },
+    async performActionFromModal(identifier: string, tag: string, isInstalled: boolean) {
+      if (isInstalled) {
+        const ext = this.installed_extensions[identifier]
+        if (!ext) {
+          return
+        }
+        this.show_dialog = false
+        await this.uninstall(ext)
+      } else {
+        await this.installFromSelected(tag)
+      }
     },
     async installFromSelected(tag: string) {
       if (!this.selected_extension) {


### PR DESCRIPTION
Allow users to uninstall from current extension modal instead of showing a disabled `installed` button.