### PR TITLE
Change logfile name

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/commonwealth/utils/logs.py
@@ -55,7 +55,7 @@ def get_new_log_path(service_name: str) -> Path:
     service_log_folder.mkdir(parents=True, exist_ok=True)
 
     # Returned log path are service-specific and store datetime information
-    datetime_now = datetime.now().strftime("%m-%d-%Y_%H:%M:%S")
+    datetime_now = datetime.now().strftime("%Y%m%d_%H%M%S")
     return service_log_folder.joinpath(f"logfile_{datetime_now}.log")
 
 


### PR DESCRIPTION
1. Remove dividers - these are unnecessary and the colon causes problems (fixes #2969)
2. Switch order from month,day,year to year,month,day. This ensures correct collation when sorted