### PR TITLE
Frontend: ExtManagerView: Fix passing a reference of installed extension to edit extension card

### DIFF
--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -331,7 +331,7 @@ export default Vue.extend({
       this.edited_extension = null
     },
     openEditDialog(extension: InstalledExtensionData): void {
-      this.edited_extension = extension
+      this.edited_extension = { ...extension }
     },
     openCreationDialog() : void {
       this.edited_extension = {


### PR DESCRIPTION
This fix cases where user edits the tag and the installed extension card changes instantaneously without create being pressed 