### PR TITLE
Fix nginx.conf syntax that I broke

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -55,34 +55,34 @@ http {
 
         location /ardupilot-manager/ {
             include cors.conf;
-            proxy_pass :8000/;
+            proxy_pass http://127.0.0.1:8000/;
         }
 
         location /bag/ {
             include cors.conf;
-            proxy_pass :9101/;
+            proxy_pass http://127.0.0.1:9101/;
         }
 
         location /beacon/ {
             include cors.conf;
-            proxy_pass :9111/;
+            proxy_pass http://127.0.0.1:9111/;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Interface-Ip $server_addr;
         }
 
         location /bridget/ {
             include cors.conf;
-            proxy_pass :27353/;
+            proxy_pass http://127.0.0.1:27353/;
         }
 
         location /cable-guy/ {
             include cors.conf;
-            proxy_pass :9090/;
+            proxy_pass http://127.0.0.1:9090/;
         }
 
         location /commander/ {
             include cors.conf;
-            proxy_pass :9100/;
+            proxy_pass http://127.0.0.1:9100/;
         }
 
         location /docker/ {
@@ -93,22 +93,22 @@ http {
         }
 
         location /file-browser/ {
-            proxy_pass :7777/;
+            proxy_pass http://127.0.0.1:7777/;
         }
 
         location /helper/ {
             include cors.conf;
-            proxy_pass :81/;
+            proxy_pass http://127.0.0.1:81/;
         }
 
         location /kraken/ {
             include cors.conf;
-            proxy_pass :9134/;
+            proxy_pass http://127.0.0.1:9134/;
         }
 
         location /nmea-injector/ {
             include cors.conf;
-            proxy_pass :2748/;
+            proxy_pass http://127.0.0.1:2748/;
         }
 
         location ^~ /logviewer/ {
@@ -122,7 +122,7 @@ http {
             proxy_hide_header Access-Control-Allow-Origin;
 
             include cors.conf;
-            proxy_pass :6040/;
+            proxy_pass http://127.0.0.1:6040/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
@@ -133,7 +133,7 @@ http {
             proxy_hide_header Access-Control-Allow-Origin;
 
             include cors.conf;
-            proxy_pass :6021/;
+            proxy_pass http://127.0.0.1:6021/;
             proxy_http_version 1.1;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
@@ -142,12 +142,12 @@ http {
 
         location /mavlink-camera-manager/ {
             include cors.conf;
-            proxy_pass :6020/;
+            proxy_pass http://127.0.0.1:6020/;
         }
 
         location /network-test/ {
             include cors.conf;
-            proxy_pass :9120/;
+            proxy_pass http://127.0.0.1:9120/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
@@ -155,14 +155,14 @@ http {
 
         location /system-information/ {
             include cors.conf;
-            proxy_pass :6030/;
+            proxy_pass http://127.0.0.1:6030/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
         }
 
         location /terminal/ {
-            proxy_pass :8088/;
+            proxy_pass http://127.0.0.1:8088/;
             # next two lines are required for websockets
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
@@ -170,7 +170,7 @@ http {
 
         location /version-chooser/ {
             include cors.conf;
-            proxy_pass :8081/;
+            proxy_pass http://127.0.0.1:8081/;
             proxy_buffering off;
             expires -1;
             add_header Cache-Control no-store;
@@ -178,12 +178,12 @@ http {
 
         location /wifi-manager/ {
             include cors.conf;
-            proxy_pass :9000/;
+            proxy_pass http://127.0.0.1:9000/;
         }
 
         location /ping/ {
             include cors.conf;
-            proxy_pass :9110/;
+            proxy_pass http://127.0.0.1:9110/;
         }
 
         location / {


### PR DESCRIPTION
Undo my introduction of invalid syntax in #2913, which breaks blueos.

It turns out that you can't start a URL with a leading colon. The only reason I thought it gave the same results is because `service nginx reload` bailed when loading the new config, but left the server running with the same state.