### PR TITLE
Installed Extensions Page: Fix single extension card min width

### DIFF
--- a/core/frontend/src/components/kraken/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/InstalledExtensionCard.vue
@@ -318,8 +318,8 @@ export default Vue.extend({
 <style scoped>
 .card-actions {
   flex-wrap: wrap;
-  column-gap: 4px;
   justify-content: center;
+  row-gap: 7px;
 }
 .progress {
   border-radius: 3px;

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -723,9 +723,9 @@ export default Vue.extend({
 .installed-extensions-container {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: flex-start;
-
+  width: 100%;
 }
 
 .main-container {
@@ -734,8 +734,9 @@ export default Vue.extend({
 
 .installed-extension-card {
   margin: 10px;
-  flex: 1 1 400px;
-  max-width: 32%;
+  flex: 1 1 calc(33.333% - 20px);
+  max-width: calc(33.333% - 20px);
+  min-width: 400px;
 }
 
 .jv-code {


### PR DESCRIPTION
When there is a single item on the installed extensions page, the card min-width is too small:
![image](https://github.com/bluerobotics/BlueOS/assets/14910201/a3ac2e00-90aa-425e-834e-5c7fe9a3bac3)

Fixed to:
![image](https://github.com/bluerobotics/BlueOS/assets/14910201/72eac7b9-6542-4694-8494-21efab20e19a)
