### PR TITLE
blueos_startup_update: only create dns link on Bullseye

### DIFF
--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -460,7 +460,6 @@ def main() -> int:
         update_startup,
         ensure_user_data_structure_is_in_place,
         ensure_nginx_permissions,
-        create_dns_conf_host_link,
         fix_ssh_ownership,
     ]
 
@@ -477,6 +476,8 @@ def main() -> int:
         )
     if host_os == HostOs.Bookworm:
         patches_to_apply.extend([fix_wpa_service])
+    if host_os == HostOs.Bullseye:
+        patches_to_apply.extend([create_dns_conf_host_link])
 
     logger.info("The following patches will be applied if needed:")
     for patch in patches_to_apply:


### PR DESCRIPTION
This is not working on Bookworm, and it is causing unnecessary reboots.
This change makes it happen on Bullseye only. On bookworm we should probaby use NetworkManager to configure dns isntead of doing the resolv.conf thing