### PR TITLE
cable-guy: make load() return False on errors

### DIFF
--- a/core/services/cable_guy/api/settings.py
+++ b/core/services/cable_guy/api/settings.py
@@ -44,6 +44,7 @@ class Settings:
         except Exception as exception:
             logger.warning(f"Failed to fetch data from file ({self.settings_file}): {exception}")
             logger.warning(data)
+            return False
 
         return True
 


### PR DESCRIPTION
load() was returning True on errors...

## Summary by Sourcery

Bug Fixes:
- Fix an issue where `load()` was returning True on errors.