### PR TITLE
ArdupilotManager: reduce verbosity when there's no board running

### DIFF
--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -122,7 +122,9 @@ def get_serials() -> Any:
 @version(1, 0)
 async def get_firmware_info() -> Any:
     if not autopilot.current_board:
-        raise RuntimeError("Cannot fetch firmware info as there's no board running.")
+        message = "No board running, firmware information is unavailable"
+        logger.warning(message)
+        return PlainTextResponse(message, status_code=503)
     try:
         return await autopilot.vehicle_manager.get_firmware_info()
     except ValueError:
@@ -133,7 +135,9 @@ async def get_firmware_info() -> Any:
 @version(1, 0)
 async def get_vehicle_type() -> Any:
     if not autopilot.current_board:
-        raise RuntimeError("Cannot fetch vehicle type info as there's no board running.")
+        message = "No board running, vehicle type is unavailable"
+        logger.warning(message)
+        return PlainTextResponse(message, status_code=503)
     try:
         return await autopilot.vehicle_manager.get_vehicle_type()
     except FetchUpdatedMessageFail as error:


### PR DESCRIPTION
before:
![image](https://github.com/bluerobotics/BlueOS/assets/4013804/4d45d698-f73d-4645-b1b4-4d89cf725885)

after:
![image](https://github.com/bluerobotics/BlueOS/assets/4013804/0c36b579-31ea-4dc9-8ed3-0145c9b8b4e7)
