### PR TITLE
Nginx: use prefixes instead of regexes

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -485,9 +485,8 @@ class Helper:
     def setup_nginx_route(metadata: ServiceMetadata, port: int) -> bool:
         name = metadata.sanitized_name
         text = f"""
-        location /extensionv2/{name} {{
-        rewrite ^/extensionv2/{name}(/|$)(.*)$ /$2 break;
-        proxy_pass http://localhost:{port};
+        location /extensionv2/{name}/ {{
+        proxy_pass :{port}/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/core/services/helper/nginx_parser.py
+++ b/core/services/helper/nginx_parser.py
@@ -8,7 +8,7 @@ def parse_nginx_file(filepath: str) -> dict[int, str]:
         location_block_pattern = re.compile(r"location\s+(?P<location>/[\w-]+)\s*{(?P<block_content>[^}]+)}", re.DOTALL)
 
         # Pattern for extracting proxy_pass directive
-        proxy_pass_pattern = re.compile(r"proxy_pass\s+http://[^:]+:(?P<port>\d+);")
+        proxy_pass_pattern = re.compile(r"proxy_pass\s.*:(?P<port>\d+).*;")
         location_blocks = location_block_pattern.finditer(content)
         result = {}
         for match in location_blocks:

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -49,161 +49,141 @@ http {
 
         # Endpoint used for backend status checks.
         # It will always return an empty 204 response when online.
-        location /status {
+        location = /status {
             return 204;
         }
 
-        location /ardupilot-manager {
+        location /ardupilot-manager/ {
             include cors.conf;
-            rewrite ^/ardupilot-manager(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:8000;
+            proxy_pass :8000/;
         }
 
-        location /bag {
+        location /bag/ {
             include cors.conf;
-            rewrite ^/bag(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9101;
+            proxy_pass :9101/;
         }
 
-        location /beacon {
+        location /beacon/ {
             include cors.conf;
-            rewrite ^/beacon(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9111;
+            proxy_pass :9111/;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Interface-Ip $server_addr;
         }
 
-        location /bridget {
+        location /bridget/ {
             include cors.conf;
-            rewrite ^/bridget(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:27353;
+            proxy_pass :27353/;
         }
 
-        location /cable-guy {
+        location /cable-guy/ {
             include cors.conf;
-            rewrite ^/cable-guy(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9090;
+            proxy_pass :9090/;
         }
 
-        location /commander {
+        location /commander/ {
             include cors.conf;
-            rewrite ^/commander(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9100;
+            proxy_pass :9100/;
         }
 
-        location /docker {
+        location /docker/ {
             limit_except GET {
                 deny all;
             }
-            rewrite ^/docker(/|$)(.*)$ /$2 break;
             proxy_pass http://unix:/var/run/docker.sock:/;
         }
 
-        location /file-browser {
-            rewrite ^/file-browser(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:7777;
+        location /file-browser/ {
+            proxy_pass :7777/;
         }
 
-        location /helper {
+        location /helper/ {
             include cors.conf;
-            rewrite ^/helper(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:81;
+            proxy_pass :81/;
         }
 
-        location /kraken {
+        location /kraken/ {
             include cors.conf;
-            rewrite ^/kraken(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9134;
+            proxy_pass :9134/;
         }
 
-        location /nmea-injector {
+        location /nmea-injector/ {
             include cors.conf;
-            rewrite ^/nmea-injector(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:2748;
+            proxy_pass :2748/;
         }
 
-        location ^~ /logviewer {
+        location ^~ /logviewer/ {
             # ^~ makes this a higher priority than locations with regex
             expires 10d;
             root /var/www/html;
         }
 
-        location /mavlink2rest {
+        location /mavlink2rest/ {
             # Hide the header from the upstream application
             proxy_hide_header Access-Control-Allow-Origin;
 
             include cors.conf;
-            rewrite ^/mavlink2rest(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:6040;
+            proxy_pass :6040/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
         }
 
-        location /webrtc/ws {
+        location /webrtc/ws/ {
             # Hide the header from the upstream application
             proxy_hide_header Access-Control-Allow-Origin;
 
             include cors.conf;
-            rewrite ^//webrtc/ws(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:6021;
+            proxy_pass :6021/;
             proxy_http_version 1.1;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
         }
 
-        location /mavlink-camera-manager {
+        location /mavlink-camera-manager/ {
             include cors.conf;
-            rewrite ^/mavlink-camera-manager(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:6020;
+            proxy_pass :6020/;
         }
 
-        location /network-test {
+        location /network-test/ {
             include cors.conf;
-            rewrite ^/network-test(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9120;
+            proxy_pass :9120/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
         }
 
-        location /system-information {
+        location /system-information/ {
             include cors.conf;
-            rewrite ^/system-information(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:6030;
+            proxy_pass :6030/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
         }
 
-        location /terminal {
-            rewrite ^/terminal(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:8088;
+        location /terminal/ {
+            proxy_pass :8088/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
         }
 
-        location /version-chooser {
+        location /version-chooser/ {
             include cors.conf;
-            rewrite ^/version-chooser(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:8081;
+            proxy_pass :8081/;
             proxy_buffering off;
             expires -1;
             add_header Cache-Control no-store;
         }
 
-        location /wifi-manager {
+        location /wifi-manager/ {
             include cors.conf;
-            rewrite ^/wifi-manager(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9000;
+            proxy_pass :9000/;
         }
 
-        location /ping {
+        location /ping/ {
             include cors.conf;
-            rewrite ^/ping(/|$)(.*)$ /$2 break;
-            proxy_pass http://127.0.0.1:9110;
+            proxy_pass :9110/;
         }
 
         location / {
@@ -227,9 +207,9 @@ http {
             add_header Cache-Control "public, max-age=604800";
         }
 
-        location ~ ^/upload(/.*)$ {
+        location /upload/ {
             client_max_body_size 100M;
-            alias /usr/blueos$1;
+            alias /usr/blueos/;
 
             # Change the access permissions of the uploaded file
             dav_access group:rw all:r;
@@ -239,7 +219,7 @@ http {
             dav_methods PUT DELETE MKCOL COPY MOVE;
         }
 
-        location /userdata {
+        location /userdata/ {
             root /usr/blueos;
             autoindex on;
             # use json as it is easily consumed by the frontend


### PR DESCRIPTION
Nginx supports full regex-based rules, but we don't actually need them

1. Switch to prefix-based locations, which are easier to understand and gets rid of unnecessary rewrite rules.
2. This has the effect of also allowing the server to rewrite "Location" and "Refresh" headers, which would otherwise require manually using `proxy_redirect`.
3. This avoids hardcoding the protocol and IP address (which make troubleshooting network issues very confusing!)