### PR TITLE
core: services: beacon: fix broken ethernet domain name config

### DIFF
--- a/core/services/beacon/main.py
+++ b/core/services/beacon/main.py
@@ -113,7 +113,12 @@ class Beacon:
         for interface in self.manager.settings.interfaces:
             match InterfaceType.guess_from_name(interface.name):
                 case InterfaceType.WIRED | InterfaceType.USB:
-                    interface.domain_names = [hostname, self.DEFAULT_HOSTNAME]  # let's keep our default just in case
+                    interface.domain_names = [
+                        old_name.replace(self.DEFAULT_HOSTNAME, hostname) for old_name in interface.domain_names
+                    ]
+                    # Let's keep our default just in case
+                    if self.DEFAULT_HOSTNAME not in interface.domain_names:
+                        interface.domain_names.append(self.DEFAULT_HOSTNAME)
                 case InterfaceType.WIFI:
                     interface.domain_names = [f"{hostname}-wifi"]
                 case InterfaceType.HOTSPOT:


### PR DESCRIPTION
Fixes #2548 

⚠️ UNTESTED ⚠️
Probably a good idea to make sure this works properly for both ethernet and USB-OTG connections before merging.

If it's possible for the `domain_names` variable to not exist or be an empty list then we should catch/handle that (`except` the `AttributeError`, and/or make sure to append the `hostname` if it's not there at the end, like is being done with the default).