### PR TITLE
Revert "core: frontend: components: kraken: StoreExtensionCard: Add number of downloads"

### DIFF
--- a/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
@@ -43,17 +43,7 @@
             <div
               class="extension-name"
             >
-              {{ extension.name }}
-              <div
-                v-if="extension?.repo_info?.downloads"
-                class="opacity-10 text-subtitle-2"
-              >
-                {{ human_download_count }}
-
-                <v-icon size="x-large">
-                  mdi-download
-                </v-icon>
-              </div>
+              {{ extension.name.toUpperCase() }}
             </div>
             <div class="extension-description">
               {{ extension.description }}
@@ -105,7 +95,6 @@
 
 <script lang="ts">
 import ColorThief from 'colorthief'
-import numeral from 'numeral'
 import Vue, { PropType } from 'vue'
 
 import { getLatestVersion, isStable, updateAvailableTag } from '@/components/kraken/Utils'
@@ -142,24 +131,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    human_download_count(): string {
-      if (typeof this.extension.repo_info?.downloads !== 'number') {
-        return ''
-      }
-
-      const downloads = this.extension.repo_info?.downloads
-
-      if (downloads < 10) {
-        return downloads.toString()
-      }
-      if (downloads < 100) {
-        return `${Math.floor(downloads / 10) * 10}+`
-      }
-      if (downloads < 1000) {
-        return `${Math.floor(downloads / 100) * 100}+`
-      }
-      return numeral(downloads).format('0.0a').replace('.0', '')
-    },
     installed_extension(): InstalledExtensionData | undefined {
       return this.installed.find((installed) => installed.identifier === this.extension.identifier)
     },
@@ -432,10 +403,11 @@ export default Vue.extend({
   font-weight: bold;
   font-size: 18px;
   max-height: 1.4em;
-  justify-content: space-between;
-  display: flex;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
   -webkit-line-clamp: 1;
-  -webkit-box-orient: horizontal;
+  -webkit-box-orient: vertical;
 }
 
 .extension-description {


### PR DESCRIPTION
Context from internal discussion:
* "Download" numbers seemed inflated and unreasonable
    ![image](https://github.com/bluerobotics/BlueOS/assets/25898329/45789407-7135-4f82-ab9a-910b4248ab20)
* Apparently [docker pulls is for manifest pulls, not image downloads](https://github.com/docker/hub-feedback/issues/1047#issuecomment-687965123)
    * Even that [may be inflated](https://github.com/docker/hub-feedback/issues/2182)
* If you become a [verified publisher](https://www.docker.com/partners/programs/) they give you more useful market insights / statistics (but we can't expect that from every Extension owner)