### PR TITLE
core: tools: machineid: Update to latest version

### DIFF
--- a/core/tools/machineid/bootstrap.sh
+++ b/core/tools/machineid/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.2.2"
+VERSION="0.2.3"
 REPOSITORY_ORG="patrickelectric"
 REPOSITORY_NAME="machineid-cli"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
Fix a bug when using the default network card to get the mac address

## Summary by Sourcery

Chores:
- Upgrade the machineid-cli dependency to 0.2.3.