### PR TITLE
Handle (for now) unsupported hotspot functionality in bookworm

### DIFF
--- a/core/frontend/src/components/wifi/WifiManager.vue
+++ b/core/frontend/src/components/wifi/WifiManager.vue
@@ -16,6 +16,7 @@
         :color="hotspot_status ? 'success' : 'gray'"
         hide-details="auto"
         :loading="hotspot_status_loading"
+        :disabled="hotspot_supported === false"
         @click="toggleHotspot"
       >
         <v-icon>{{ hotspot_status ? 'mdi-access-point' : 'mdi-access-point-off' }}</v-icon>
@@ -201,7 +202,10 @@ export default Vue.extend({
       )
     },
     hotspot_status(): boolean | null {
-      return wifi.hotspot_status
+      return wifi.hotspot_status?.enabled ?? null
+    },
+    hotspot_supported(): boolean | null {
+      return wifi.hotspot_status?.supported ?? null
     },
     show_search(): boolean {
       if (!this.connectable_networks) {

--- a/core/frontend/src/components/wifi/WifiUpdater.vue
+++ b/core/frontend/src/components/wifi/WifiUpdater.vue
@@ -69,7 +69,7 @@ export default Vue.extend({
     async fetchHotspotStatus(): Promise<void> {
       await back_axios({
         method: 'get',
-        url: `${wifi.API_URL}/hotspot`,
+        url: `${wifi.API_URL}/hotspot_extended_status`,
         timeout: 10000,
       })
         .then((response) => {

--- a/core/frontend/src/store/wifi.ts
+++ b/core/frontend/src/store/wifi.ts
@@ -4,7 +4,7 @@ import {
 
 import store from '@/store'
 import {
-  Network, NetworkCredentials, SavedNetwork, WifiStatus,
+  Network, NetworkCredentials, SavedNetwork, WifiStatus, HotspotStatus
 } from '@/types/wifi'
 import { sorted_networks } from '@/utils/wifi'
 
@@ -25,7 +25,7 @@ class WifiStore extends VuexModule {
 
   network_status: WifiStatus | null = null
 
-  hotspot_status: boolean | null = null
+  hotspot_status: HotspotStatus | null = null
 
   smart_hotspot_status: boolean | null = null
 
@@ -71,7 +71,7 @@ class WifiStore extends VuexModule {
   }
 
   @Mutation
-  setHotspotStatus(status: boolean | null): void {
+  setHotspotStatus(status: HotspotStatus | null): void {
     this.hotspot_status = status
   }
 

--- a/core/frontend/src/types/wifi.ts
+++ b/core/frontend/src/types/wifi.ts
@@ -7,6 +7,11 @@ export interface Network {
     frequency: number
 }
 
+export interface HotspotStatus {
+    enabled: boolean
+    supported: boolean
+  }
+
 export interface WifiStatus {
     bssid: string
     freq: number

--- a/core/services/wifi/Hotspot.py
+++ b/core/services/wifi/Hotspot.py
@@ -44,7 +44,7 @@ class HotspotManager:
         self.ipr = IPRoute()
 
         self._ap_interface_name = ap_interface_name
-        self._supports_hotspot = self.check_hotspot_support()
+        self.supports_hotspot = self.check_hotspot_support()
         try:
             dev_id = device_id()
         except Exception:
@@ -165,7 +165,7 @@ class HotspotManager:
 
     def start(self) -> None:
         logger.info("Starting hotspot.")
-        if not self._supports_hotspot:
+        if not self.supports_hotspot:
             raise RuntimeError("Hotspot not supported on this device.")
         try:
             self._create_temp_config_file()
@@ -201,7 +201,7 @@ class HotspotManager:
         self.start()
 
     def is_running(self) -> bool:
-        if not self._supports_hotspot:
+        if not self.supports_hotspot:
             return False
         return self._subprocess is not None and self._subprocess.poll() is None
 
@@ -245,7 +245,7 @@ class HotspotManager:
             f.write(self.hostapd_config())
 
     def _include_interface_on_dhcpcd(self) -> None:
-        if not self._supports_hotspot:
+        if not self.supports_hotspot:
             return
         with open("/etc/dhcpcd.conf", "r", encoding="utf-8") as f:
             original_lines = f.readlines()

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -23,7 +23,12 @@ from tabulate import tabulate
 from uvicorn import Config, Server
 
 from exceptions import BusyError
-from typedefs import SavedWifiNetwork, ScannedWifiNetwork, WifiCredentials
+from typedefs import (
+    HotspotStatus,
+    SavedWifiNetwork,
+    ScannedWifiNetwork,
+    WifiCredentials,
+)
 from WifiManager import WifiManager
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
@@ -169,6 +174,12 @@ async def disconnect() -> Any:
 @version(1, 0)
 def hotspot_state() -> Any:
     return wifi_manager.hotspot.is_running()
+
+
+@app.get("/hotspot_extended_status", summary="Get extended hotspot status.")
+@version(1, 0)
+def hotspot_extended_state() -> HotspotStatus:
+    return HotspotStatus(supported=wifi_manager.hotspot.supports_hotspot, enabled=wifi_manager.hotspot.is_running())
 
 
 @app.post("/hotspot", summary="Enable/disable hotspot.")

--- a/core/services/wifi/typedefs.py
+++ b/core/services/wifi/typedefs.py
@@ -4,6 +4,11 @@ from typing import Optional
 from pydantic import BaseModel
 
 
+class HotspotStatus(BaseModel):
+    supported: bool
+    enabled: bool
+
+
 class ScannedWifiNetwork(BaseModel):
     ssid: Optional[str]
     bssid: str


### PR DESCRIPTION
This greys out the hotspot buttons and prevents the backend from trying to enable it if the underlying OS is not supported

~needs testing~ tested on pi4/bookworm