### PR TITLE
frontend: use 0 frequency for HEARTBEAT messages

### DIFF
--- a/core/frontend/src/components/mavlink/MavlinkUpdater.vue
+++ b/core/frontend/src/components/mavlink/MavlinkUpdater.vue
@@ -10,7 +10,7 @@ import mavlink from '@/store/mavlink'
 export default Vue.extend({
   name: 'MavlinkUpdater',
   mounted() {
-    mavlink.setMessageRefreshRate({ messageName: 'HEARTBEAT', refreshRate: 1 })
+    mavlink.setMessageRefreshRate({ messageName: 'HEARTBEAT', refreshRate: 0 })
     mavlink.setMessageRefreshRate({ messageName: 'SYS_STATUS', refreshRate: 3 })
   },
 })


### PR DESCRIPTION
0 means we get all messages. using 1 means we were losing a lot of heartbeats, as we have multiple components sending them at 1Hz and our mavlink interface was not designed with this in mind

This fixes issues in the Motor Test page where it loses heartbeats and doesn't detect arming/disarming and modes properly