### PR TITLE
fix: update telemetry service details on compose.yml

### DIFF
--- a/core/compose/compose.yml
+++ b/core/compose/compose.yml
@@ -51,13 +51,14 @@ services:
   #     - "27353:27353" # Bridget
   #     - "49153:49153" # Cockpit
   cloud-telemetry:
-    image: public.ecr.aws/h4c9p1o0/blueos-cloud-agent-dev
+    image: public.ecr.aws/blueos/bcloud-agent
     container_name: blueos-cloud-telemetry
     privileged: true
     restart: always
     network_mode: host
     pid: "host"
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
       - /run/udev:/run/udev
       - /etc/resolv.conf:/etc/resolv.conf
       - /etc/machine-id:/host/etc/machine-id # cloud-agent binds host content to /host


### PR DESCRIPTION
Some people are having issues trying to run BlueOS in development mode due to stale information about MajorTom service (#3030, #2953)
