### PR TITLE
core: frontend: PowerMenu: reorder options with increasing severity

### DIFF
--- a/core/frontend/src/components/app/PowerMenu.vue
+++ b/core/frontend/src/components/app/PowerMenu.vue
@@ -27,20 +27,6 @@
         <v-container class="pa-2">
           <v-card-actions class="flex-column">
             <v-btn
-              v-tooltip="'Shuts down the onboard computer'"
-              class="ma-2"
-              :disabled="non_default_status"
-              @click="poweroff"
-            >
-              <v-icon
-                left
-                color="red"
-              >
-                mdi-power-standby
-              </v-icon>
-              Power off
-            </v-btn>
-            <v-btn
               v-tooltip="'Restarts the autopilot'"
               class="ma-2"
               :loading="restarting_autopilot"
@@ -54,6 +40,20 @@
                 mdi-restart
               </v-icon>
               Restart Autopilot
+            </v-btn>
+            <v-btn
+              v-tooltip="'Restarts the core alone, should be enough in most cases'"
+              class="ma-2"
+              :disabled="non_default_status"
+              @click="restartContainer"
+            >
+              <v-icon
+                left
+                color="orange"
+              >
+                mdi-folder-refresh
+              </v-icon>
+              {{ settings.is_pirate_mode ? "Restart Core container" : "Soft restart" }}
             </v-btn>
             <v-btn
               v-tooltip="'Fully restarts the onboard computer'"
@@ -70,18 +70,18 @@
               Reboot
             </v-btn>
             <v-btn
-              v-tooltip="'Restarts the core alone, should be enough in most cases'"
+              v-tooltip="'Shuts down the onboard computer'"
               class="ma-2"
               :disabled="non_default_status"
-              @click="restartContainer"
+              @click="poweroff"
             >
               <v-icon
                 left
-                color="orange"
+                color="red"
               >
-                mdi-folder-refresh
+                mdi-power-standby
               </v-icon>
-              {{ settings.is_pirate_mode ? "Restart Core container" : "Soft restart" }}
+              Power off
             </v-btn>
           </v-card-actions>
         </v-container>


### PR DESCRIPTION
The current order seems arbitrary, and is a bit confusing to navigate.

I think it makes sense to have the options ordered with the least critical state change first (only the autopilot gets restarted), and the most critical change last (the onboard computer gets shut down, and needs to be manually power cycled to turn back on).

### Original order
1. Power Off
2. Restart Autopilot
3. Reboot
4. Restart Core Container

### New (suggested) order
1. Restart Autopilot
2. Restart Core Container
3. Reboot
4. Power Off