### PR TITLE
frontend: InlineParameterEditor: populate parameter value when mounting

### DIFF
--- a/core/frontend/src/components/parameter-editor/InlineParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/InlineParameterEditor.vue
@@ -306,6 +306,9 @@ export default Vue.extend({
           .map((value) => parseFloat(value))
           .includes(this.internal_new_value)
       }
+      if (this.param?.value) {
+        this.internal_new_value_as_string = this.internal_new_value.toString()
+      }
 
       this.saveEditedParam()
       if (!this.is_form_valid) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix an issue where the parameter value was not populated when the component was mounted.