### PR TITLE
libs: common: streaming: Reduce default timeout in timeout streaming

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/streaming.py
+++ b/core/libs/commonwealth/commonwealth/utils/streaming.py
@@ -72,7 +72,7 @@ async def _fetch_stream(
         await queue.put((None, None))
 
 
-async def timeout_streamer(gen: AsyncGenerator[str | bytes, None], timeout: int = 30) -> AsyncGenerator[str, None]:
+async def timeout_streamer(gen: AsyncGenerator[str | bytes, None], timeout: int = 3) -> AsyncGenerator[str, None]:
     """
     Streamer wrapper for async generators and provide a consistent response format
     with error handling with additional timeout limit for each item iteration.


### PR DESCRIPTION
Reduce default timeout in streaming timeout to have better experience in places like log fetcher