### PR TITLE
frontend: add 'soc' option when looking for temperature source

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -156,7 +156,9 @@ export default Vue.extend({
   computed: {
     cpu_temperature(): string {
       const temperature_sensors = system_information.system?.temperature
-      const main_sensor = temperature_sensors?.find((sensor) => sensor.name.toLowerCase().includes('cpu'))
+      const main_sensor = temperature_sensors?.find(
+        (sensor) => sensor.name.toLowerCase().includes('cpu') || sensor.name.toLowerCase().includes('soc'),
+      )
       return main_sensor ? main_sensor.temperature.toFixed(1) : 'Loading..'
     },
     cpu_throttled() : boolean {

--- a/core/frontend/src/components/system-information/SystemCondition.vue
+++ b/core/frontend/src/components/system-information/SystemCondition.vue
@@ -108,7 +108,9 @@ export default Vue.extend({
     },
     temperature(): Record<string, unknown> {
       const temperature_sensors = system_information.system?.temperature
-      const main_sensor = temperature_sensors?.find((sensor) => sensor.name.toLowerCase().includes('cpu'))
+      const main_sensor = temperature_sensors?.find((
+        sensor,
+      ) => sensor.name.toLowerCase().includes('cpu') || sensor.name.toLowerCase().includes('soc'))
       const main_temperature = main_sensor?.temperature.toFixed(1) ?? 'Loading..'
       console.log(`main_temperature: ${main_temperature}`)
       const temperature_text = temperature_sensors?.map(


### PR DESCRIPTION
these are the temps available on my (radxa) system:
![image](https://github.com/user-attachments/assets/e7761956-68ec-4201-9bda-fa1b433c9e1f)
