### PR TITLE
vehicle-setup: disable calibrate button if vehicle has no position available

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
@@ -81,7 +81,7 @@
         <v-btn
           v-if="state !== states.CALIBRATING && state !== states.FAILED"
           color="primary"
-          :disabled="!compass_mask"
+          :disabled="!compass_mask || !coordinates"
           @click="calibrate()"
         >
           Calibrate

--- a/core/frontend/src/components/vehiclesetup/configuration/compass/LargeVehicleCompassCalibrator.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/LargeVehicleCompassCalibrator.vue
@@ -33,7 +33,7 @@
         <StatusTextWatcher :style="`display : ${status_type === 'error' ? 'block' : 'none'};`" />
       </v-card-text>
       <v-card-actions class="justify-center">
-        <v-btn color="primary" :disabled="calibrating || !compass_mask" @click="calibrate()">
+        <v-btn color="primary" :disabled="calibrating || !compass_mask || !coordinates" @click="calibrate()">
           Calibrate
         </v-btn>
         <reboot-button />


### PR DESCRIPTION
The reasoning here is that without a position, the WMM cannot be used, resulting in a worse calibration. This does NOT require a gps or dvl, there's a UI for setting a rough position estimate we can rely on.

## Summary by Sourcery

Enhancements:
- Disable the compass calibration button in the vehicle setup UI when the vehicle has no position available.