### PR TITLE
Fix invalid reference pass in digest passed on install on kraken

### DIFF
--- a/core/services/kraken/kraken.py
+++ b/core/services/kraken/kraken.py
@@ -137,7 +137,7 @@ class Kraken:
         self.settings.extensions.append(new_extension)
         self.manager.save()
         try:
-            tag = f"{extension.docker}:{extension.tag}" + (f":{digest}" if digest else "")
+            tag = f"{extension.docker}:{extension.tag}" + (f"@{digest}" if digest else "")
 
             async for line in self.client.images.pull(tag, repo=extension.docker, tag=extension.tag, stream=True):
                 yield json.dumps(line).encode("utf-8")


### PR DESCRIPTION
When installing some extension, the progress popup closes unexpectedly after clicking in install, but the extension still being installed, since the way digest was being passed was considered invalid reference the front end closes the popup but the back still installing. With the fix the digest is passed in a compatible manner and the progress popup when installing keeps open. 