### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.15.1

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.15.0"
+VERSION="t3.15.1"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
The MCM was using the wrong settings file, [as reported here](https://github.com/mavlink/mavlink-camera-manager/issues/417).
