### PR TITLE
Add new entry for mavlink2rest in default ArdupilotManager endpoints

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -353,6 +353,15 @@ class ArduPilotManager(metaclass=Singleton):
                 enabled=True,
             ),
             Endpoint(
+                name="MAVLink2RestServer",
+                owner=self.settings.app_name,
+                connection_type=EndpointType.UDPServer,
+                place="127.0.0.1",
+                argument=14001,
+                persistent=True,
+                protected=True,
+            ),
+            Endpoint(
                 name="MAVLink2Rest",
                 owner=self.settings.app_name,
                 connection_type=EndpointType.UDPClient,

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -355,7 +355,7 @@ class ArduPilotManager(metaclass=Singleton):
             Endpoint(
                 name="MAVLink2Rest",
                 owner=self.settings.app_name,
-                connection_type=EndpointType.UDPServer,
+                connection_type=EndpointType.UDPClient,
                 place="127.0.0.1",
                 argument=14000,
                 persistent=True,

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -102,7 +102,7 @@ PRIORITY_SERVICES=(
     'autopilot',0,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
     'cable_guy',0,"$SERVICES_PATH/cable_guy/main.py"
     'video',0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
-    'mavlink2rest',0,"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
+    'mavlink2rest',0,"mavlink2rest --connect=udpout:127.0.0.1:14001 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 
 SERVICES=(

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -102,7 +102,7 @@ PRIORITY_SERVICES=(
     'autopilot',0,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
     'cable_guy',0,"$SERVICES_PATH/cable_guy/main.py"
     'video',0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --verbose"
-    'mavlink2rest',0,"mavlink2rest --connect=udpout:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
+    'mavlink2rest',0,"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 
 SERVICES=(


### PR DESCRIPTION
Revert changes made da3f785 since we  need to make sure we have backward compatibility with settings.json when migrating from newer versions to older ones and reapply them but using a new endpoint instead of modifying exiting one.