### PR TITLE
Fix priority changing on Bookworm

### DIFF
--- a/core/frontend/src/components/app/NetworkInterfacePriorityMenu.vue
+++ b/core/frontend/src/components/app/NetworkInterfacePriorityMenu.vue
@@ -153,7 +153,6 @@ export default Vue.extend({
       })
         .catch((error) => {
           const message = `Could not set network interface priorities: ${interface_priorities}, error: ${error}`
-          console.log(interface_priorities)
           notifier.pushError('INCREASE_NETWORK_INTERFACE_METRIC_FAIL', message)
         })
         .then(() => {

--- a/core/frontend/src/components/app/NetworkInterfacePriorityMenu.vue
+++ b/core/frontend/src/components/app/NetworkInterfacePriorityMenu.vue
@@ -140,16 +140,20 @@ export default Vue.extend({
       await Promise.all(interfaces.map((iface) => this.checkInterfaceInternet(host, iface)))
     },
     async setHighestInterface(): Promise<void> {
-      this.is_loading = true
-      const interface_priority = this.interfaces.map((inter) => ({ name: inter.name }))
+      const interface_priorities = this.interfaces.map((inter) => ({ name: inter.name, priority: 0 }))
+      interface_priorities.forEach((inter, index) => {
+        inter.priority = index * 1000
+      })
+      this.interfaces = []
       await back_axios({
         method: 'post',
         url: `${ethernet.API_URL}/set_interfaces_priority`,
         timeout: 10000,
-        data: interface_priority,
+        data: interface_priorities,
       })
         .catch((error) => {
-          const message = `Could not increase the priority for interface '${interface_priority}', ${error}.`
+          const message = `Could not set network interface priorities: ${interface_priorities}, error: ${error}`
+          console.log(interface_priorities)
           notifier.pushError('INCREASE_NETWORK_INTERFACE_METRIC_FAIL', message)
         })
         .then(() => {
@@ -161,7 +165,6 @@ export default Vue.extend({
           this.close()
         })
       await this.fetchAvailableInterfaces()
-      this.is_loading = false
     },
     async fetchAvailableInterfaces(): Promise<void> {
       await back_axios({
@@ -173,9 +176,9 @@ export default Vue.extend({
         .then((response) => {
           const interfaces = response.data as EthernetInterface[]
           interfaces.sort((a, b) => {
-            if (!a.info) return -1
-            if (!b.info) return 1
-            return a.info.priority - b.info.priority
+            const priorityA = a.priority ?? Number.MAX_SAFE_INTEGER
+            const priorityB = b.priority ?? Number.MAX_SAFE_INTEGER
+            return priorityA - priorityB
           })
           this.interfaces = interfaces
         })

--- a/core/frontend/src/types/ethernet.ts
+++ b/core/frontend/src/types/ethernet.ts
@@ -19,4 +19,5 @@ export interface EthernetInterface {
     name: string,
     addresses: InterfaceAddress[],
     info?: InterfaceInfo,
+    priority?: number,
 }

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -56,12 +56,7 @@ class EthernetManager:
         # Load settings and do the initial configuration
         if not self.settings.load():
             logger.error(f"Failed to load previous settings. Using default configuration: {default_configs}")
-            try:
-                for config in default_configs:
-                    self.set_configuration(config)
-            except Exception as error:
-                logger.error(f"Failed loading default configuration. {error}")
-            return
+            self.settings.root = {"content": [entry.dict() for entry in default_configs]}
 
         logger.info("Loading previous settings.")
         for item in self.settings.root["content"]:

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -282,6 +282,14 @@ class EthernetManager:
             logger.error(f"Failed to add IP '{ip}' to interface '{interface_name}'. {error}")
 
         saved_interface = self.get_saved_interface_by_name(interface_name)
+        if saved_interface is None:
+            # If the interface is not saved, create a new one
+            saved_interface = NetworkInterface(
+                name=interface_name,
+                addresses=[
+                    InterfaceAddress(ip=ip, mode=AddressMode.Unmanaged),
+                ],
+            )
         new_address = InterfaceAddress(ip=ip, mode=mode)
         if new_address not in saved_interface.addresses:
             saved_interface.addresses.append(new_address)
@@ -306,6 +314,9 @@ class EthernetManager:
             raise RuntimeError(f"Cannot delete IP '{ip_address}' from interface {interface_name}.") from error
 
         saved_interface = self.get_saved_interface_by_name(interface_name)
+        if saved_interface is None:
+            logger.error(f"Interface {interface_name} is not managed by Cable Guy. Not deleting IP {ip_address}.")
+            return
         saved_interface.addresses = [address for address in saved_interface.addresses if address.ip != ip_address]
         self._update_interface_settings(interface_name, saved_interface)
 

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -86,8 +86,6 @@ class EthernetManager:
             raise ValueError(f"Invalid interface name ('{interface.name}'). Valid names are: {valid_names}")
 
         logger.info(f"Setting configuration for interface '{interface.name}'.")
-        # Reset the interface by removing all IPs and DHCP servers associated with it
-        self.flush_interface(interface.name)
         self.remove_dhcp_server_from_interface(interface.name)
 
         if interface.addresses:

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -80,7 +80,7 @@ class EthernetManager:
         """
         if not watchdog_call:
             self.network_handler.cleanup_interface_connections(interface.name)
-        interfaces = self.get_ethernet_interfaces()
+        interfaces = self.get_interfaces()
         valid_names = [interface.name for interface in interfaces]
         if interface.name not in valid_names:
             raise ValueError(f"Invalid interface name ('{interface.name}'). Valid names are: {valid_names}")

--- a/core/services/cable_guy/networksetup.py
+++ b/core/services/cable_guy/networksetup.py
@@ -379,8 +379,46 @@ class DHCPCD(AbstractNetworkHandler):
         with open("/etc/dhcpcd.conf", "w", encoding="utf-8") as f:
             f.writelines(lines)
 
+    def _get_dhcp_address_using_dhclient(self, interface_name: str) -> str | None:
+        """Run dhclient to get a new IP address and return it.
+
+        Args:
+            interface_name: Name of the interface to get IP for
+
+        Returns:
+            The IP address acquired from DHCP, or None if failed
+        """
+        try:
+            # Just run dhclient without releasing existing IPs
+            command = f"timeout 5 dhclient -v {interface_name} 2>&1"
+            logger.info(f"Running: {command}")
+            dhclient_output = os.popen(command).read()
+
+            bound_ip_match = re.search(r"bound to ([0-9.]+)", dhclient_output)
+            if bound_ip_match:
+                return bound_ip_match.group(1)
+
+            logger.error(f"Could not find bound IP in dhclient output: {dhclient_output}")
+            return None
+
+        except Exception as e:
+            logger.error(f"Failed to run dhclient: {e}")
+            return None
+
     def trigger_dynamic_ip_acquisition(self, interface_name: str) -> None:
-        raise NotImplementedError("This Handler does not support triggering dynamic IP acquisition")
+        """Get a new IP from DHCP using dhclient.
+        The IP will be managed by dhclient and not added to NetworkManager's configuration.
+
+        Args:
+            interface_name: Name of the interface to get IP for
+        """
+        # Get new IP using dhclient
+        new_ip = self._get_dhcp_address_using_dhclient(interface_name)
+        if not new_ip:
+            logger.error(f"Failed to get DHCP-acquired IP for {interface_name}")
+            return
+
+        logger.info(f"Got new IP {new_ip} from DHCP for {interface_name}")
 
     def set_interfaces_priority(self, interfaces: List[NetworkInterfaceMetricApi]) -> None:
         """Sets network interface priority..

--- a/core/services/cable_guy/networksetup.py
+++ b/core/services/cable_guy/networksetup.py
@@ -1,7 +1,7 @@
 import os
 import re
 import socket
-from typing import Dict, List
+from typing import Any, List
 
 import sdbus
 from loguru import logger
@@ -14,7 +14,7 @@ from sdbus_block.networkmanager import (
     NetworkManagerSettings,
 )
 
-from typedefs import NetworkInterfaceMetric, NetworkInterfaceMetricApi
+from typedefs import NetworkInterfaceMetricApi
 
 sdbus.set_default_bus(sdbus.sd_bus_open_system())
 
@@ -27,9 +27,6 @@ class AbstractNetworkHandler:
 
     def detect(self) -> bool:
         raise NotImplementedError("NetworkManager does not support detecting network interfaces priority")
-
-    def get_interfaces_priority(self) -> List[NetworkInterfaceMetric]:
-        raise NotImplementedError("NetworkManager does not support getting network interfaces priority")
 
     def set_interfaces_priority(self, interfaces: List[NetworkInterfaceMetricApi]) -> None:
         raise NotImplementedError("NetworkManager does not support setting interface priority")
@@ -49,6 +46,83 @@ class AbstractNetworkHandler:
     def cleanup_interface_connections(self, interface_name: str) -> None:
         pass
 
+    def _update_route(self, interface_name: str, interface_index: int, route: Any, priority: int) -> None:
+        """Update a single route with new priority.
+
+        Args:
+            interface_name: Name of the interface
+            interface_index: Index of the interface
+            route: Route object
+            priority: New priority to set
+        """
+        # Skip non-default routes (those not pointing to 0.0.0.0/0)
+        dst = route.get_attr("RTA_DST")
+        if dst is not None:  # If dst is None, it's a default route (0.0.0.0/0)
+            return
+        if route.get_attr("RTA_PRIORITY") == priority:
+            return
+
+        self.ipr.route(
+            "del",
+            oif=interface_index,
+            family=socket.AF_INET,
+            scope=route["scope"],
+            proto=route["proto"],
+            type=route["type"],
+            dst="0.0.0.0/0",  # For default route
+            gateway=route.get_attr("RTA_GATEWAY"),
+            table=route.get_attr("RTA_TABLE", 254),  # Default to main table if not specified
+        )
+
+        for attempt in range(3):
+            try:
+                # Add the new route with updated priority
+                logger.info(f"Adding new route for {interface_name} with priority {priority}")
+                self.ipr.route(
+                    "add",
+                    oif=interface_index,
+                    family=socket.AF_INET,
+                    scope=route["scope"],
+                    proto=route["proto"],
+                    type=route["type"],
+                    dst="0.0.0.0/0",  # For default route
+                    gateway=route.get_attr("RTA_GATEWAY"),
+                    priority=priority + attempt,
+                    table=route.get_attr("RTA_TABLE", 254),  # Default to main table if not specified
+                )
+                logger.info(f"Updated default route for {interface_name} with priority {priority}")
+                break
+            except Exception as e:
+                logger.error(f"Failed to update route for {interface_name}: {e} (attempt {attempt})")
+
+    def set_interfaces_priority_using_ipr(self, interfaces: List[NetworkInterfaceMetricApi]) -> None:
+        if not interfaces:
+            logger.info("No interfaces to set priority for")
+            return
+
+        for interface in interfaces:
+            try:
+                # Use specified priority or increment current_priority
+                priority = interface.priority
+
+                # Get interface index
+                interface_index = self.ipr.link_lookup(ifname=interface.name)[0]
+
+                # Get all routes for this interface
+                routes = self.ipr.get_routes(oif=interface_index, family=socket.AF_INET)
+
+                # Update existing routes
+                for route in routes:
+                    try:
+                        self._update_route(interface.name, interface_index, route, priority)
+                    except Exception as e:
+                        logger.error(f"Failed to update route for {interface.name}: {e}")
+                        continue
+
+            except Exception as e:
+                logger.error(f"Failed to set priority for interface {interface.name}: {e}")
+                continue
+
 
 class BookwormHandler(AbstractNetworkHandler):
     """
@@ -61,6 +135,9 @@ class BookwormHandler(AbstractNetworkHandler):
         network_manager_settings = NetworkManagerSettings()
         for connection_path in network_manager_settings.connections:
             profile = NetworkConnectionSettings(connection_path).get_profile()
+            # Skip if this is a wireless connection
+            if profile.connection.connection_type == "802-11-wireless":
+                continue
             if profile.connection.interface_name == interface_name:
                 logger.info(
                     f"Removing connection {profile.connection.uuid} ({profile.connection.connection_id}) for interface {interface_name}"
@@ -106,40 +183,6 @@ class BookwormHandler(AbstractNetworkHandler):
         except Exception as error:
             logger.error(f"Failed to add IP '{ip}' to interface '{interface_name}'. {error}")
 
-    def get_interfaces_priority(self) -> List[NetworkInterfaceMetric]:
-        """Get the priority metrics for all network interfaces using IPRoute.
-
-        Returns:
-            List[NetworkInterfaceMetric]: A list of priority metrics for each interface.
-        """
-        interfaces = self.ipr.get_links()
-        # Get all IPv4 routes
-        routes = self.ipr.get_routes(family=socket.AF_INET)
-
-        # Create a mapping of interface index to name
-        name_dict = {iface["index"]: iface.get_attr("IFLA_IFNAME") for iface in interfaces}
-
-        # Get metrics for each interface from routes
-        metric_index_list = [
-            {"metric": route.get_attr("RTA_PRIORITY", 0), "index": route.get_attr("RTA_OIF")} for route in routes
-        ]
-
-        # Keep the highest metric per interface
-        metric_dict: Dict[int, int] = {}
-        for d in metric_index_list:
-            if d["index"] in metric_dict:
-                metric_dict[d["index"]] = max(metric_dict[d["index"]], d["metric"])
-            else:
-                metric_dict[d["index"]] = d["metric"]
-
-        # Create NetworkInterfaceMetric objects for each interface
-        result = []
-        for index, name in name_dict.items():
-            metric = NetworkInterfaceMetric(index=index, name=name, priority=metric_dict.get(index, 0))
-            result.append(metric)
-
-        return result
-
     # pylint: disable=too-many-nested-blocks
     def set_interfaces_priority(self, interfaces: List[NetworkInterfaceMetricApi]) -> None:
         """Sets network interface priority using IPRoute.
@@ -148,58 +191,7 @@ class BookwormHandler(AbstractNetworkHandler):
             interfaces (List[NetworkInterfaceMetricApi]): A list of interfaces and their priority metrics,
                 sorted by priority to set.
         """
-        if not interfaces:
-            logger.info("No interfaces to set priority for")
-            return
-
-        # If there's only one interface and no priority specified, set it to highest priority (0)
-        if len(interfaces) == 1 and interfaces[0].priority is None:
-            interfaces[0].priority = 0
-
-        current_priority = 1000
-        for interface in interfaces:
-            try:
-                # Use specified priority or increment current_priority
-                priority = interface.priority if interface.priority is not None else current_priority
-
-                # Get interface index
-                interface_index = self.ipr.link_lookup(ifname=interface.name)[0]
-
-                # Get all routes for this interface
-                routes = self.ipr.get_routes(oif=interface_index, family=socket.AF_INET)
-
-                # Update existing routes
-                for route in routes:
-                    try:
-                        route_data = {"priority": priority}
-
-                        # Copy existing route attributes
-                        for attr in ["RTA_DST", "RTA_GATEWAY", "RTA_TABLE", "RTA_PREFSRC"]:
-                            value = route.get_attr(attr)
-                            if value:
-                                # Convert attribute name to lowercase and remove RTA_ prefix
-                                key = attr.lower().replace("rta_", "")
-                                route_data[key] = value
-
-                        # Update the route
-                        self.ipr.route(
-                            "replace",
-                            oif=interface_index,
-                            family=socket.AF_INET,
-                            scope=route["scope"],
-                            proto=route["proto"],
-                            type=route["type"],
-                            **route_data,
-                        )
-                        logger.info(f"Updated route for {interface.name} with priority {priority}")
-                    except Exception as e:
-                        logger.error(f"Failed to update route for {interface.name}: {e}")
-                        continue
-
-                current_priority += 1000
-            except Exception as e:
-                logger.error(f"Failed to set priority for interface {interface.name}: {e}")
-                continue
+        self.set_interfaces_priority_using_ipr(interfaces)
 
     def _get_dhcp_address_using_dhclient(self, interface_name: str) -> str | None:
         """Run dhclient to get a new IP address and return it.
@@ -275,7 +267,6 @@ class DHCPCD(AbstractNetworkHandler):
     dhcpcd_conf_start_string = "#blueos-interface-priority-start"
     dhcpcd_conf_end_string = "#blueos-interface-priority-end"
     # https://man.archlinux.org/man/dhcpcd.conf.5#metric
-    default_dhcpdc_metric = 1000
 
     def detect(self) -> bool:
         return os.path.isfile("/etc/dhcpcd.conf")
@@ -311,42 +302,6 @@ class DHCPCD(AbstractNetworkHandler):
         except Exception as exception:
             logger.warning(f"Failed to read {self.dhcpcd_conf_path}, error: {exception}")
             return []
-
-    def get_interfaces_priority(self) -> List[NetworkInterfaceMetric]:
-        """Parses dhcpcd config file to get network interface priorities.
-        Goes through the dhcpcd config file line by line looking for "interface"
-        and "metric" lines. Extracts the interface name and metric value. The
-        metric is used as the priority, with lower being better.
-
-        List[NetworkInterfaceMetric]: A list of priority metrics for each interface.
-        """
-        lines = self._get_service_dhcpcd_content()
-        result = []
-        current_interface = None
-        current_metric = None
-        for line in lines:
-            if line.startswith("interface"):
-                if current_interface is not None and current_metric is not None:  # type: ignore[unreachable]
-                    # Metric is inverted compared to priority, lowest metric wins
-                    result.append(NetworkInterfaceMetric(index=0, name=current_interface, priority=current_metric))  # type: ignore[unreachable]
-
-                current_interface = line.split()[1]
-                current_metric = None
-
-            elif line.startswith("metric") and current_interface is not None:
-                try:
-                    current_metric = int(line.split()[1])
-                except Exception as exception:
-                    logger.error(
-                        f"Failed to parse {current_interface} metric, error: {exception}, line: {line}, using default metric"
-                    )
-                    current_metric = self.default_dhcpdc_metric
-
-        # Add the last entry to the result_list
-        if current_interface is not None and current_metric is not None:
-            result.append(NetworkInterfaceMetric(index=0, name=current_interface, priority=current_metric))
-
-        return result
 
     def _remove_dhcpcd_configuration(self) -> None:
         """Removes the network priority configuration added by this service from
@@ -427,7 +382,8 @@ class DHCPCD(AbstractNetworkHandler):
             interfaces (List[NetworkInterfaceMetricApi]): A list of interfaces and their priority metrics.
         """
 
-        # Note: With DHCPCD, lower priority wins!
+        self.set_interfaces_priority_using_ipr(interfaces)
+
         self._remove_dhcpcd_configuration()
 
         # Update interfaces priority if possible
@@ -435,11 +391,7 @@ class DHCPCD(AbstractNetworkHandler):
             logger.info("Cant change network priority from empty list.")
             return
 
-        # If there is a single interface without metric, make it the highest priority
-        if len(interfaces) == 1 and interfaces[0].priority is None:
-            interfaces[0].priority = 0
-
-        current_priority = interfaces[0].priority or self.default_dhcpdc_metric
+        current_priority = interfaces[0].priority
         lines = []
         lines.append(f"{self.dhcpcd_conf_start_string}\n")
         for interface in interfaces:

--- a/core/services/cable_guy/typedefs.py
+++ b/core/services/cable_guy/typedefs.py
@@ -31,6 +31,7 @@ class NetworkInterface(BaseModel):
     name: str
     addresses: List[InterfaceAddress]
     info: Optional[InterfaceInfo]
+    priority: Optional[int]
 
     def __hash__(self) -> int:
         return hash(self.name) + sum(hash(address) for address in self.addresses)
@@ -44,4 +45,4 @@ class NetworkInterfaceMetric(BaseModel):
 
 class NetworkInterfaceMetricApi(BaseModel):
     name: str
-    priority: Optional[int]
+    priority: int


### PR DESCRIPTION
to test the routing, use `watch ip route`, then change it in the UI.

this is now also always using the settings file as a source of truth, instead of randomly accepting the current state and saving it to the settings file.

fix #3086 

tested on bookworm and bullseye

## Summary by Sourcery

Fix interface priority issues on Debian Bookworm.

Bug Fixes:
- Fix priority changing on Bookworm.

Enhancements:
- Always use the settings file as the source of truth for network configuration, rather than randomly accepting the current state and saving it.

Tests:
- Tested on Bookworm, needs testing on Bullseye.