### PR TITLE
Frontend: Autopilot: add missing NotSafeOverlay import

### DIFF
--- a/core/frontend/src/views/Autopilot.vue
+++ b/core/frontend/src/views/Autopilot.vue
@@ -112,6 +112,7 @@ import {
 import AutopilotSerialConfiguration from '@/components/autopilot/AutopilotSerialConfiguration.vue'
 import BoardChangeDialog from '@/components/autopilot/BoardChangeDialog.vue'
 import FirmwareManager from '@/components/autopilot/FirmwareManager.vue'
+import NotSafeOverlay from '@/components/common/NotSafeOverlay.vue'
 import { MavAutopilot } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
 import Notifier from '@/libs/notifier'
 import settings from '@/libs/settings'


### PR DESCRIPTION
trying to understand how ci allowed this through...