### PR TITLE
Add path check prior to pushing repeated path in router when using logo to navigate to home

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -709,7 +709,9 @@ export default Vue.extend({
       this.backend_offline = backend_offline
     },
     goHome(): void {
-      this.$router.push('/')
+      if (this.$router.currentRoute.path !== '/') {
+        this.$router.push('/')
+      }
     },
   },
 })


### PR DESCRIPTION
Fix small error appearing on console when clicking in logo when already in home.

![image](https://github.com/bluerobotics/BlueOS/assets/58235456/57bfaa3c-d2c1-4d2c-8ce2-233066881c74)
