### PR TITLE
Fix Endpoint comparison, always overwrite mavlink2rest one

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -360,6 +360,7 @@ class ArduPilotManager(metaclass=Singleton):
                 argument=14000,
                 persistent=True,
                 protected=True,
+                overwrite_settings=True,
             ),
             Endpoint(
                 name="Internal Link",

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -67,7 +67,7 @@ class Endpoint:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):
             raise NotImplementedError
-        return str(self) == str(other)
+        return str(self) == str(other) and self.connection_type == other.connection_type and self.place == other.place
 
 
 VALID_SERIAL_BAUDRATES = [


### PR DESCRIPTION
fix #2874 