### PR TITLE
Setup tweaks

### DIFF
--- a/core/frontend/src/components/vehiclesetup/Configure.vue
+++ b/core/frontend/src/components/vehiclesetup/Configure.vue
@@ -15,6 +15,7 @@
           {{ page.title }}
         </v-tab>
       </v-tabs>
+      <not-safe-overlay />
       <v-tabs-items :value="currentSubtab">
         <v-tab-item
           v-for="page in filtered_pages"
@@ -33,6 +34,7 @@
 <script lang="ts">
 import Vue from 'vue'
 
+import NotSafeOverlay from '@/components/common/NotSafeOverlay.vue'
 import VehicleInfo from '@/components/vehiclesetup/overview/VehicleInfo.vue'
 import VehicleViewer from '@/components/vehiclesetup/viewers/VehicleViewer.vue'
 import autopilot from '@/store/autopilot_manager'
@@ -76,6 +78,7 @@ export default Vue.extend({
     BaroCalib,
     FailsafesConfigration,
     Camera,
+    NotSafeOverlay,
   },
   data() {
     return {

--- a/core/frontend/src/components/vehiclesetup/configuration/accelerometer/FullAccelerometerCalibration.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/accelerometer/FullAccelerometerCalibration.vue
@@ -11,7 +11,7 @@
         v-bind="attrs"
         v-on="on"
       >
-        Full Calibration
+        Start Full Calibration
       </v-btn>
     </template>
 

--- a/core/frontend/src/components/vehiclesetup/configuration/accelerometer/FullAccelerometerCalibration.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/accelerometer/FullAccelerometerCalibration.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog
     v-model="dialog"
-    persistent
+    :persistent="!show_ok_button && !show_next_button && !show_start_button"
     width="500"
   >
     <template #activator="{ on, attrs }">

--- a/core/frontend/src/components/vehiclesetup/configuration/compass/ArdupilotMavlinkCompassSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/ArdupilotMavlinkCompassSetup.vue
@@ -34,7 +34,20 @@
               <v-expansion-panels>
                 <v-expansion-panel>
                   <v-expansion-panel-header>
-                    Quick Compass Calibration
+                    Full (Onboard) Calibration
+                  </v-expansion-panel-header>
+                  <v-expansion-panel-content>
+                    <p>
+                      This does a full calibration of the compasses.
+                      It requires you to spin the vehicle around manually multiple times.
+                      You need to move the vehicle around in all 3 axis.
+                    </p>
+                    <full-compass-calibrator :compasses="compasses" />
+                  </v-expansion-panel-content>
+                </v-expansion-panel>
+                <v-expansion-panel>
+                  <v-expansion-panel-header>
+                    Large Vehicle Calibration
                   </v-expansion-panel-header>
                   <v-expansion-panel-content>
                     <p>
@@ -58,19 +71,6 @@
                       you see the message <b>"CompassLearn: finished"</b>
                     </p>
                     <compass-learn :compasses="compasses" />
-                  </v-expansion-panel-content>
-                </v-expansion-panel>
-                <v-expansion-panel>
-                  <v-expansion-panel-header>
-                    Onboard Calibration
-                  </v-expansion-panel-header>
-                  <v-expansion-panel-content>
-                    <p>
-                      This does a full calibration of the compasses.
-                      It requires you to spin the vehicle around manually multiple times.
-                      You need to move the vehicle around in all 3 axis.
-                    </p>
-                    <full-compass-calibrator :compasses="compasses" />
                   </v-expansion-panel-content>
                 </v-expansion-panel>
                 <v-expansion-panel>

--- a/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
@@ -85,7 +85,7 @@
           Dismiss
         </v-btn>
         <RebootButton />
-        <v-btn color="red" :disabled="state !== states.CALIBRATING" @click="cancelCalibration()">
+        <v-btn v-if="state == states.CALIBRATING" color="red" @click="cancelCalibration()">
           Cancel
         </v-btn>
       </v-card-actions>

--- a/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
@@ -9,7 +9,7 @@
         v-bind="attrs"
         v-on="on"
       >
-        Full Calibration
+        Start Full Calibration
       </v-btn>
     </template>
 

--- a/core/frontend/src/components/vehiclesetup/configuration/compass/LargeVehicleCompassCalibrator.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/LargeVehicleCompassCalibrator.vue
@@ -9,7 +9,7 @@
         v-bind="attrs"
         v-on="on"
       >
-        Run Large Vehicle Calibration
+        Start Large Vehicle Calibration
       </v-btn>
     </template>
 


### PR DESCRIPTION
Makes some wording consistent
Allows closing accel cal dialog
Make calibrations "not-safe" when armed
Only show cancel button for full calibration when it is in a cancel-able state