### PR TITLE
frontend: BrIframe: Allow extensions to perform operations with the clipboard

### DIFF
--- a/core/frontend/src/components/utils/BrIframe.vue
+++ b/core/frontend/src/components/utils/BrIframe.vue
@@ -20,6 +20,7 @@
       height="100%"
       width="100%"
       frameBorder="0"
+      allow="clipboard-read; clipboard-write"
       allowfullscreen
       @load="loadFinished"
     />


### PR DESCRIPTION
Today, extensions do not have allowance to read from or write to the clipboard.