### PR TITLE
Core: AutoPilot Manager: Isolate mavlink proxy types and endpoints - (Serial PX4 support part 3) 

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -14,18 +14,17 @@ from loguru import logger
 
 from exceptions import (
     ArdupilotProcessKillFail,
-    EndpointAlreadyExists,
     NoDefaultFirmwareAvailable,
     NoPreferredBoardSet,
 )
 from firmware.FirmwareManagement import FirmwareManager
 from flight_controller_detector.Detector import Detector as BoardDetector
 from flight_controller_detector.linux.linux_boards import LinuxFlightController
-from mavlink_proxy.Endpoint import Endpoint
+from mavlink_proxy.Endpoint import Endpoint, EndpointType
+from mavlink_proxy.exceptions import EndpointAlreadyExists
 from mavlink_proxy.Manager import Manager as MavlinkManager
 from settings import Settings
 from typedefs import (
-    EndpointType,
     Firmware,
     FlightController,
     FlightControllerFlags,

--- a/core/services/ardupilot_manager/exceptions.py
+++ b/core/services/ardupilot_manager/exceptions.py
@@ -63,37 +63,5 @@ class NoDefaultFirmwareAvailable(RuntimeError):
     """Default firmware file is not available."""
 
 
-class EndpointCreationFail(RuntimeError):
-    """Failed to add endpoint."""
-
-
-class EndpointDeleteFail(RuntimeError):
-    """Failed to delete endpoint."""
-
-
-class EndpointUpdateFail(RuntimeError):
-    """Failed to update endpoint."""
-
-
-class MavlinkRouterStartFail(RuntimeError):
-    """Failed to initiate Mavlink router."""
-
-
-class NoMasterMavlinkEndpoint(ValueError):
-    """No master Mavlink endpoint set."""
-
-
-class EndpointAlreadyExists(ValueError):
-    """Mavlink endpoint already exists."""
-
-
-class DuplicateEndpointName(ValueError):
-    """Another mavlink endpoint with same name already exists."""
-
-
-class EndpointDontExist(ValueError):
-    """Given Mavlink endpoint do not exist."""
-
-
 class NoPreferredBoardSet(RuntimeError):
     """No preferred board is set yet."""

--- a/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
@@ -8,14 +8,14 @@ from typing import Any, List, Optional, Set, Type
 
 from loguru import logger
 
-from exceptions import (
+from mavlink_proxy.Endpoint import Endpoint
+from mavlink_proxy.exceptions import (
     DuplicateEndpointName,
     EndpointAlreadyExists,
     EndpointDontExist,
     MavlinkRouterStartFail,
     NoMasterMavlinkEndpoint,
 )
-from mavlink_proxy.Endpoint import Endpoint
 
 
 class AbstractRouter(metaclass=abc.ABCMeta):

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -1,10 +1,19 @@
+from enum import Enum
 from typing import Any, Dict, Iterable, Optional, Type
 
 import validators
 from pydantic import constr, root_validator
 from pydantic.dataclasses import dataclass
 
-from typedefs import EndpointType
+
+class EndpointType(str, Enum):
+    """Supported Mavlink endpoint types."""
+
+    UDPServer = "udpin"
+    UDPClient = "udpout"
+    TCPServer = "tcpin"
+    TCPClient = "tcpout"
+    Serial = "serial"
 
 
 @dataclass

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -3,8 +3,7 @@ import subprocess
 from typing import Optional
 
 from mavlink_proxy.AbstractRouter import AbstractRouter
-from mavlink_proxy.Endpoint import Endpoint
-from typedefs import EndpointType
+from mavlink_proxy.Endpoint import Endpoint, EndpointType
 
 
 class MAVLinkRouter(AbstractRouter):

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -3,8 +3,7 @@ import subprocess
 from typing import Optional
 
 from mavlink_proxy.AbstractRouter import AbstractRouter
-from mavlink_proxy.Endpoint import Endpoint
-from typedefs import EndpointType
+from mavlink_proxy.Endpoint import Endpoint, EndpointType
 
 
 class MAVLinkServer(AbstractRouter):

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVP2P.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVP2P.py
@@ -3,8 +3,7 @@ import subprocess
 from typing import Optional
 
 from mavlink_proxy.AbstractRouter import AbstractRouter
-from mavlink_proxy.Endpoint import Endpoint
-from typedefs import EndpointType
+from mavlink_proxy.Endpoint import Endpoint, EndpointType
 
 
 class MAVP2P(AbstractRouter):

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
@@ -3,8 +3,7 @@ import subprocess
 from typing import Optional
 
 from mavlink_proxy.AbstractRouter import AbstractRouter
-from mavlink_proxy.Endpoint import Endpoint
-from typedefs import EndpointType
+from mavlink_proxy.Endpoint import Endpoint, EndpointType
 
 
 class MAVProxy(AbstractRouter):

--- a/core/services/ardupilot_manager/mavlink_proxy/Manager.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Manager.py
@@ -10,14 +10,14 @@ import mavlink_proxy.MAVLinkRouter
 import mavlink_proxy.MAVLinkServer
 import mavlink_proxy.MAVP2P
 import mavlink_proxy.MAVProxy
-from exceptions import (
+from mavlink_proxy.AbstractRouter import AbstractRouter
+from mavlink_proxy.Endpoint import Endpoint
+from mavlink_proxy.exceptions import (
     EndpointCreationFail,
     EndpointDeleteFail,
     EndpointUpdateFail,
     NoMasterMavlinkEndpoint,
 )
-from mavlink_proxy.AbstractRouter import AbstractRouter
-from mavlink_proxy.Endpoint import Endpoint
 
 
 class Manager:

--- a/core/services/ardupilot_manager/mavlink_proxy/exceptions.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/exceptions.py
@@ -1,0 +1,30 @@
+class DuplicateEndpointName(ValueError):
+    """Another mavlink endpoint with same name already exists."""
+
+
+class EndpointAlreadyExists(ValueError):
+    """Mavlink endpoint already exists."""
+
+
+class EndpointDontExist(ValueError):
+    """Given Mavlink endpoint do not exist."""
+
+
+class MavlinkRouterStartFail(RuntimeError):
+    """Failed to initiate Mavlink router."""
+
+
+class NoMasterMavlinkEndpoint(ValueError):
+    """No master Mavlink endpoint set."""
+
+
+class EndpointCreationFail(RuntimeError):
+    """Failed to add endpoint."""
+
+
+class EndpointDeleteFail(RuntimeError):
+    """Failed to delete endpoint."""
+
+
+class EndpointUpdateFail(RuntimeError):
+    """Failed to update endpoint."""

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -13,11 +13,10 @@ import pytest
 sys.path.append(str(pathlib.Path(__file__).absolute().parent.parent))
 
 from mavlink_proxy.AbstractRouter import AbstractRouter
-from mavlink_proxy.Endpoint import Endpoint
+from mavlink_proxy.Endpoint import Endpoint, EndpointType
 from mavlink_proxy.MAVLinkRouter import MAVLinkRouter
 from mavlink_proxy.MAVP2P import MAVP2P
 from mavlink_proxy.MAVProxy import MAVProxy
-from typedefs import EndpointType
 
 _, slave_port = pty.openpty()
 serial_port_name = os.ttyname(slave_port)

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -166,16 +166,6 @@ class FirmwareFormat(str, Enum):
     ELF = "ELF"
 
 
-class EndpointType(str, Enum):
-    """Supported Mavlink endpoint types."""
-
-    UDPServer = "udpin"
-    UDPClient = "udpout"
-    TCPServer = "tcpin"
-    TCPClient = "tcpout"
-    Serial = "serial"
-
-
 class Serial(BaseModel):
     """Simplified representation of linux serial port configurations,
     gets transformed into command line arguments such as


### PR DESCRIPTION
* Isolate mavlink_proxy type definitions and exceptions in its own module