### PR TITLE
frontend: index.html: add meta tags and headers  to avoid caching index.html

### DIFF
--- a/core/frontend/index.html
+++ b/core/frontend/index.html
@@ -7,6 +7,10 @@
     <link rel="icon" href="/favicon.ico">
     <title>BlueOS</title>
     <link rel="stylesheet" href="/userdata/styles/theme_style.css">
+    <!-- Prevent caching -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
   </head>
   <body>
     <noscript>

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -216,6 +216,12 @@ http {
             autoindex on;
             # allow frontend to see files using json
             autoindex_format json;
+
+            # prevent caching of index.html
+            if ($uri = /index.html) {
+                add_header Last-Modified "";
+                add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            }
         }
 
         location /assets/ {


### PR DESCRIPTION
This should fix some weird caching issues when we switch versions, which required forcing refreshes