### PR TITLE
frontend: add tooltips on InlineParameterEditor with parameter name, options, and description

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterLabel.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLabel.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="d-flex align-center">
+    <span>{{ label }}</span>
+    <v-tooltip bottom>
+      <template #activator="{ on, attrs }">
+        <v-icon
+          small
+          class="ml-2"
+          v-bind="attrs"
+          v-on="on"
+        >
+          mdi-information
+        </v-icon>
+      </template>
+      <div>
+        <strong>{{ param?.name }}</strong><br>
+        <span v-if="param?.description">Description: {{ param.description }}<br></span>
+        <span v-if="param?.range">Range: {{ param.range.low }} to {{ param.range.high }}<br></span>
+        <span v-if="param?.units">Units: {{ param.units }}<br></span>
+        <span v-if="param?.options">Options: {{ formatOptions }}<br></span>
+        <span v-if="param?.rebootRequired">Requires reboot</span>
+      </div>
+    </v-tooltip>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+
+import Parameter from '@/types/autopilot/parameter'
+
+export default Vue.extend({
+  name: 'ParameterLabel',
+  props: {
+    label: {
+      type: String,
+      required: true,
+    },
+    param: {
+      type: Object as PropType<Parameter>,
+      required: true,
+    },
+    formatOptions: {
+      type: String,
+      required: true,
+    },
+  },
+})
+</script>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/1650e972-adc6-473f-b486-53567719338f)

fix #3044 