### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.18.1

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.18.0"
+VERSION="t3.18.1"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
This patch:
- Fixes OpenAPI specs by defining the return codes/errors.
- Improves Redirec to WebRTC compatibility by re-payloading the RTP packages.

[changelog](https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.18.1)