### PR TITLE
frontend: Change Create/Edit extension card top differ from Create and Editing operations

### DIFF
--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -225,7 +225,7 @@ export default Vue.extend({
       show_log: false,
       metrics: {} as Dictionary<{ cpu: number, memory: number}>,
       metrics_interval: 0,
-      edited_extension: null as null | InstalledExtensionData,
+      edited_extension: null as null | InstalledExtensionData & { editing: boolean },
       fetch_installed_ext_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
       fetch_running_containers_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
       fetch_containers_stats_task: new OneMoreTime({ delay: 25000, disposeWith: this }),
@@ -331,7 +331,7 @@ export default Vue.extend({
       this.edited_extension = null
     },
     openEditDialog(extension: InstalledExtensionData): void {
-      this.edited_extension = { ...extension }
+      this.edited_extension = { ...extension, editing: true }
     },
     openCreationDialog() : void {
       this.edited_extension = {
@@ -341,7 +341,8 @@ export default Vue.extend({
         enabled: true,
         tag: '',
         permissions: '{}',
-        user_permissions: '{}',
+        user_permissions: '',
+        editing: false,
       }
     },
     getContainer(extension: InstalledExtensionData): RunningContainer | undefined {


### PR DESCRIPTION
When editing:
![image](https://github.com/user-attachments/assets/cdebab36-b58c-411a-8c48-7b8411541ddc)

When creating:
![image](https://github.com/user-attachments/assets/3952e9e9-1826-4488-9c07-4827f230aa51)

Also allow custom permissions to be either empty or valid json, since sometimes when user does not wants to use custom permissions they can only send empty
