### PR TITLE
core: frontend: allow reversing motors in the frontend

### DIFF
--- a/core/frontend/src/components/vehiclesetup/PwmSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/PwmSetup.vue
@@ -23,6 +23,7 @@
                   <th class="text-left subtitle-1 font-weight-bold">
                     Motor Test
                   </th>
+                  <th />
                   <th>
                     <v-switch
                       v-model="desired_armed_state"
@@ -51,6 +52,15 @@
                 >
                   <td width="20%">
                     {{ motor.name }}
+                  </td>
+                  <td width="10%">
+                    <parameterSwitch
+                      v-if="motor.reverse_parameter"
+                      :parameter="motor.reverse_parameter"
+                      :on-value="reverse_on_value"
+                      :off-value="reverse_off_value"
+                      label="Reversed"
+                    />
                   </td>
                   <td width="80%">
                     <v-slider
@@ -154,10 +164,14 @@ import { SERVO_FUNCTION } from '@/types/autopilot/parameter-sub-enums'
 import { Dictionary } from '@/types/common'
 import mavlink_store_get from '@/utils/mavlink'
 
+import ParameterSwitch from '../common/ParameterSwitch.vue'
+
 interface MotorTestTarget {
   name: string
   servo: number // target and servo differ in rover
   target: number
+  direction: number
+  reverse_parameter?: Parameter
 }
 
 const rover_function_map = {
@@ -180,6 +194,7 @@ export default Vue.extend({
   name: 'PwmSetup',
   components: {
     ParameterEditorDialog,
+    ParameterSwitch,
     VehicleViewer,
   },
   data() {
@@ -195,6 +210,9 @@ export default Vue.extend({
       arming_timeout: undefined as number | undefined,
       has_focus: true,
       motors_zeroed: false,
+      // These two change from firmware to firmware...
+      reverse_on_value: 1.0,
+      reverse_off_value: 0.0,
     }
   },
   computed: {
@@ -221,11 +239,14 @@ export default Vue.extend({
       ).map((parameter) => {
         const number = parseInt(/\d+/g.exec(parameter.name)?.[0] ?? '0', 10)
         const name = param_value_map.Submarine[parameter.name] ?? `Motor ${number}`
+        const direction_parameter = autopilot_data.parameterRegex(`MOT_${number}_DIRECTION`)?.[0]
         const target = number - 1
         return {
           name,
           servo: number,
           target,
+          direction: direction_parameter.value,
+          reverse_parameter: direction_parameter,
         }
       })
     },
@@ -234,6 +255,14 @@ export default Vue.extend({
         return this.available_rover_motors
       }
       return this.available_sub_motors
+    },
+    motor_direction(): {[key: number]: number} {
+      const motorDict = {} as {[key: number]: number}
+      const availableMotors = this.available_motors
+      for (const motor of availableMotors) {
+        motorDict[motor.target] = motor.direction
+      }
+      return motorDict
     },
     available_rover_motors(): MotorTestTarget[] {
       return this.servo_function_parameters.filter(
@@ -248,12 +277,24 @@ export default Vue.extend({
         const name = printParam(parameter)
         const servo = parseInt(/\d+/g.exec(parameter.name)?.[0] ?? '0', 10)
         const target = rover_function_map[parameter.value] ?? 0
+        const reverse_parameter = autopilot_data.parameterRegex(`SERVO${servo}_REVERSED`)?.[0]
         return {
           name,
           servo,
           target,
+          direction: reverse_parameter.value ? -1.0 : 1.0,
+          reverse_parameter,
         }
       })
+    },
+    motor_target_with_reversion(): {[key: number]: number} {
+      const targets = { ...this.motor_targets }
+      for (const motor_string of Object.keys(targets)) {
+        const motor = parseInt(motor_string, 10)
+        const raw_value = targets[motor] - 1500
+        targets[motor] = 1500 + this.motor_direction[motor] * raw_value
+      }
+      return targets
     },
     vehicle_id(): number {
       return autopilot_data.system_id
@@ -327,6 +368,12 @@ export default Vue.extend({
       // To reflect changed made from other sources like from GCSs
       this.desired_armed_state = this.is_armed
     },
+    is_rover() {
+      this.updateReversionValues()
+    },
+    is_sub() {
+      this.updateReversionValues()
+    },
   },
   mounted() {
     this.motor_zeroer_interval = setInterval(this.zero_motors, 300)
@@ -334,6 +381,7 @@ export default Vue.extend({
     mavlink.setMessageRefreshRate({ messageName: 'SERVO_OUTPUT_RAW', refreshRate: 10 })
     this.desired_armed_state = this.is_armed
     this.installListeners()
+    this.updateReversionValues()
   },
   beforeDestroy() {
     clearInterval(this.motor_zeroer_interval)
@@ -342,6 +390,16 @@ export default Vue.extend({
     this.uninstallListeners()
   },
   methods: {
+    updateReversionValues() {
+      if (this.is_rover) {
+        this.reverse_on_value = 1.0
+        this.reverse_off_value = 0
+        return
+      }
+      // sub
+      this.reverse_on_value = -1.0
+      this.reverse_off_value = 1.0
+    },
     focusListener() {
       this.has_focus = true
     },
@@ -386,7 +444,7 @@ export default Vue.extend({
         return
       }
       if (this.is_armed && this.desired_armed_state) {
-        for (const [motor, value] of Object.entries(this.motor_targets)) {
+        for (const [motor, value] of Object.entries(this.motor_target_with_reversion)) {
           this.doMotorTest(parseInt(motor, 10), value)
         }
       }


### PR DESCRIPTION
[Screencast from 2024-04-24 13-59-44.webm](https://github.com/bluerobotics/BlueOS/assets/4013804/013c4e38-9c7e-4666-b0d0-5fd62de5eaa8)

helps #1818 

At least gets us to parity with qgc on that regard

tested with a servo on both sub and rover