### PR TITLE
Frontend: Parameter Loader: show reboot button on failures

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -140,6 +140,7 @@
         >
           Write Parameters
         </v-btn>
+        <RebootButton v-if="error" />
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -149,12 +150,16 @@
 import Vue, { PropType } from 'vue'
 import { Dictionary } from 'vue-router'
 
+import RebootButton from '@/components/utils/RebootButton.vue'
 import mavlink2rest from '@/libs/MAVLink2Rest'
 import autopilot_data from '@/store/autopilot'
 import { printParamWithUnit } from '@/types/autopilot/parameter'
 
 export default Vue.extend({
   name: 'ParameterLoader',
+  components: {
+    RebootButton,
+  },
   props: {
     parameters: {
       type: Object as PropType<Dictionary<number>> | undefined,
@@ -251,6 +256,9 @@ export default Vue.extend({
     writeSelectedParams() {
       for (const [name, value] of Object.entries(this.user_selected_params)) {
         this.writeParam(name, value)
+        if (autopilot_data.parameter(name)?.rebootRequired) {
+          autopilot_data.setRebootRequired(true)
+        }
       }
     },
     writeParam(name: string, value: number) {


### PR DESCRIPTION
## Summary by Sourcery

This pull request adds a reboot button to the parameter loader dialog that is displayed when an error occurs during parameter loading. It also checks if a parameter requires a reboot after it is written and sets a flag to indicate that a reboot is required.

New Features:
- Adds a reboot button to the parameter loader dialog that is displayed when an error occurs during parameter loading.

Enhancements:
- The parameter loader now checks if a parameter requires a reboot after it is written and sets a flag to indicate that a reboot is required.