### PR TITLE
core: start-blueos-core: Fix permission logic

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -90,8 +90,8 @@ fi
 # we need 777 in order for other users to be able to alter it
 find /var/logs/blueos -type d -exec chmod a+rw {} \;
 mkdir -p /usr/blueos/userdata/settings
-find /usr/blueos -type d -exec chmod a+rw {} \;
-find /usr/blueos -type f -exec chmod a+rw {} \;
+find /usr/blueos/userdata -type d -exec chmod a+rw {} \;
+find /usr/blueos/userdata -type f -exec chmod a+rw {} \;
 
 # These services have priority because they do the fundamental for the vehicle to work,
 # and by initializing them first we reduce the time users have to wait to control the vehicle.

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -86,8 +86,7 @@ else
     echo "Waring: Using dockers's resolv.conf, this may cause DNS issues if the host's network configuration changes."
 fi
 
-# fix permissions for logging folders:
-# we need 777 in order for other users to be able to alter it
+# Fix permissions for logging folders to allow other users to alter it
 find /var/logs/blueos -type d -exec chmod a+rw {} \;
 mkdir -p /usr/blueos/userdata/settings
 find /usr/blueos/userdata -type d -exec chmod a+rw {} \;


### PR DESCRIPTION
The previous code did not work since it was running with the extensions folder that can have a huge number of files
Not sure about the original work done in: #2322

Edit: Tested and fixed the problem of having extensions with more than 200k files