### PR TITLE
Navigator64 fixes

### DIFF
--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -28,7 +28,7 @@ static_files = [
     ),
     StaticFile(
         defaults_folder,
-        "ardupilot_navigator",
+        "ardupilot_navigator64",
         "https://firmware.ardupilot.org/Sub/stable-4.5.0/navigator64/ardusub",
     ),
     StaticFile(

--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -29,7 +29,7 @@ static_files = [
     StaticFile(
         defaults_folder,
         "ardupilot_navigator64",
-        "https://firmware.ardupilot.org/Sub/stable-4.5.0/navigator64/ardusub",
+        "https://firmware.ardupilot.org/Sub/stable-4.5.1/navigator64/ardusub",
     ),
     StaticFile(
         defaults_folder, "ardupilot_pixhawk1", "https://firmware.ardupilot.org/Sub/stable-4.5.0/Pixhawk1/ardusub.apj"


### PR DESCRIPTION
~letting ci build this one for testing.~ tested
should fix the default firmware for navigator64 not being found on a fresh install