### PR TITLE
kraken: Add treatment for ext start when offline

### DIFF
--- a/core/services/kraken/manifest/exceptions.py
+++ b/core/services/kraken/manifest/exceptions.py
@@ -16,3 +16,7 @@ class ManifestNotFound(Exception):
 
 class ManifestOperationNotAllowed(Exception):
     pass
+
+
+class ManifestBackendOffline(Exception):
+    pass


### PR DESCRIPTION
Fix #2727

* Add ManifestBackendOffline error in manifest fetch
* Add treatment to try to start anyway if fails to fetch manifest