### PR TITLE
Improve remote access support

### DIFF
--- a/core/frontend/src/menus.ts
+++ b/core/frontend/src/menus.ts
@@ -137,6 +137,7 @@ export interface menuItem {
   new_page?: string, // The address will open in a new page
   route?: string, // The option routes to a different address
   submenus?: menuItem[], // Menus that the main option provide
+  disabled?: boolean, // The option is disabled
 }
 
 export default menus

--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -11,6 +11,7 @@ export interface ServiceMetadata {
     sanitized_name?: string
     extra_query?: string
     avoid_iframes?: boolean
+    works_in_relative_paths?: boolean
 }
 
 export interface Service {

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -95,6 +95,9 @@ export default defineConfig(({ command, mode }) => {
         '^/docker': {
           target: SERVER_ADDRESS,
         },
+        '^/extensionv2': {
+          target: SERVER_ADDRESS,
+        },
         '^/file-browser': {
           target: SERVER_ADDRESS,
         },

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -105,6 +105,7 @@ class ServiceMetadata(BaseModel):
     avoid_iframes: Optional[bool]
     api: str
     sanitized_name: Optional[str]
+    works_in_relative_paths: Optional[bool]
 
 
 class ServiceInfo(BaseModel):

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -101,7 +101,7 @@ find /usr/blueos/userdata -type f -exec chmod a+rw {} \;
 PRIORITY_SERVICES=(
     'autopilot',0,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
     'cable_guy',0,"$SERVICES_PATH/cable_guy/main.py"
-    'video',0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
+    'video',0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --stun-server stun://stun.l.google.com:19302 --verbose"
     'mavlink2rest',0,"mavlink2rest --connect=udpout:127.0.0.1:14001 --server [::]:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -152,6 +152,20 @@ http {
             proxy_set_header Connection "Upgrade";
         }
 
+        location /webrtc/ws {
+            # Hide the header from the upstream application
+            proxy_hide_header Access-Control-Allow-Origin;
+
+            include cors.conf;
+            rewrite ^/webrtc$ /webrtc/ redirect;
+            rewrite ^/webrtc/(.*)$ /$1 break;
+            proxy_pass http://127.0.0.1:6021;
+            proxy_http_version 1.1;
+            # next two lines are required for websockets
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+        }
+
         location /mavlink-camera-manager {
             include cors.conf;
             rewrite ^/mavlink-camera-manager$ /mavlink-camera-manager/ redirect;

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -262,5 +262,6 @@ http {
         location ~ ^/redirect-port/(?<port>\d+) {
             return 301 $scheme://$host:$port;
         }
+        include /home/pi/tools/nginx/extensions/*.conf;
     }
 }

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -55,82 +55,71 @@ http {
 
         location /ardupilot-manager {
             include cors.conf;
-            rewrite ^/ardupilot-manager$ /ardupilot-manager/ redirect;
-            rewrite ^/ardupilot-manager/(.*)$ /$1 break;
-            proxy_pass http://localhost:8000;
+            rewrite ^/ardupilot-manager(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:8000;
         }
 
         location /bag {
             include cors.conf;
-            rewrite ^/bag$ /bag/ redirect;
-            rewrite ^/bag/(.*)$ /$1 break;
-            proxy_pass http://localhost:9101;
+            rewrite ^/bag(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9101;
         }
 
         location /beacon {
             include cors.conf;
-            rewrite ^/beacon$ /beacon/ redirect;
-            rewrite ^/beacon/(.*)$ /$1 break;
-            proxy_pass http://localhost:9111;
+            rewrite ^/beacon(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9111;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Interface-Ip $server_addr;
         }
 
         location /bridget {
             include cors.conf;
-            rewrite ^/bridget$ /bridget/ redirect;
-            rewrite ^/bridget/(.*)$ /$1 break;
-            proxy_pass http://localhost:27353;
+            rewrite ^/bridget(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:27353;
         }
 
         location /cable-guy {
             include cors.conf;
-            rewrite ^/cable-guy$ /cable-guy/ redirect;
-            rewrite ^/cable-guy/(.*)$ /$1 break;
-            proxy_pass http://localhost:9090;
+            rewrite ^/cable-guy(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9090;
         }
 
         location /commander {
             include cors.conf;
-            rewrite ^/commander$ /commander/ redirect;
-            rewrite ^/commander/(.*)$ /$1 break;
-            proxy_pass http://localhost:9100;
+            rewrite ^/commander(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9100;
         }
 
         location /docker {
             limit_except GET {
                 deny all;
             }
-            rewrite ^/docker$ /docker/ redirect;
-            rewrite ^/docker/(.*)$ /$1 break;
+            rewrite ^/docker(/|$)(.*)$ /$2 break;
             proxy_pass http://unix:/var/run/docker.sock:/;
         }
 
         location /file-browser {
-            rewrite ^/file-browser$ /file-browser/ redirect;
-            rewrite ^/file-browser/(.*)$ /$1 break;
-            proxy_pass http://localhost:7777;
+            rewrite ^/file-browser(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:7777;
         }
 
         location /helper {
             include cors.conf;
-            rewrite ^/helper$ /helper/ redirect;
-            rewrite ^/helper/(.*)$ /$1 break;
-            proxy_pass http://localhost:81;
+            rewrite ^/helper(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:81;
         }
 
         location /kraken {
             include cors.conf;
-            rewrite ^/kraken$ /kraken/ redirect;
-            rewrite ^/kraken/(.*)$ /$1 break;
-            proxy_pass http://localhost:9134;
+            rewrite ^/kraken(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9134;
         }
 
         location /nmea-injector {
             include cors.conf;
-            rewrite ^/nmea-injector$ /nmea-injector/ redirect;
-            rewrite ^/nmea-injector/(.*)$ /$1 break;
-            proxy_pass http://localhost:2748;
+            rewrite ^/nmea-injector(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:2748;
         }
 
         location ^~ /logviewer {
@@ -144,9 +133,8 @@ http {
             proxy_hide_header Access-Control-Allow-Origin;
 
             include cors.conf;
-            rewrite ^/mavlink2rest$ /mavlink2rest/ redirect;
-            rewrite ^/mavlink2rest/(.*)$ /$1 break;
-            proxy_pass http://localhost:6040;
+            rewrite ^/mavlink2rest(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:6040;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
@@ -157,8 +145,7 @@ http {
             proxy_hide_header Access-Control-Allow-Origin;
 
             include cors.conf;
-            rewrite ^/webrtc$ /webrtc/ redirect;
-            rewrite ^/webrtc/(.*)$ /$1 break;
+            rewrite ^//webrtc/ws(/|$)(.*)$ /$2 break;
             proxy_pass http://127.0.0.1:6021;
             proxy_http_version 1.1;
             # next two lines are required for websockets
@@ -168,16 +155,14 @@ http {
 
         location /mavlink-camera-manager {
             include cors.conf;
-            rewrite ^/mavlink-camera-manager$ /mavlink-camera-manager/ redirect;
-            rewrite ^/mavlink-camera-manager/(.*)$ /$1 break;
-            proxy_pass http://localhost:6020;
+            rewrite ^/mavlink-camera-manager(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:6020;
         }
 
         location /network-test {
             include cors.conf;
-            rewrite ^/network-test$ /network-test/ redirect;
-            rewrite ^/network-test/(.*)$ /$1 break;
-            proxy_pass http://localhost:9120;
+            rewrite ^/network-test(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9120;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
@@ -185,18 +170,16 @@ http {
 
         location /system-information {
             include cors.conf;
-            rewrite ^/system-information$ /system-information/ redirect;
-            rewrite ^/system-information/(.*)$ /$1 break;
-            proxy_pass http://localhost:6030;
+            rewrite ^/system-information(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:6030;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
         }
 
         location /terminal {
-            rewrite ^/terminal$ /terminal/ redirect;
-            rewrite ^/terminal/(.*)$ /$1 break;
-            proxy_pass http://localhost:8088;
+            rewrite ^/terminal(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:8088;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
@@ -204,9 +187,8 @@ http {
 
         location /version-chooser {
             include cors.conf;
-            rewrite ^/version-chooser$ /version-chooser/ redirect;
-            rewrite ^/version-chooser/(.*)$ /$1 break;
-            proxy_pass http://localhost:8081;
+            rewrite ^/version-chooser(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:8081;
             proxy_buffering off;
             expires -1;
             add_header Cache-Control no-store;
@@ -214,16 +196,14 @@ http {
 
         location /wifi-manager {
             include cors.conf;
-            rewrite ^/wifi-manager$ /wifi-manager/ redirect;
-            rewrite ^/wifi-manager/(.*)$ /$1 break;
-            proxy_pass http://localhost:9000;
+            rewrite ^/wifi-manager(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9000;
         }
 
         location /ping {
             include cors.conf;
-            rewrite ^/ping$ /ping/ redirect;
-            rewrite ^/ping/(.*)$ /$1 break;
-            proxy_pass http://localhost:9110;
+            rewrite ^/ping(/|$)(.*)$ /$2 break;
+            proxy_pass http://127.0.0.1:9110;
         }
 
         location / {


### PR DESCRIPTION
reviving #1842 as a fallback for remote control

This introduces a new optional `works_in_relative_paths`  to the services metadata.
These will use a relative path (under `/extensionv2/`) to load the extension in the browser.
This allows them to be used seamlessly behind a webserver with ssl.