### PR TITLE
core: cable-guy: Fix parsing error when response has no body

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -318,7 +318,7 @@ class Helper:
             "127.0.0.1", port=port, path="/", timeout=1.0, method="GET", follow_redirects=10
         )
         log_msg = f"Detecting service at port {port}"
-        if response.status == http.client.BAD_REQUEST || response.decoded_data is None:
+        if response.status == http.client.BAD_REQUEST or response.decoded_data is None:
             # If not valid web server, documentation will not be available
             logger.debug(f"{log_msg}: Invalid: {response.status} - {response.decoded_data!r}")
             return info

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -318,9 +318,9 @@ class Helper:
             "127.0.0.1", port=port, path="/", timeout=1.0, method="GET", follow_redirects=10
         )
         log_msg = f"Detecting service at port {port}"
-        if response.status == http.client.BAD_REQUEST:
+        if response.status == http.client.BAD_REQUEST || response.decoded_data is None:
             # If not valid web server, documentation will not be available
-            logger.debug(f"{log_msg}: Invalid: {response.status} - {response.decoded_data}")
+            logger.debug(f"{log_msg}: Invalid: {response.status} - {response.decoded_data!r}")
             return info
 
         info.valid = True


### PR DESCRIPTION
Fix parsing error when response has no body

Previously, you could see errors like this in the log:
```
2025-01-23 23:30:16.526 | WARNING  | __main__:detect_service:333 - Failed parsing the service title: object of type 'NoneType' has no len()
```