### PR TITLE
core: services: ardupilot_manager: mavlink-server: Remove tlog endpoint

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -1,6 +1,5 @@
 import re
 import subprocess
-from datetime import datetime
 from typing import Optional
 
 from mavlink_proxy.AbstractRouter import AbstractRouter
@@ -38,11 +37,7 @@ class MAVLinkServer(AbstractRouter):
                 return f"zenoh:{endpoint.place}:{endpoint.argument}"
             raise ValueError(f"Endpoint of type {endpoint.connection_type} not supported on MAVLink-Server.")
 
-        # MAVlink-Server takes direct file paths as endpoints, so we generate a timestamped file path
-        now = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        logging_endpoint = f"tlogwriter:/root/.config/ardupilot-manager/firmware/logs/mavlink-server-{now}.tlog"
-        str_endpoints = [convert_endpoint(endpoint) for endpoint in [master_endpoint, *self.endpoints()]]
-        endpoints = " ".join([*str_endpoints, logging_endpoint])
+        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in [master_endpoint, *self.endpoints()]])
 
         return f"{self.binary()} {endpoints}"
 


### PR DESCRIPTION
We should only log when the vehicle is armed
https://github.com/bluerobotics/mavlink-server/issues/42