### PR TITLE
Fix ssh ownership

### DIFF
--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -445,6 +445,13 @@ def run_command_is_working():
     return True
 
 
+def fix_ssh_ownership() -> bool:
+    logger.info("Fixing .ssh ownership...")
+    command = "sudo chown -R $USER:$USER $HOME/.ssh"
+    run_command(command, False)
+    return False
+
+
 def main() -> int:
     start = time.time()
     # check if boot_loop_detector exists
@@ -479,6 +486,7 @@ def main() -> int:
         ensure_user_data_structure_is_in_place,
         ensure_nginx_permissions,
         create_dns_conf_host_link,
+        fix_ssh_ownership(),
     ]
 
     # this will always be pi4 as pi5 is not supported


### PR DESCRIPTION
fix #2176 

I tested by doing `chown -R root:root /home/pi/.ssh` and restarting the container. but it is already root:root in our images, I had manually changed it to do `ssh-copy-id`

![image](https://github.com/bluerobotics/BlueOS/assets/4013804/00f32c4a-0ee3-483e-ba50-f44c80813be6)