### PR TITLE
Fix parameters showing only when opening ParameterLoader for the second time

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -33,6 +33,7 @@
         </v-row>
         <!-- display all parameters in a concise table using virtual scroller -->
         <v-virtual-scroll
+          :bench="100"
           :items="parametersFromSet(different_param_set)"
           :item-height="30"
           class="virtual-table"

--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -34,7 +34,7 @@
         <!-- display all parameters in a concise table using virtual scroller -->
         <v-virtual-scroll
           :items="parametersFromSet(different_param_set)"
-          item-height="30"
+          :item-height="30"
           class="virtual-table"
           disabled
         >

--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -9,7 +9,7 @@
       <v-card-title class="pt-6">
         Loading Parameters
       </v-card-title>
-      <v-card-text v-if="Object.keys(different_param_set).length !== 0" height="80%">
+      <v-card-text v-if="different_param_set_length !== 0" height="80%">
         <v-row class="virtual-table-row">
           <v-col class="virtual-table-cell checkbox-cell">
             <v-checkbox

--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -36,8 +36,7 @@
           :bench="100"
           :items="parametersFromSet(different_param_set)"
           :item-height="30"
-          class="virtual-table"
-          disabled
+          :max-height="500"
         >
           <template #default="{ item }">
             <v-row class="virtual-table-row">


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

## Summary by Sourcery

Bug Fixes:
- Fix an issue where parameters were not displayed when opening the ParameterLoader for the first time.