### PR TITLE
core: tools: nginx: Add cache path

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -24,6 +24,9 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Cache
+    proxy_cache_path /var/cache/nginx keys_zone=ourcache:10m levels=1:2 max_size=1g inactive=30d;
+
     ##
     # Logging Settings
     ##
@@ -51,6 +54,16 @@ http {
         # It will always return an empty 204 response when online.
         location = /status {
             return 204;
+        }
+
+        location ~ ^/cache/(.*) {
+            resolver 8.8.8.8 ipv6=off;
+            set $target $1;
+            proxy_cache ourcache;
+            proxy_cache_valid 200 30d;
+            proxy_cache_revalidate on;
+            proxy_cache_use_stale error timeout invalid_header http_500 http_502 http_503 http_504;
+            proxy_pass https://$target;
         }
 
         location /ardupilot-manager/ {


### PR DESCRIPTION
With that, any path that returns a resource can be accessed via the cache path.
Tested with:
- http://192.168.2.2/cache/keanu-reeves.org/wp/wp-content/uploads/2024/05/Keanu-Reeves-Kirsten-Stewart-and-800x400.jpg
- http://192.168.2.2/cache/firmware.ardupilot.org/manifest.json