### PR TITLE
Autopilot Manager: pass process pid as string when using 'kill'

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -510,7 +510,7 @@ class AutoPilotManager(metaclass=Singleton):
                 logger.debug(f"Ardupilot appears to be running.. going to call pkill: {error}")
 
             try:
-                subprocess.run(["kill", "-9", process.pid], check=True)
+                subprocess.run(["kill", "-9", f"{process.pid}"], check=True)
             except Exception as error:
                 raise AutoPilotProcessKillFail(f"Failed to kill {process.name()}::{process.pid}.") from error
 


### PR DESCRIPTION
fixes this:
![image](https://github.com/user-attachments/assets/80e7853a-e838-4968-ba33-a50d1a9e9633)
