### PR TITLE
.github: workflows: create weekly submodule sync

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -1,0 +1,31 @@
+on:
+  schedule:
+    # Run at 11:11 (UTC) every Monday
+    - cron:  '11 11 * * 1'
+  # Allow running manually, from the Actions tab or through the GitHub HTTP API
+  workflow_dispatch:
+
+name: Sync Submodules
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Git submodule update
+      run: |
+        git submodule update --init --recursive --remote
+
+    - name: Commit update
+      run: |
+        git config --global user.name 'Git bot'
+        git config --global user.email 'bot@noreply.github.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        git commit -am "submodules: Updated references" && git push || echo "No changes to commit"


### PR DESCRIPTION
Copied from [our docs](https://github.com/bluerobotics/BlueOS-docs/blob/latest/.github/workflows/sync-submodules.yml), with the schedule changed from daily to weekly, and set to a time off the hour to [reduce the chance of delays](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule) (and because I like repeated numbers :-P).

Should help to avoid things like [the parameter descriptions and values getting outdated](https://discuss.bluerobotics.com/t/higher-current-power-sense-module/12027/20).

## Summary by Sourcery

CI:
- Adds a scheduled workflow to sync submodules weekly to avoid outdated references.