### PR TITLE
Frontend: CloudTrayMenu: Fix set major tom token in bag to not delete other existing keys

### DIFF
--- a/core/frontend/src/components/cloud/CloudTrayMenu.vue
+++ b/core/frontend/src/components/cloud/CloudTrayMenu.vue
@@ -349,7 +349,8 @@ export default Vue.extend({
 
       if (isTokenValid) {
         try {
-          await bag.setData('major_tom', { token: this.token })
+          const tomData = await bag.getData('major_tom')
+          await bag.setData('major_tom', { ...tomData, token: this.token })
 
           await back_axios({
             url: `${KRAKEN_API_URL}/extension/restart`,


### PR DESCRIPTION
Change set major tom token to preserve other keys since when changing token major tom itself may already have set other keys and CloudTrayMenu was overriding it