### PR TITLE
allow getting ssh user and password from environment variables

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/commands.py
+++ b/core/libs/commonwealth/commonwealth/utils/commands.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 from typing import List, Optional
@@ -12,8 +13,8 @@ class KeyNotFound(Exception):
 def run_command_with_password(command: str, check: bool = True) -> "subprocess.CompletedProcess['str']":
     # attempt to run the command with sshpass
     # used as a fallback if the ssh key is not found
-    user = "pi"
-    password = "raspberry"
+    user = os.environ.get("SSH_USER", "pi")
+    password = os.environ.get("SSH_PASSWORD", "raspberry")
 
     return subprocess.run(
         [
@@ -35,7 +36,7 @@ def run_command_with_password(command: str, check: bool = True) -> "subprocess.C
 
 def run_command_with_ssh_key(command: str, check: bool = True) -> "subprocess.CompletedProcess['str']":
     # attempt to run the command with the ssh key
-    user = "pi"
+    user = os.environ.get("SSH_USER", "pi")
     id_file = "/root/.config/.ssh/id_rsa"
     if not Path(id_file).exists():
         raise KeyNotFound
@@ -84,8 +85,8 @@ def upload_file_with_password(
 ) -> "subprocess.CompletedProcess['str']":
     # attempt to upload the file with sshpass
     # used as a fallback if the ssh key is not found
-    user = "pi"
-    password = "raspberry"
+    user = os.environ.get("SSH_USER", "pi")
+    password = os.environ.get("SSH_PASSWORD", "raspberry")
 
     return subprocess.run(
         [
@@ -105,7 +106,7 @@ def upload_file_with_password(
 
 def upload_file_with_ssh_key(source: str, destination: str, check: bool = True) -> "subprocess.CompletedProcess['str']":
     # attempt to upload the file with the ssh key
-    user = "pi"
+    user = os.environ.get("SSH_USER", "pi")
     id_file = "/root/.config/.ssh/id_rsa"
     if not Path(id_file).exists():
         raise KeyNotFound

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -226,7 +226,10 @@ def setup_ssh() -> None:
     key_path = Path("/root/.config/.ssh")
     private_key = key_path / "id_rsa"
     public_key = private_key.with_suffix(".pub")
-    authorized_keys = Path("/home/pi/.ssh/authorized_keys")
+    user = os.environ.get("SSH_USER", "pi")
+    gid = int(os.environ.get("USER_GID", 1000))
+    uid = int(os.environ.get("USER_UID", 1000))
+    authorized_keys = Path(f"/home/{user}/.ssh/authorized_keys")
 
     try:
         key_path.mkdir(parents=True, exist_ok=True)
@@ -247,7 +250,7 @@ def setup_ssh() -> None:
             authorized_keys_text += public_key_text
             authorized_keys.write_text(authorized_keys_text, "utf-8")
 
-        shutil.chown(authorized_keys, "pi", "pi")
+        os.chown(authorized_keys, uid, gid)
         authorized_keys.chmod(0o600)
     except Exception as error:
         logger.error(f"Error setting up ssh: {error}")

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -159,8 +159,10 @@ function create_service {
     tmux send-keys -t $SESSION_NAME "run-service '$SERVICE_NAME' '$command' $memory_limit_mb " C-m
 }
 
+SSH_USER=${SSH_USER:-pi}
+
 ssh_command() {
-  ssh -i /root/.config/.ssh/id_rsa -o StrictHostKeyChecking=no pi@localhost "$1"
+  ssh -i /root/.config/.ssh/id_rsa -o StrictHostKeyChecking=no $SSH_USER@localhost "$1"
 }
 
 prepare_cgroups() {

--- a/core/tools/scripts/red-pill
+++ b/core/tools/scripts/red-pill
@@ -9,7 +9,7 @@ usage() {
 }
 
 # Default values
-user="pi"
+user=${SSH_USER:-pi}
 
 while getopts ":hu:" opt; do
   case ${opt} in


### PR DESCRIPTION
I used this to install BlueOS on a Radxa Zero 3E running ubuntu.
The issue is there's no `pi` user there, so it requires these changes in order to be able to install the ssh key.
Additionaly, this is the updated startup.json:

```
{
    "core": {
        "binds": {
            "/dev/": {
                "bind": "/dev/",
                "mode": "rw"
            },
            "/etc/blueos": {
                "bind": "/etc/blueos",
                "mode": "rw"
            },
            "/etc/dhcpcd.conf": {
                "bind": "/etc/dhcpcd.conf",
                "mode": "rw"
            },
            "/etc/machine-id": {
                "bind": "/etc/machine-id",
                "mode": "ro"
            },
            "/etc/resolv.conf.host": {
                "bind": "/etc/resolv.conf.host",
                "mode": "ro"
            },
            "/home/pi/.ssh": {
                "bind": "/home/pi/.ssh",
                "mode": "rw"
            },
            "/home/rock/.ssh": {
                "bind": "/home/rock/.ssh",
                "mode": "rw"
            },
            "/run/udev": {
                "bind": "/run/udev",
                "mode": "ro"
            },
            "/sys/": {
                "bind": "/sys/",
                "mode": "rw"
            },
            "/tmp/wpa_playground": {
                "bind": "/tmp/wpa_playground",
                "mode": "rw"
            },
            "/usr/blueos/bin": {
                "bind": "/usr/blueos/bin",
                "mode": "rw"
            },
            "/usr/blueos/extensions": {
                "bind": "/usr/blueos/extensions",
                "mode": "rw"
            },
            "/usr/blueos/userdata": {
                "bind": "/usr/blueos/userdata",
                "mode": "rw"
            },
            "/var/logs/blueos": {
                "bind": "/var/logs/blueos",
                "mode": "rw"
            },
            "/var/run/dbus": {
                "bind": "/var/run/dbus",
                "mode": "rw"
            },
            "/var/run/docker.sock": {
                "bind": "/var/run/docker.sock",
                "mode": "rw"
            },
            "/var/run/wpa_supplicant": {
                "bind": "/var/run/wpa_supplicant",
                "mode": "rw"
            }
        },
        "enabled": true,
        "environment": [
            "SSH_USER=rock",
            "SSH_PASSWORD=rock",
            "USER_UID=1001",
            "USER_GID=1001",
            "BLUEOS_DISABLE_SERVICES=wifi,autopilot"
        ],
        "image": "williangalvani/blueos-core",
        "network": "host",
        "privileged": true,
        "tag": "user_pass",
        "webui": false
    }
}
```

For documentation sake:
 - I'm using [radxa-zero3_ubuntu_jammy_cli_b6.img.xz](https://github.com/radxa-build/radxa-zero3/releases/download/b6/radxa-zero3_ubuntu_jammy_cli_b6.img.xz)
 - I just logged in and run the install script, then updated the image until it could setup ssh properly
 - debian and cli images dont seem to be working at all on the radxa zero 3e


potentially fix #2984 