### PR TITLE
Create component for "gating" pages and wait until parameters finish loading

### DIFF
--- a/core/frontend/src/components/utils/ParameterLoadingSpinner.vue
+++ b/core/frontend/src/components/utils/ParameterLoadingSpinner.vue
@@ -1,0 +1,35 @@
+<template>
+  <spinning-logo
+    v-if="!params_finished_loaded"
+    size="20%"
+    :subtitle="`${loaded_params}/${total_params} parameters loaded`"
+  />
+  <div v-else>
+    <slot />
+  </div>
+</template>
+<script lang="ts">
+import Vue from 'vue'
+
+import SpinningLogo from '@/components/common/SpinningLogo.vue'
+import autopilot_data from '@/store/autopilot'
+
+export default Vue.extend({
+  name: 'ParameterLoadingSpinner',
+  components: {
+    SpinningLogo,
+  },
+
+  computed: {
+    params_finished_loaded(): boolean {
+      return autopilot_data.finished_loading
+    },
+    loaded_params(): number {
+      return autopilot_data.parameters_loaded
+    },
+    total_params(): number {
+      return autopilot_data.parameters_total
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/vehiclesetup/configuration/accelerometer/ArdupilotAccelerometerSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/accelerometer/ArdupilotAccelerometerSetup.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main-container">
-    <v-card v-if="params_finished_loaded" outline class="pa-2">
+    <v-card outline class="pa-2">
       <v-simple-table>
         <thead>
           <tr>
@@ -50,11 +50,6 @@
         <QuickAccelerometerCalibration />
       </v-card-actions>
     </v-card>
-    <spinning-logo
-      v-else
-      size="50%"
-      :subtitle="`${loaded_params}/${total_params} parameters loaded`"
-    />
   </div>
 </template>
 <script lang="ts">
@@ -80,15 +75,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    params_finished_loaded(): boolean {
-      return autopilot_data.finished_loading
-    },
-    loaded_params(): number {
-      return autopilot_data.parameters_loaded
-    },
-    total_params(): number {
-      return autopilot_data.parameters_total
-    },
     imus() : deviceId[] {
       return autopilot_data.parameterRegex('^INS_ACC.*_ID')
         .filter((param) => param.value !== 0)

--- a/core/frontend/src/components/vehiclesetup/configuration/compass/ArdupilotMavlinkCompassSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/ArdupilotMavlinkCompassSetup.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="pa-3">
-    <v-card v-if="params_finished_loaded">
+    <v-card>
       <div class="main-container d-flex flex-col">
         <v-card outline class="mr-2 mb-2 flex-shrink-1">
           <div class="compass-container">
@@ -192,7 +192,6 @@
         :param="edited_param"
       />
     </v-card>
-    <spinning-logo v-else size="50%" :subtitle="`${loaded_params}/${total_params} parameters loaded`" />
   </div>
 </template>
 <script lang="ts">
@@ -203,7 +202,6 @@ import {
 } from 'vuetify/lib'
 
 import ParameterSwitch from '@/components/common/ParameterSwitch.vue'
-import SpinningLogo from '@/components/common/SpinningLogo.vue'
 import CompassDisplay from '@/components/vehiclesetup/configuration/compass/CompassDisplay.vue'
 import CompassParams from '@/components/vehiclesetup/configuration/compass/CompassParams.vue'
 import mavlink2rest from '@/libs/MAVLink2Rest'
@@ -226,7 +224,6 @@ export default Vue.extend({
     VTextField,
     LargeVehicleCompassCalibrator,
     ParameterSwitch,
-    SpinningLogo,
     VCardText,
     VExpansionPanel,
     FullCompassCalibrator,
@@ -249,15 +246,6 @@ export default Vue.extend({
         results[compass.paramValue] = this.color_options[index % this.color_options.length]
       }
       return results
-    },
-    params_finished_loaded(): boolean {
-      return autopilot_data.finished_loading
-    },
-    loaded_params(): number {
-      return autopilot_data.parameters_loaded
-    },
-    total_params(): number {
-      return autopilot_data.parameters_total
     },
     compass_autodec(): Parameter | undefined {
       return autopilot_data.parameter('COMPASS_AUTODEC')

--- a/core/frontend/src/views/VehicleSetupView.vue
+++ b/core/frontend/src/views/VehicleSetupView.vue
@@ -20,9 +20,11 @@
         v-for="page in pages"
         :key="page.value"
       >
-        <pwm-setup v-if="page.value === 'pwm_outputs'" />
-        <setup-overview v-else-if="page.value === 'overview'" />
-        <configure v-else-if="page.value === 'configure'" />
+        <parameter-loading-spinner>
+          <pwm-setup v-if="page.value === 'pwm_outputs'" />
+          <setup-overview v-else-if="page.value === 'overview'" />
+          <configure v-else-if="page.value === 'configure'" />
+        </parameter-loading-spinner>
       </v-tab-item>
     </v-tabs-items>
   </v-container>
@@ -32,6 +34,7 @@
 import Vue from 'vue'
 
 import { fetchFirmwareVehicleType, fetchVehicleType } from '@/components/autopilot/AutopilotManagerUpdater'
+import ParameterLoadingSpinner from '@/components/utils/ParameterLoadingSpinner.vue'
 import Configure from '@/components/vehiclesetup/Configure.vue'
 import PwmSetup from '@/components/vehiclesetup/PwmSetup.vue'
 import setupOverview from '@/components/vehiclesetup/SetupOverview.vue'
@@ -49,6 +52,7 @@ export default Vue.extend({
     PwmSetup,
     setupOverview,
     Configure,
+    ParameterLoadingSpinner,
   },
   data() {
     return {


### PR DESCRIPTION
Also apply it to all of the vehicle-setup section, which makes everything smoother as the data doesn't get populated slowly, and removes duplicated code

we have to check how loading default parameters deal with it
