### PR TITLE
VersionChooser: Allow login for docker daemon by version chooser interface

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -38,6 +38,14 @@
                 "bind": "/home/pi/.ssh",
                 "mode": "rw"
             },
+            "/home/pi/.docker": {
+                "bind": "/home/pi/.docker",
+                "mode": "rw"
+            },
+            "/root/.docker": {
+                "bind": "/root/.docker",
+                "mode": "rw"
+            },
             "/etc/blueos": {
                 "bind": "/etc/blueos",
                 "mode": "rw"

--- a/core/frontend/src/components/version-chooser/DockerLogin.vue
+++ b/core/frontend/src/components/version-chooser/DockerLogin.vue
@@ -1,0 +1,266 @@
+<template>
+  <v-card>
+    <v-card-subtitle class="text-center pt-6">
+      Log in using your Docker Hub credentials to access private repositories
+      and benefit from an increased rate limit.
+    </v-card-subtitle>
+
+    <SpinningLogo
+      v-if="op_loading"
+      size="100px"
+      :subtitle="op_description"
+    />
+    <div v-else>
+      <v-tabs
+        v-model="tab"
+        fixed-tabs
+        @change="onTabChange"
+      >
+        <v-tab key="0" href="#0" class="tab-text">
+          <v-icon class="mr-3">
+            mdi-login
+          </v-icon>
+          Login
+        </v-tab>
+        <v-tab key="1" href="#1" class="tab-text">
+          <v-icon class="mr-3">
+            mdi-account
+          </v-icon>
+          Accounts
+        </v-tab>
+      </v-tabs>
+      <v-card-text v-if="is_login_tab">
+        <div class="d-flex justify-space-around">
+          <v-switch
+            v-model="log_in_info.root"
+            label="Login root user"
+            class="pb-3"
+          />
+          <v-switch
+            v-model="use_custom_registry"
+            label="Custom registry"
+            class="pb-3"
+          />
+        </div>
+
+        <v-text-field
+          v-if="use_custom_registry"
+          v-model="log_in_info.registry"
+          class="pb-3"
+          label="Custom Registry"
+          outlined
+          hide-details
+        />
+
+        <v-text-field
+          v-model="log_in_info.username"
+          class="pb-3"
+          label="Docker Username"
+          outlined
+          hide-details
+        />
+
+        <v-text-field
+          v-model="log_in_info.password"
+          label="Docker Password or PAT"
+          type="password"
+          outlined
+          hide-details
+        />
+      </v-card-text>
+      <v-card-text v-if="is_accounts_tab">
+        <v-list
+          v-if="has_some_account"
+        >
+          <v-list-item
+            v-for="account in accounts"
+            :key="account.username"
+          >
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ account.username }}
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                {{ account.registry }}
+              </v-list-item-subtitle>
+            </v-list-item-content>
+            <div v-if="account.root">
+              <v-tooltip bottom>
+                <template #activator="{ on }">
+                  <v-icon v-on="on">
+                    mdi-shield-account
+                  </v-icon>
+                </template>
+                <span>Used by root user</span>
+              </v-tooltip>
+            </div>
+            <v-list-item-action>
+              <v-btn
+                icon
+                @click="logout(account.username, account.registry)"
+              >
+                <v-icon>mdi-logout</v-icon>
+              </v-btn>
+            </v-list-item-action>
+          </v-list-item>
+        </v-list>
+        <v-card-subtitle
+          v-else
+          class="text-center pt-6"
+        >
+          No connected accounts
+        </v-card-subtitle>
+      </v-card-text>
+    </div>
+    <v-alert
+      v-if="has_error"
+      class="mx-4"
+      type="error"
+    >
+      {{ op_error }}
+    </v-alert>
+    <v-alert
+      v-if="has_success"
+      class="mx-4"
+      type="success"
+    >
+      {{ op_success }}
+    </v-alert>
+    <v-card-actions class="justify-center pb-4">
+      <v-btn
+        color="primary"
+        @click="$emit('cancel')"
+      >
+        Cancel
+      </v-btn>
+      <v-spacer />
+      <v-btn
+        color="success"
+        @click="login"
+      >
+        Login
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import SpinningLogo from '@/components/common/SpinningLogo.vue'
+import { DockerLoginInfo } from '@/types/version-chooser'
+import { dockerAccounts, dockerLogin, dockerLogout } from '@/utils/version_chooser'
+
+const DEFAULT_DOCKER_REGISTRY = 'https://index.docker.io/v1/'
+
+const DEFAULT_LOG_IN_INFO = {
+  root: false,
+  registry: DEFAULT_DOCKER_REGISTRY,
+  username: '',
+  password: '',
+} as DockerLoginInfo
+
+export default Vue.extend({
+  name: 'VersionCard',
+  components: {
+    SpinningLogo,
+  },
+  data() {
+    return {
+      tab: '0',
+
+      log_in_info: { ...DEFAULT_LOG_IN_INFO },
+      use_custom_registry: false,
+
+      accounts: [] as DockerLoginInfo[],
+
+      op_loading: false,
+      op_description: '',
+      op_error: undefined as string | undefined,
+      op_success: undefined as string | undefined,
+    }
+  },
+  computed: {
+    has_error(): boolean {
+      return this.op_error !== undefined
+    },
+    has_success(): boolean {
+      return this.op_success !== undefined
+    },
+    has_some_account(): boolean {
+      return this.accounts.length > 0
+    },
+    is_login_tab(): boolean {
+      return this.tab === '0'
+    },
+    is_accounts_tab(): boolean {
+      return this.tab === '1'
+    },
+  },
+  async mounted() {
+    await this.fetchAccounts()
+  },
+  methods: {
+    cleanAlerts() {
+      this.op_error = undefined
+      this.op_success = undefined
+    },
+    prepareOperation(description: string) {
+      this.op_error = undefined
+      this.op_success = undefined
+      this.op_loading = true
+      this.op_description = description
+    },
+    resetInput() {
+      this.log_in_info = { ...DEFAULT_LOG_IN_INFO }
+      this.use_custom_registry = false
+    },
+    async onTabChange() {
+      this.cleanAlerts()
+      await this.fetchAccounts()
+    },
+    async login() {
+      this.prepareOperation('Logging in to Docker Hub...')
+
+      try {
+        await dockerLogin(this.log_in_info)
+
+        this.resetInput()
+        this.op_success = 'Successfully added account in Docker Daemon.'
+      } catch (op_error) {
+        this.op_error = String(op_error ?? 'Failed to login to Docker Hub.')
+      } finally {
+        this.op_loading = false
+      }
+    },
+    async logout(username: string, registry?: string) {
+      this.prepareOperation('Logging out from Docker Hub...')
+
+      try {
+        const data = {
+          username,
+          registry,
+        } as DockerLoginInfo
+
+        await dockerLogout(data)
+        await this.fetchAccounts()
+      } catch (op_error) {
+        this.op_error = String(op_error ?? 'Failed to logout to Docker Hub.')
+      } finally {
+        this.op_loading = false
+      }
+    },
+    async fetchAccounts() {
+      this.prepareOperation('Fetching connected accounts...')
+
+      try {
+        this.accounts = await dockerAccounts()
+      } catch (op_error) {
+        this.op_error = String(op_error ?? 'Failed to list connected accounts.')
+      } finally {
+        this.op_loading = false
+      }
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -4,6 +4,14 @@
       max-width="1000"
       class="mx-auto"
     >
+      <v-dialog
+        v-model="show_docker_login_dialog"
+        max-width="450"
+      >
+        <DockerLogin
+          @cancel="show_docker_login_dialog = false"
+        />
+      </v-dialog>
       <v-card
         v-if="!settings.is_pirate_mode"
         max-width="900"
@@ -77,7 +85,15 @@
         max-width="900"
         class="mx-auto my-12 pa-4"
       >
-        <h2>Remote Versions</h2>
+        <div class="d-flex justify-space-between pb-3">
+          <h2>Remote Versions</h2>
+          <v-btn
+            color="primary"
+            @click="show_docker_login_dialog = true"
+          >
+            Docker Login
+          </v-btn>
+        </div>
         <v-form
           @submit.prevent="loadVersions()"
         >
@@ -211,6 +227,7 @@ import PullTracker from '@/utils/pull_tracker'
 import * as VCU from '@/utils/version_chooser'
 
 import SpinningLogo from '../common/SpinningLogo.vue'
+import DockerLogin from './DockerLogin.vue'
 import VersionCard from './VersionCard.vue'
 
 const notifier = new Notifier(version_chooser_service)
@@ -218,6 +235,7 @@ const notifier = new Notifier(version_chooser_service)
 export default Vue.extend({
   name: 'VersionChooser',
   components: {
+    DockerLogin,
     SpinningLogo,
     VersionCard,
     PullProgress,
@@ -257,6 +275,7 @@ export default Vue.extend({
       selected_image: default_repository,
       deleting: '', // image currently being deleted, if any
       file_input_error: '',
+      show_docker_login_dialog: false,
     }
   },
   computed: {

--- a/core/frontend/src/types/version-chooser.ts
+++ b/core/frontend/src/types/version-chooser.ts
@@ -31,6 +31,13 @@ export interface ServerResponse {
   type: string,
 }
 
+export interface DockerLoginInfo {
+  root?: boolean
+  registry?: string
+  username: string
+  password?: string
+}
+
 export function isServerResponse(response: unknown): response is ServerResponse {
   // eslint-disable-next-line no-extra-parens
   return (response as ServerResponse).status !== undefined

--- a/core/frontend/src/utils/version_chooser.ts
+++ b/core/frontend/src/utils/version_chooser.ts
@@ -3,6 +3,7 @@ import { gt as sem_ver_greater, SemVer } from 'semver'
 import Notifier from '@/libs/notifier'
 import { version_chooser_service } from '@/types/frontend_services'
 import {
+  DockerLoginInfo,
   LocalVersionsQuery, Version, VersionsQuery, VersionType,
 } from '@/types/version-chooser'
 import back_axios from '@/utils/api'
@@ -173,8 +174,36 @@ async function loadBootstrapCurrentVersion(): Promise<string | undefined> {
     })
 }
 
+async function dockerLogin(info: DockerLoginInfo): Promise<void> {
+  await back_axios({
+    method: 'post',
+    url: `${API_URL}/docker/login/`,
+    data: info,
+  })
+}
+
+async function dockerLogout(info: DockerLoginInfo): Promise<void> {
+  await back_axios({
+    method: 'post',
+    url: `${API_URL}/docker/logout/`,
+    data: info,
+  })
+}
+
+async function dockerAccounts(): Promise<DockerLoginInfo[]> {
+  const data = await back_axios({
+    method: 'get',
+    url: `${API_URL}/docker/accounts/`,
+  })
+
+  return data.data as DockerLoginInfo[]
+}
+
 export {
   DEFAULT_REMOTE_IMAGE,
+  dockerAccounts,
+  dockerLogin,
+  dockerLogout,
   fixVersion,
   getLatestBeta,
   getLatestStable,

--- a/core/services/versionchooser/docker_login.py
+++ b/core/services/versionchooser/docker_login.py
@@ -1,0 +1,120 @@
+import base64
+import json
+import os
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List
+
+from aiohttp import web
+
+DOCKER_USER_CONFIG_DIR = "/home/pi/.docker"
+DOCKER_ROOT_CONFIG_DIR = "/root/.docker"
+
+DOCKER_USER_CONFIG_FILE = os.path.join(DOCKER_USER_CONFIG_DIR, "config.json")
+DOCKER_ROOT_CONFIG_FILE = os.path.join(DOCKER_ROOT_CONFIG_DIR, "config.json")
+
+DEFAULT_DOCKER_REGISTRY = "https://index.docker.io/v1/"
+
+
+@dataclass
+class DockerLoginInfo:
+    root: bool = True
+    registry: str = DEFAULT_DOCKER_REGISTRY
+    username: str = ""
+    password: str = ""
+
+    @staticmethod
+    def from_json(data: Dict[str, Any]) -> "DockerLoginInfo":
+        return DockerLoginInfo(
+            root=data.get("root", True),
+            registry=data.get("registry", DEFAULT_DOCKER_REGISTRY),
+            username=data.get("username", ""),
+            password=data.get("password", ""),
+        )
+
+
+def get_accounts_from_file(file_path: str, root: bool) -> List[DockerLoginInfo]:
+    if not os.path.exists(file_path):
+        return []
+
+    with open(file_path, "r", encoding="utf-8") as file:
+        config = json.load(file)
+
+    login_infos: List[DockerLoginInfo] = []
+
+    # Key is registry URL, value is a dict with key "auth" and the value is the auth info composed of a base64 encoded
+    # string with "username:password"
+    auths: Dict[str, Dict[str, str]] = config.get("auths", {})
+
+    for registry, data in auths.items():
+        auth = data.get("auth", None)
+        if auth is not None:
+            try:
+                decoded_auth = base64.b64decode(auth).decode("utf-8")
+                username, password = decoded_auth.split(":", 1)
+                login_infos.append(DockerLoginInfo(root=root, registry=registry, username=username, password=password))
+            except Exception:
+                pass
+
+    return login_infos
+
+
+def login_to_file(info: DockerLoginInfo, file_path: str) -> None:
+    # Make sure the directories exist
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+    if os.path.exists(file_path):
+        with open(file_path, "r", encoding="utf-8") as file:
+            config = json.load(file)
+    else:
+        config = {}
+
+    if "auths" not in config:
+        config["auths"] = {}
+
+    encoded_auth = base64.b64encode(f"{info.username}:{info.password}".encode("utf-8")).decode("utf-8")
+    config["auths"][info.registry] = {"auth": encoded_auth}
+
+    with open(file_path, "w", encoding="utf-8") as file:
+        json.dump(config, file, indent=4)
+
+
+def logout_from_file(info: DockerLoginInfo, file_path: str) -> None:
+    if not os.path.exists(file_path):
+        return
+
+    with open(file_path, "r", encoding="utf-8") as file:
+        config = json.load(file)
+
+    if "auths" not in config:
+        return
+
+    if info.registry in config["auths"]:
+        del config["auths"][info.registry]
+
+    with open(file_path, "w", encoding="utf-8") as file:
+        json.dump(config, file, indent=4)
+
+
+def get_docker_accounts() -> web.Response:
+    root_accounts = get_accounts_from_file(DOCKER_ROOT_CONFIG_FILE, True)
+    user_accounts = get_accounts_from_file(DOCKER_USER_CONFIG_FILE, False)
+
+    for account in root_accounts:
+        # If some root account with same registry and username is found in user accounts, remove it
+        user_accounts = [x for x in user_accounts if x.registry != account.registry or x.username != account.username]
+
+    accounts = root_accounts + user_accounts
+
+    return web.json_response([asdict(account) for account in accounts])
+
+
+def make_docker_login(info: DockerLoginInfo) -> None:
+    login_to_file(info, DOCKER_USER_CONFIG_FILE)
+
+    if info.root:
+        login_to_file(info, DOCKER_ROOT_CONFIG_FILE)
+
+
+def make_docker_logout(info: DockerLoginInfo) -> None:
+    logout_from_file(info, DOCKER_USER_CONFIG_FILE)
+    logout_from_file(info, DOCKER_ROOT_CONFIG_FILE)

--- a/core/services/versionchooser/main.py
+++ b/core/services/versionchooser/main.py
@@ -8,6 +8,12 @@ from aiohttp import web
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from loguru import logger
 
+from docker_login import (
+    DockerLoginInfo,
+    get_docker_accounts,
+    make_docker_login,
+    make_docker_logout,
+)
 from utils.chooser import STATIC_FOLDER, VersionChooser
 
 SERVICE_NAME = "version-chooser"
@@ -74,6 +80,24 @@ async def load(request: web.Request) -> Any:
 
 async def restart() -> Any:
     return await versionChooser.restart()
+
+
+async def docker_login(request: web.Request) -> None:
+    data = await request.json()
+    info = DockerLoginInfo.from_json(data)
+
+    return make_docker_login(info)
+
+
+async def docker_logout(request: web.Request) -> Any:
+    data = await request.json()
+    info = DockerLoginInfo.from_json(data)
+
+    return make_docker_logout(info)
+
+
+def docker_accounts() -> Any:
+    return get_docker_accounts()
 
 
 if __name__ == "__main__":

--- a/core/services/versionchooser/openapi/versionchooser.yaml
+++ b/core/services/versionchooser/openapi/versionchooser.yaml
@@ -194,6 +194,51 @@ paths:
               type: string
               format: binary
 
+  /docker/login/:
+    post:
+      operationId: main.docker_login
+      summary: Login Docker daemon to a registry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DockerLoginInfo'
+      responses:
+        '200':
+          description: Successfully logged in
+
+  /docker/logout/:
+    post:
+      operationId: main.docker_logout
+      summary: Logout Docker daemon from a registry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DockerLoginInfo'
+      responses:
+        '200':
+          description: Successfully logged out
+
+  /docker/accounts/:
+    get:
+      operationId: main.docker_accounts
+      summary: Get the list of accounts logged in
+      responses:
+        '200':
+          description: List of accounts logged in
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accounts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DockerLoginInfo'
+
 components:
   schemas:
     Version:
@@ -205,3 +250,21 @@ components:
         tag:
           type: string
           example: master
+
+    DockerLoginInfo:
+      type: object
+      properties:
+        username:
+          type: string
+          example: username
+        password:
+          type: string
+          example: password
+        registry:
+          type: string
+          example: "https://index.docker.io/v1/"
+        root:
+          type: boolean
+          example: true
+      required:
+        - username

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -31,6 +31,8 @@ DELTA_JSON = {
             "/etc/machine-id": {"bind": "/etc/machine-id", "mode": "ro"},
             "/etc/resolv.conf.host": {"bind": "/etc/resolv.conf.host", "mode": "ro"},
             "/home/pi/.ssh": {"bind": "/home/pi/.ssh", "mode": "rw"},
+            "/home/pi/.docker": {"bind": "/home/pi/.docker", "mode": "rw"},
+            "/root/.docker": {"bind": "/root/.docker", "mode": "rw"},
             "/run/udev": {"bind": "/run/udev", "mode": "ro"},
             "/sys/": {"bind": "/sys/", "mode": "rw"},
             "/usr/blueos/bin": {"bind": "/usr/blueos/bin", "mode": "rw"},


### PR DESCRIPTION
Allows users to perform a Docker login to the default Docker registry or custom registries using their Docker username and password or a Personal Access Token (PAT).

Effectively allows for the following:
* Mirrors the functionality of the `docker login` command.
* Saves credentials to `.docker/config.json` for both the normal user and the root user (if specified).
* Affects the entire Docker daemon context, enabling all BlueOS services to fetch images or other resources from the authenticated registry.

To access users must be in `pirate mode` on the version chooser page:
![image](https://github.com/user-attachments/assets/4d069254-b357-4910-8183-c9de7f1bca93)

---

By default, the dialog logs in using only the normal Raspberry Pi user (not root) and the default Docker registry (`https://index.docker.io/v1/`). 

If needed, users can:
- Authenticate to a custom registry by enabling the **Custom Registry** switch.
- Use the authentication for `sudo docker` commands by enabling the **Login as Root User** switch. 

![image](https://github.com/user-attachments/assets/25783fde-959f-48e3-bd82-244df7f4c0a7)

Connected accounts can be seen at the accounts tab. Ones with the `shield` icon means that the credentials are valid for `sudo docker` commands.

![image](https://github.com/user-attachments/assets/c2cb6da2-76a3-450d-89fd-efa0f7d82261)

Validation:

* Trying to pull private repository without login:
![image_2025-01-28_15-53-12](https://github.com/user-attachments/assets/fe0e0277-bdce-4f73-abad-fd80f2344e3e)
* Trying to pull private repository after performing login:
![image](https://github.com/user-attachments/assets/d91026de-cefb-473a-9cb5-6004ddee2cf0)

---

NOTE: This PR does not includes the *on login* authentication check, and does not allows users to test their credentials to check if they still valid. A following PR will add the check, probably matching the [auth](https://docs.docker.com/reference/api/engine/version/v1.39/#tag/System/operation/SystemAuth) endpoint docs.