### PR TITLE
Cgroups updates

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -12,7 +12,7 @@
             },
             "/sys/": {
                 "bind": "/sys/",
-                "mode": "ro"
+                "mode": "rw"
             },
             "/var/run/wpa_supplicant/wlan0": {
                 "bind": "/var/run/wpa_supplicant/wlan0",

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -34,6 +34,7 @@ DELTA_JSON = {
             "/usr/blueos/bin": {"bind": "/usr/blueos/bin", "mode": "rw"},
             "/etc/resolv.conf.host": {"bind": "/etc/resolv.conf.host", "mode": "ro"},
             "/home/pi/.ssh": {"bind": "/home/pi/.ssh", "mode": "rw"},
+            "/sys/": {"bind": "/sys/", "mode": "rw"},
         }
     }
 }


### PR DESCRIPTION
Our startup and blueos_startup_update files are inconsistent. also it _should_ require rw access for cgroups to work. it seems to be working regardless...

needs testing