### PR TITLE
ArdupilotManager: generate serial command line options in ardupilotmanager instead of boards

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -169,6 +169,9 @@ class ArduPilotManager(metaclass=Singleton):
                 logger.error(e)
         return serials
 
+    def get_serial_cmdline(self) -> str:
+        return " ".join([f"-{entry.port} {entry.endpoint}" for entry in self.get_serials()])
+
     def get_default_params_cmdline(self, platform: Platform) -> str:
         # check if file exists and return it's path as --defaults parameter
         default_params_path = self.firmware_manager.default_user_params_path(platform)
@@ -222,7 +225,7 @@ class ArduPilotManager(metaclass=Singleton):
             f" -A udp:{master_endpoint.place}:{master_endpoint.argument}"
             f" --log-directory {self.settings.firmware_folder}/logs/"
             f" --storage-directory {self.settings.firmware_folder}/storage/"
-            f" {self._current_board.get_serial_cmdlines()}"
+            f" {self.get_serial_cmdline()}"
             f" {self.get_default_params_cmdline(board.platform)}"
         )
 

--- a/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
@@ -15,10 +15,6 @@ class LinuxFlightController(FlightController):
     def detect(self) -> bool:
         raise NotImplementedError
 
-    def get_serial_cmdlines(self) -> str:
-        cmdlines = [f"-{entry.port} {entry.endpoint}" for entry in self.get_serials()]
-        return " ".join(cmdlines)
-
     def get_serials(self) -> List[Serial]:
         raise NotImplementedError
 


### PR DESCRIPTION

This fixes an issue where the serial port mapping in ArdupilotManager is not being used, instead it always uses the board's default definition