### PR TITLE
eslint: add no-else-return

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'no-bitwise': 'off',
     'no-console': 'off',
     'no-continue': 'off',
+    "no-else-return": ["error", { "allowElseIf": false }],
     'no-extra-parens': ['error', 'all'],
     'no-mixed-operators': 'off',
     // modified https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L339


### PR DESCRIPTION
This catches unnecessary else blocks. sadly doesn't seems to work after `throw`

also, this works with --fix, which is neat