### PR TITLE
PwmSetup:: add servoToHighlight function and map for handling newer ardusub version functions in highlighting

### DIFF
--- a/core/frontend/src/components/vehiclesetup/PwmSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/PwmSetup.vue
@@ -128,7 +128,7 @@
                   v-for="(item, index) in servo_function_parameters"
                   :key="item.name"
                   style="cursor: pointer;"
-                  @mouseover="highlight = [stringToUserFriendlyText(printParam(item))]"
+                  @mouseover="highlight = [servoToHighlight(item)]"
                   @mouseleave="highlight = default_highlight"
                   @click="showParamEdit(item)"
                 >
@@ -425,6 +425,14 @@ export default Vue.extend({
       const percent = (value - 1500) / 10
       const left = percent < 0 ? 50 + percent : 50
       return `width: ${Math.abs(percent)}%; left: ${left}%; background-color: red`
+    },
+    servoToHighlight(param: Parameter): string {
+      const pretty_name = this.stringToUserFriendlyText(printParam(param))
+      // map for backwards compatibility
+      const map: Record<string, string> = {
+        Mount1Pitch: 'MountTilt',
+      }
+      return map[pretty_name] ?? pretty_name
     },
     showParamEdit(param: Parameter) {
       this.selected_param = param


### PR DESCRIPTION
Fix mount not highlighting in pwm setup view

## Summary by Sourcery

Improves the PWM setup view by ensuring the mount is highlighted and adding compatibility for newer ArduSub versions. This is achieved by introducing a `servoToHighlight` function and a mapping for handling function name differences.

Bug Fixes:
- Fixes an issue where the mount was not being highlighted in the PWM setup view.

Enhancements:
- Adds a mapping to handle newer ArduSub versions in highlighting, ensuring compatibility with older configurations.