### PR TITLE
Fix shellcheck warning listed in deploy

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -58,7 +58,7 @@ MOUNT_LOCATION=/tmp/blueos_deploy
 mkdir -p $MOUNT_LOCATION
 
 DEV_PART2=$DEV_DISK
-DEV_PART2+=2
+DEV_PART2="${DEV_PART2}2"
 
 echo "unmounting $DEV_DISK"
 umount $DEV_DISK?*


### PR DESCRIPTION
Fixes this warning making clear the append statement

```
DEV_PART2+=2
^-------^ SC2324 (warning): var+=1 will append, not increment. Use (( var += 1 )), declare -i var, or quote number to silence.
```