### PR TITLE
Switch blueos-bootstrap from rc.local to systemd

### DIFF
--- a/install/configs/blueos.service
+++ b/install/configs/blueos.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Start BlueOS on boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker start blueos-bootstrap
+
+[Install]
+WantedBy=multi-user.target

--- a/install/install.sh
+++ b/install/install.sh
@@ -226,8 +226,23 @@ docker create \
     -e BLUEOS_CONFIG_PATH=$HOME/.config/blueos \
     $BLUEOS_BOOTSTRAP
 
-# add docker entry to rc.local
-sed -i "\%^exit 0%idocker start blueos-bootstrap" /etc/rc.local || echo "Failed to add docker start on rc.local, BlueOS will not start on boot!"
+# Ensure docker can run without sudo
+groupadd docker
+usermod -aG docker pi
+
+# Create service to start blueos-bootstrap container on boot
+echo "[Unit]
+Description=Start BlueOS on boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker start blueos-bootstrap
+
+[Install]
+WantedBy=multi-user.target" >> /etc/systemd/system/blueos.service
+
+systemctl start start-blueos
+systemctl enable start-blueos
 
 # Configure network settings
 ## This should be after everything, otherwise network problems can happen

--- a/install/install.sh
+++ b/install/install.sh
@@ -227,13 +227,13 @@ docker create \
     $BLUEOS_BOOTSTRAP
 
 # Ensure docker can run without sudo
-groupadd docker
-usermod -aG docker pi
+groupadd docker || true
+usermod -aG docker pi || true
 
 # Create service to start blueos-bootstrap container on boot
 curl -fsSL "$ROOT/install/configs/blueos.service" -o /etc/systemd/system/blueos.service
-systemctl start start-blueos
-systemctl enable start-blueos
+systemctl start blueos
+systemctl enable blueos
 
 # Configure network settings
 ## This should be after everything, otherwise network problems can happen

--- a/install/install.sh
+++ b/install/install.sh
@@ -231,16 +231,7 @@ groupadd docker
 usermod -aG docker pi
 
 # Create service to start blueos-bootstrap container on boot
-echo "[Unit]
-Description=Start BlueOS on boot
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/docker start blueos-bootstrap
-
-[Install]
-WantedBy=multi-user.target" >> /etc/systemd/system/blueos.service
-
+curl -fsSL "$ROOT/install/configs/blueos.service" -o /etc/systemd/system/blueos.service
 systemctl start start-blueos
 systemctl enable start-blueos
 


### PR DESCRIPTION
The current install script uses rc.local to start the blueos-bootstrap container, which works fine on Raspberry Pi SoCs. However, it does not work for other SoCs, such as the Nvidia Jetson Nano, which does not use rc.local. This patch will use a systemd service to start the blueos-bootstrap container on boot, supported by both Raspberry Pi SoCs and Nvidia Jetson SoCs. 