### PR TITLE
Overwrite /etc/resolv.conf.host if it exists

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -253,7 +253,7 @@ echo "Restarting random-seeds."
 rm -rf /var/lib/systemd/random-seed /loader/random-seed
 
 echo "creating dns link"
-sudo ln /etc/resolv.conf /etc/resolv.conf.host
+sudo ln --force /etc/resolv.conf /etc/resolv.conf.host
 
 echo "Installation finished successfully."
 echo "You can access after the reboot:"


### PR DESCRIPTION
This prevents the install script from crashing if run on an existing blueos machine.