### PR TITLE
blueos_startup_update: add 'remove_console' step

### DIFF
--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -446,6 +446,24 @@ def run_command_is_working():
     return True
 
 
+def remove_console():
+    """
+    removes "console=serial0,115200" from cmdline.txt
+    """
+    if not cmdline_file:
+        logger.error("cmdline unknown, aborting console patch")
+        return False
+    cmdline_content = load_file(cmdline_file).strip().split(" ")
+    unpatched_cmdline_content = cmdline_content.copy()
+
+    new_cmdline = " ".join([content for content in cmdline_content if "console=serial" not in content])
+
+    if unpatched_cmdline_content != new_cmdline:
+        save_file(cmdline_file, new_cmdline, "before_remove_console")
+        return True
+    return False
+
+
 def main() -> int:
     start = time.time()
     current_git_version = os.getenv("GIT_DESCRIBE_TAGS")
@@ -472,6 +490,7 @@ def main() -> int:
 
     # TODO: parse tag as semver and check before applying patches
     patches_to_apply = [
+        remove_console,
         update_startup,
         ensure_user_data_structure_is_in_place,
         ensure_nginx_permissions,


### PR DESCRIPTION
this install step was not in blueos_startup_update
https://github.com/bluerobotics/BlueOS/blob/master/install/boards/bcm_27xx.sh#L83-L84