### PR TITLE
Cable guy tweaks

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -91,24 +91,27 @@ class EthernetManager:
             interface: NetworkInterface
         """
         interfaces = self.get_ethernet_interfaces()
-        logger.debug(f"Found following ethernet interfaces: {interfaces}.")
         valid_names = [interface.name for interface in interfaces]
-
         if interface.name not in valid_names:
             raise ValueError(f"Invalid interface name ('{interface.name}'). Valid names are: {valid_names}")
 
+        logger.info(f"Setting configuration for interface '{interface.name}'.")
         # Reset the interface by removing all IPs and DHCP servers associated with it
         self.flush_interface(interface.name)
         self.remove_dhcp_server_from_interface(interface.name)
 
         # Even if it happened to receive more than one dynamic IP, only one trigger is necessary
         if any(address.mode == AddressMode.Client for address in interface.addresses):
+            logger.info(f"Triggering dynamic IP acquisition for interface '{interface.name}'.")
             self.trigger_dynamic_ip_acquisition(interface.name)
 
+        logger.info(f"Configuring addresses for interface '{interface.name}': {interface.addresses}.")
         for address in interface.addresses:
             if address.mode == AddressMode.Unmanaged:
+                logger.info(f"Adding static IP '{address.ip}' to interface '{interface.name}'.")
                 self.add_static_ip(interface.name, address.ip)
             elif address.mode == AddressMode.Server:
+                logger.info(f"Adding DHCP server with gateway '{address.ip}' to interface '{interface.name}'.")
                 self.add_dhcp_server_to_interface(interface.name, address.ip)
 
     def _get_wifi_interfaces(self) -> List[str]:

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -40,7 +40,13 @@ args = parser.parse_args()
 
 if args.default_config == "bluerov2":
     default_configs = [
-        NetworkInterface(name="eth0", addresses=[InterfaceAddress(ip="192.168.2.2", mode=AddressMode.Server)]),
+        NetworkInterface(
+            name="eth0",
+            addresses=[
+                InterfaceAddress(ip="192.168.2.2", mode=AddressMode.Server),
+                InterfaceAddress(ip="0.0.0.0", mode=AddressMode.Client),
+            ],
+        ),
         NetworkInterface(name="usb0", addresses=[InterfaceAddress(ip="192.168.3.1", mode=AddressMode.Server)]),
     ]
 

--- a/core/services/cable_guy/networksetup.py
+++ b/core/services/cable_guy/networksetup.py
@@ -80,7 +80,10 @@ class NetworkManagerHandler(AbstractNetworkHandler):
                     logger.info(f"IP {ip} already exists for {interface_name}")
                     continue
                 new_ip = AddressData(address=ip, prefix=24)
-                settings["ipv4"]["method"] = ("s", "shared")
+                properties = settings.get_settings()
+                properties["ipv4"]["method"] = ("s", "shared")
+                settings.update(properties)
+                settings.save()
                 data.ipv4.address_data.append(new_ip)
                 settings.update_profile(data)
                 network_manager.activate_connection(connection_path)


### PR DESCRIPTION
should fix the case where the pi is not getting a dynamic ip automatically when using networkmanager

also fixes 

```
2025-01-13 18:54:19.966 | INFO     | api.manager:add_static_ip:258 - Adding static IP '192.168.2.2' to interface 'eth0'.
2025-01-13 18:54:20.972 | ERROR    | networksetup:add_static_ip:89 - Failed to set static ip 192.168.2.2 for eth0: 'NetworkConnectionSettings' object is not subscriptable
```