### PR TITLE
Fix service links when using IPv6 addresses

### DIFF
--- a/core/frontend/src/components/scanner/availableServicesTable.vue
+++ b/core/frontend/src/components/scanner/availableServicesTable.vue
@@ -96,9 +96,7 @@ export default Vue.extend({
      * e.g. http://[currenthost]:[newport]/[newpath]
      */
     createWebpageUrl(port: number, path = ''): string {
-      return `${window.location.protocol}//${
-        window.location.host.split(':')[0]
-      }:${port}${path}`
+      return `${window.location.protocol}//${window.location.hostname}:${port}${path}`
     },
   },
 })


### PR DESCRIPTION
Previously, the hostname would get truncated at the first colon.