### PR TITLE
fix pre-push hooks, and move to Poetry

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -29,20 +29,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt install shellcheck
+        sudo apt-get install --no-install-recommends --assume-yes shellcheck parallel
         python -m pip install --upgrade pip
-        pip install pipenv
-        pipenv install poetry && pipenv run poetry install
-        echo "installing mavlink-router"
-        pipenv run ./core/tools/mavlink_router/bootstrap.sh
-        echo "installing mavp2p"
-        pipenv run ./core/tools/mavp2p/bootstrap.sh
-        echo "installing ardupilot_tools"
-        pipenv run ./core/tools/ardupilot_tools/bootstrap.sh
-        pipenv run python ./core/libs/bridges/setup.py install
-        pipenv run python ./core/libs/commonwealth/setup.py install
-        rm -rf core/libs/bridges/build
-        rm -rf core/libs/commonwealth/build
+        pip install poetry
 
     - name: Run tests
       run: |

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -2,9 +2,9 @@
 
 set -e
 
-# Check if pipenv is installed
-command -v pipenv >/dev/null 2>&1 || {
-    echo >&2 "pipenv is not installed. Aborting. Please install it and try again."
+# Check if poetry is installed
+command -v poetry >/dev/null 2>&1 || {
+    echo >&2 "poetry is not installed. Aborting. Please install it and try again."
     exit 1
 }
 
@@ -20,16 +20,16 @@ command -v parallel >/dev/null 2>&1 || {
     exit 1
 }
 
-# poetry can rely on pip to uninstall packages sometimes...
-pipenv install poetry pip --skip-lock
-pipenv run poetry install
+poetry install
+. "$(poetry env info --path)/bin/activate"
+
 # download some required files if they are not present
 echo "installing mavlink-router"
-pipenv run ./core/tools/mavlink_router/bootstrap.sh
+./core/tools/mavlink_router/bootstrap.sh
 echo "installing mavp2p"
-pipenv run ./core/tools/mavp2p/bootstrap.sh
+./core/tools/mavp2p/bootstrap.sh
 echo "installing ardupilot_tools"
-pipenv run ./core/tools/ardupilot_tools/bootstrap.sh
+./core/tools/ardupilot_tools/bootstrap.sh
 
 isort_extra_args="--check-only --diff"
 black_extra_args="--check --diff"
@@ -77,28 +77,28 @@ git ls-files '*.sh' | xargs -L 1 shellcheck --exclude=SC2005,SC2015,SC2046,SC204
 
 echo "Running isort.."
 # Run isort for each python project
-dirname $(git ls-files "$repository_path/*/setup.py") | xargs -I {} pipenv run isort --src-path="{}" ${isort_extra_args} "{}"
+dirname $(git ls-files "$repository_path/*/setup.py") | xargs -I {} isort --src-path="{}" ${isort_extra_args} "{}"
 
 # This will only get the python files track by git, not including submodules
 python_files=$(git ls-files '*.py')
 
 echo "Running black.."
-pipenv run black ${black_extra_args} $python_files
+black ${black_extra_args} $python_files
 
 # do not run the rest of the script if running for fixing
 [ "$fixing" = true ] && exit 0
 
 # Faster than pylint to check for issues
 echo "Running ruff.."
-pipenv run ruff $python_files
+ruff $python_files
 
 echo "Running pylint.."
-pipenv run pylint $python_files
+pylint $python_files
 
 echo "Running mypy.."
-git ls-files '*setup.py' | parallel 'pipenv run mypy $(dirname {}) --cache-dir "$(dirname {})/__mypycache__"'
+git ls-files '*setup.py' | parallel 'mypy $(dirname {}) --cache-dir "$(dirname {})/__mypycache__"'
 
 echo "Running pytest.."
-pipenv run pytest -n 10 --cov="$repository_path" --cov-report html
+pytest -n 10 --cov="$repository_path" --cov-report html
 
 exit 0

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -29,7 +29,7 @@ echo "installing mavlink-router"
 echo "installing mavp2p"
 ./core/tools/mavp2p/bootstrap.sh
 echo "installing ardupilot_tools"
-./core/tools/ardupilot_tools/bootstrap.sh
+NOSUDO=1 ./core/tools/ardupilot_tools/bootstrap.sh
 
 isort_extra_args="--check-only --diff"
 black_extra_args="--check --diff"

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -2,6 +2,27 @@
 
 set -e
 
+# Check if the required Python version is available
+PYTHON_VERSION=$(grep -oP 'python\s*=\s*"[^0-9]*\K[0-9]+\.[0-9]+' pyproject.toml)
+command -v "python$PYTHON_VERSION" >/dev/null 2>&1 || {
+    if [ "$(command -v pyenv)" ]; then
+        echo "Pyenv is available, switching local Python version to $PYTHON_VERSION"
+        pyenv install -fs "$PYTHON_VERSION"
+        pyenv local "$PYTHON_VERSION"
+    else
+        cat >&2 <<EOF
+Python $PYTHON_VERSION is not available. Aborting.
+If your Linux distribution doesn't provide it, consider using Pyenv:
+    1. Install Pyenv using your Linux distribution package manager
+    2. Run the following commands:
+        pyenv install $PYTHON_VERSION
+        pyenv local $PYTHON_VERSION
+For more information about pyenv, please visit https://github.com/pyenv/pyenv#readme
+EOF
+    exit 1
+    fi
+}
+
 # Check if poetry is installed
 command -v poetry >/dev/null 2>&1 || {
     echo >&2 "poetry is not installed. Aborting. Please install it and try again."

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = false
 py-modules = []
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "~3.11"
 pytest-xdist = "^3.3.1"
 toml = "^0.10.2"
 


### PR DESCRIPTION
This migrates the hooks/pre-push to use Poetry directly, and makes all the files contained within the project's virtual environment, instead of loading files on the users' folder, making the development environment more replicable.

To use the pre-push, the user must have a Python 3.11 available. Before, it would use whatever the system's Python was, failing to run when the user had 3.12 or 3.10 for example.

To test:
- checkout to this PR's branch
- clean the project: `\rm -rf .venv poetry.lock`
- run the pre-push hook: `.hooks/pre-push`

To check whether it had any impact on the normal installation:
- Try out the `joaoantoniocardoso/blueos-core`:`fix-pre-push` on BlueOS

I have tested it myself, but more samples are welcome.

After this patch is merged, we can all clean our system:

* `ls "$(python -m site --user-site)"`
* `ls "$(python -m site --user-base)/bin"`