### PR TITLE
core: frontend: extensions: raise error if tag is included in docker name

### DIFF
--- a/core/frontend/src/components/kraken/ExtensionCreationDialog.vue
+++ b/core/frontend/src/components/kraken/ExtensionCreationDialog.vue
@@ -124,6 +124,9 @@ export default Vue.extend({
       return 'This field must contain two words separated by a period. Numbers are allowed after the first character.'
     },
     validate_dockerhub(input: string): (true | string) {
+      if (input.includes(':')) {
+        return 'The name must not contain the docker tag'
+      }
       // A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits,
       // underscores, periods and dashes. A tag name may not start with a period or a dash and
       // may contain a maximum of 128 characters.


### PR DESCRIPTION

![image](https://github.com/bluerobotics/BlueOS/assets/4013804/702d486c-52ac-4ada-ad15-d59df4f10fbf)
