### PR TITLE
Cable-guy: DHCP servers with unspecified lease ranges now serve 101-200

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
+++ b/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
@@ -34,7 +34,7 @@ class Dnsmasq:
 
         if ipv4_lease_range is None:
             # If no lease-range is defined we offer all available IPs for lease
-            ipv4_lease_range = (list(self.ipv4_network.hosts())[0], list(self.ipv4_network.hosts())[-1])
+            ipv4_lease_range = (list(self.ipv4_network.hosts())[100], list(self.ipv4_network.hosts())[199])
         self._ipv4_lease_range = ipv4_lease_range
 
         self._lease_time = lease_time


### PR DESCRIPTION
This just changes things so that we don't serve the whole range while we don't have a proper configuration interface for the dhcp servers