### PR TITLE
Fix wifi not getting an ip address on bookworm

### DIFF
--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -48,7 +48,7 @@ class WifiManager:
             )
             if ssid is not None and password is not None:
                 self.set_hotspot_credentials(WifiCredentials(ssid=ssid, password=password))
-            if self._settings_manager.settings.hotspot_enabled in [True, None]:
+            if self.hotspot.supports_hotspot and self._settings_manager.settings.hotspot_enabled in [True, None]:
                 time.sleep(5)
                 self.enable_hotspot()
         except Exception:
@@ -381,6 +381,9 @@ class WifiManager:
 
     async def start_hotspot_watchdog(self) -> None:
         logger.debug("Starting hotspot watchdog.")
+        if not self.hotspot.supports_hotspot:
+            logger.debug("Hotspot is not supported. Stopping watchdog.")
+            return
         while True:
             await asyncio.sleep(30)
             try:

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -17,5 +17,5 @@ parallel --halt now,fail=1 '/home/pi/tools/{}/bootstrap.sh' ::: "${TOOLS[@]}"
 
 # Tools that uses apt to do the installation
 # APT is terrible like pip and don't know how to handle parallel installation
-# This section is empty as all got moved up to our base image, but this is the
-# section where new ones would go if we don't want then in the base image
+# These should periodically be moved onto the base image
+apt update && apt install -y --no-install-recommends dhcpcd5


### PR DESCRIPTION
also handles the not-supported hotspot in a couple of other spots to cleanup logs.