### PR TITLE
VehicleSetup: fix issue in vehciles with more than 3 compasses

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/compass/ArdupilotMavlinkCompassSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/ArdupilotMavlinkCompassSetup.vue
@@ -426,7 +426,7 @@ export default Vue.extend({
       for (const [index, compass] of compasses.entries()) {
         const param_name = `COMPASS_PRIO${index + 1}_ID`
         const param = autopilot_data.parameter(param_name)
-        if (param?.value !== compass.paramValue) {
+        if (param && param?.value !== compass.paramValue) {
           mavlink2rest.setParam(param_name, compass.paramValue, autopilot_data.system_id)
           autopilot_data.setRebootRequired(true)
         }


### PR DESCRIPTION
This happens in sitl. the code always tries to reorder compasses if more than 3 are available, as it checks for "undefined"