### PR TITLE
Cable-guy: save settings after changes

### DIFF
--- a/core/services/cable_guy/networksetup.py
+++ b/core/services/cable_guy/networksetup.py
@@ -124,6 +124,7 @@ class NetworkManagerHandler(AbstractNetworkHandler):
                 metric += 1000
                 logger.info(f"Settting current priority for {interface.name} as {metric}")
                 settings.update(properties)
+                settings.save()
                 network_manager.activate_connection(connection_path)
 
 


### PR DESCRIPTION
It makes sense for network priorities to be persistent, otherwise a working configuration may break itself on reboot.

needs testing