### PR TITLE
frontend: HealthTrayMenu: fix 'loading...' temperature on PIs

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -156,7 +156,7 @@ export default Vue.extend({
   computed: {
     cpu_temperature(): string {
       const temperature_sensors = system_information.system?.temperature
-      const main_sensor = temperature_sensors?.find((sensor) => sensor.name === 'CPU')
+      const main_sensor = temperature_sensors?.find((sensor) => sensor.name.toLowerCase().includes('cpu'))
       return main_sensor ? main_sensor.temperature.toFixed(1) : 'Loading..'
     },
     cpu_throttled() : boolean {


### PR DESCRIPTION
On the pi, the temp is labeled ""cpu_thermal temp1" This should be generic enough

![image](https://github.com/bluerobotics/BlueOS/assets/4013804/05208e8c-86b5-4056-aa00-dfccacf962bc)


fix #2750 