### PR TITLE
Add "Backup DHCP Server" option to only enable the server if another one isnt found at startup

### DIFF
--- a/core/frontend/src/components/ethernet/DHCPServerDialog.vue
+++ b/core/frontend/src/components/ethernet/DHCPServerDialog.vue
@@ -139,7 +139,11 @@ export default Vue.extend({
         method: 'post',
         url: `${ethernet.API_URL}/dhcp`,
         timeout: 10000,
-        params: { interface_name: this.adapter.name, ipv4_gateway: this.selected_ip, is_backup_server: this.is_backup_server },
+        params: {
+          interface_name: this.adapter.name,
+          ipv4_gateway: this.selected_ip,
+          is_backup_server: this.is_backup_server,
+        },
       })
         .then(() => {
           this.creation_status = ServerCreationStatus.Succeeded

--- a/core/frontend/src/components/ethernet/DHCPServerDialog.vue
+++ b/core/frontend/src/components/ethernet/DHCPServerDialog.vue
@@ -17,6 +17,10 @@
           label="Server Gateway"
         />
 
+        <v-checkbox
+          v-model="is_backup_server"
+          label="Backup Server"
+        />
         <v-btn
           :disabled="!allow_enabling"
           color="primary"
@@ -86,6 +90,7 @@ export default Vue.extend({
       creation_status: ServerCreationStatus.NotStarted,
       connection_result_message: '',
       selected_ip: '',
+      is_backup_server: false,
     }
   },
   computed: {
@@ -134,7 +139,7 @@ export default Vue.extend({
         method: 'post',
         url: `${ethernet.API_URL}/dhcp`,
         timeout: 10000,
-        params: { interface_name: this.adapter.name, ipv4_gateway: this.selected_ip },
+        params: { interface_name: this.adapter.name, ipv4_gateway: this.selected_ip, is_backup_server: this.is_backup_server },
       })
         .then(() => {
           this.creation_status = ServerCreationStatus.Succeeded

--- a/core/frontend/src/components/ethernet/InterfaceCard.vue
+++ b/core/frontend/src/components/ethernet/InterfaceCard.vue
@@ -136,7 +136,7 @@ export default Vue.extend({
       return this.is_connected ? 'Connected' : 'Not connected'
     },
     is_there_dhcp_server_already(): boolean {
-      return this.adapter.addresses.some((address) => address.mode === AddressMode.server)
+      return this.adapter.addresses.some((address) => [AddressMode.server, AddressMode.backupServer].includes(address.mode))
     },
     is_static_ip_present(): boolean {
       return this.adapter.addresses.some((address) => address.mode === AddressMode.unmanaged)
@@ -190,6 +190,7 @@ export default Vue.extend({
         case AddressMode.client: return 'Dynamic IP'
         case AddressMode.server: return 'DHCP Server'
         case AddressMode.unmanaged: return 'Static IP'
+        case AddressMode.backupServer: return 'Backup DHCP Server'
         default: return 'Undefined mode'
       }
     },

--- a/core/frontend/src/components/ethernet/InterfaceCard.vue
+++ b/core/frontend/src/components/ethernet/InterfaceCard.vue
@@ -136,7 +136,9 @@ export default Vue.extend({
       return this.is_connected ? 'Connected' : 'Not connected'
     },
     is_there_dhcp_server_already(): boolean {
-      return this.adapter.addresses.some((address) => [AddressMode.server, AddressMode.backupServer].includes(address.mode))
+      return this.adapter.addresses.some(
+        (address) => [AddressMode.server, AddressMode.backupServer].includes(address.mode),
+      )
     },
     is_static_ip_present(): boolean {
       return this.adapter.addresses.some((address) => address.mode === AddressMode.unmanaged)

--- a/core/frontend/src/types/ethernet.ts
+++ b/core/frontend/src/types/ethernet.ts
@@ -1,6 +1,7 @@
 export enum AddressMode {
     client = 'client',
     server = 'server',
+    backupServer = 'backup_server',
     unmanaged = 'unmanaged',
 }
 

--- a/core/libs/commonwealth/commonwealth/utils/DHCPDiscovery.py
+++ b/core/libs/commonwealth/commonwealth/utils/DHCPDiscovery.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import asyncio
+import re
+import sys
+from typing import List
+
+from loguru import logger
+
+
+class DHCPDiscoveryError(Exception):
+    """Base exception for DHCP discovery errors"""
+
+
+async def discover_dhcp_servers(iface: str, timeout: int = 15) -> List[str]:
+    """
+    Discover DHCP servers on the network using nmap's DHCP discovery script
+
+    Args:
+        interface: Network interface to use
+        timeout: Time to wait for responses in seconds
+
+    Returns:
+        List of DHCP server IP addresses found
+
+    Raises:
+        DHCPDiscoveryError: If discovery fails
+    """
+    try:
+        # Run nmap with DHCP discovery script
+        cmd = [
+            "sudo",  # Need root privileges
+            "nmap",
+            "--script",
+            "broadcast-dhcp-discover",
+            "-e",
+            iface,  # Specify interface
+            "--script-timeout",
+            f"{timeout}s",
+        ]
+
+        # Run nmap asynchronously
+        logger.info(f"Running nmap command: {' '.join(cmd)}")
+        process = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+
+        stdout, stderr = await process.communicate()
+        output = stdout.decode()
+        error = stderr.decode()
+
+        if process.returncode != 0:
+            logger.info(f"nmap output: {output}")
+            logger.info(f"nmap error: {error}")
+            raise DHCPDiscoveryError(f"nmap failed: {error}")
+
+        # Parse nmap output for DHCP servers
+        servers = []
+
+        # Look for Server Identifier or DHCP Server lines
+        server_pattern = r"Server(?:\s+Identifier|\s*:)\s*(\d+\.\d+\.\d+\.\d+)"
+        for match in re.finditer(server_pattern, output):
+            server_ip = match.group(1)
+            if server_ip not in servers:
+                servers.append(server_ip)
+
+        return servers
+
+    except FileNotFoundError as e:
+        raise DHCPDiscoveryError("nmap is not installed. Please install nmap package.") from e
+    except Exception as e:
+        raise DHCPDiscoveryError(f"Failed to discover DHCP servers: {str(e)}") from e
+
+
+async def main() -> None:
+    """Main function for command line usage"""
+    interface_to_scan = sys.argv[1]
+
+    try:
+        servers = await discover_dhcp_servers(interface_to_scan)
+        if servers:
+            print(f"Found {len(servers)} DHCP server(s):")
+            for server in servers:
+                print(f"  {server}")
+        else:
+            print("No DHCP servers found.")
+    except DHCPDiscoveryError as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: sudo {sys.argv[0]} <interface>")
+        sys.exit(1)
+    asyncio.run(main())

--- a/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
+++ b/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
@@ -140,6 +140,10 @@ class Dnsmasq:
         return self._subprocess is not None and self._subprocess.poll() is None
 
     @property
+    def is_backup_server(self) -> bool:
+        return self._is_backup
+
+    @property
     def interface(self) -> str:
         return self._interface
 

--- a/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
+++ b/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
@@ -90,7 +90,6 @@ class Dnsmasq:
             f"--dhcp-option=option:router,{self._ipv4_gateway}",
             "--bind-interfaces",
             "--dhcp-option=option6:information-refresh-time,6h",
-            "--dhcp-authoritative",
             "--dhcp-rapid-commit",
             "--cache-size=1500",
             "--no-negcache",

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -386,6 +386,8 @@ class EthernetManager:
                     and self._dhcp_server_on_interface(interface).ipv4_gateway == ip
                 ):
                     mode = AddressMode.Server
+                    if self._dhcp_server_on_interface(interface).is_backup_server:
+                        mode = AddressMode.BackupServer
                 else:
                     mode = AddressMode.Unmanaged if is_static_ip and valid_ip else AddressMode.Client
                 valid_addresses.append(InterfaceAddress(ip=ip, mode=mode))

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -114,7 +114,7 @@ def delete_address(interface_name: str, ip_address: str) -> Any:
 
 @app.post("/dhcp", summary="Add local DHCP server to interface.")
 @version(1, 0)
-def add_dhcp_server(interface_name: str, ipv4_gateway: str, is_backup_server: bool = False) -> Any:
+async def add_dhcp_server(interface_name: str, ipv4_gateway: str, is_backup_server: bool = False) -> Any:
     """REST API endpoint to enable/disable local DHCP server."""
     manager.add_dhcp_server_to_interface(interface_name, ipv4_gateway, is_backup_server)
     manager.save()

--- a/core/services/cable_guy/typedefs.py
+++ b/core/services/cable_guy/typedefs.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 class AddressMode(str, Enum):
     Client = "client"
+    BackupServer = "backup_server"
     Server = "server"
     Unmanaged = "unmanaged"
 

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -18,4 +18,4 @@ parallel --halt now,fail=1 '/home/pi/tools/{}/bootstrap.sh' ::: "${TOOLS[@]}"
 # Tools that uses apt to do the installation
 # APT is terrible like pip and don't know how to handle parallel installation
 # These should periodically be moved onto the base image
-apt update && apt install -y --no-install-recommends dhcpcd5 iptables iproute2 isc-dhcp-client
+apt update && apt install -y --no-install-recommends dhcpcd5 iptables iproute2 isc-dhcp-client nmap


### PR DESCRIPTION
fix #3143 

needs testing

## Summary by Sourcery

Adds a "Backup DHCP Server" option that only enables the DHCP server if another one isn't found at startup. This prevents conflicts when multiple DHCP servers are running on the same network.

New Features:
- Adds a "Backup DHCP Server" option to the DHCP server configuration, which only enables the server if no other DHCP server is detected on the network at startup.
- Adds a checkbox in the frontend to enable the "Backup DHCP Server" option.
- Adds a new AddressMode for "backupServer" to distinguish backup DHCP servers from regular ones.

Tests:
- Adds nmap to the list of system tools to install, which is used to detect other DHCP servers on the network.