### PR TITLE
frontend: pass urls through to filebrowser

### DIFF
--- a/core/frontend/src/router/index.ts
+++ b/core/frontend/src/router/index.ts
@@ -54,7 +54,7 @@ const routes: Array<RouteConfig> = [
     component: defineAsyncComponent(() => import('../views/EndpointView.vue')),
   },
   {
-    path: '/tools/file-browser',
+    path: '/tools/file-browser/:path*',
     name: 'File Browser',
     component: defineAsyncComponent(() => import('../views/FileBrowserView.vue')),
   },

--- a/core/frontend/src/views/FileBrowserView.vue
+++ b/core/frontend/src/views/FileBrowserView.vue
@@ -1,6 +1,6 @@
 <template>
   <BrIframe
-    :source="service_path"
+    :source="full_path"
   />
 </template>
 
@@ -18,6 +18,11 @@ export default Vue.extend({
     return {
       service_path: '/file-browser/',
     }
+  },
+  computed: {
+    full_path() {
+      return `${this.service_path}${this.$route.params.path ?? ''}`
+    },
   },
 })
 </script>


### PR DESCRIPTION
This passes urls through to filebrowser, so we can link folders to users without using the hard-coded ports.

something like http://blueos.local/tools/file-browser/files/configs/