### PR TITLE
frontend: camera: allow setting gimbal servo to any channel

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/camera.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/camera.vue
@@ -21,7 +21,7 @@
             <v-select
               v-if="is_servo_type"
               v-model="mnt1_pitch_new_param"
-              :items="recommended_params"
+              :items="servo_params"
               :item-text="friendlyName"
               :item-value="'name'"
               label="Mount 1 Pitch Servo"
@@ -121,13 +121,6 @@ export default {
     }
   },
   computed: {
-    recommended_params(): Parameter[] {
-      // return parameters in servo_params that are on channel 9 and higher
-      return this.servo_params.filter((param) => {
-        const servoNumber = parseInt(param.name.replace('SERVO', '').split('_')[0], 10)
-        return servoNumber >= 9
-      })
-    },
     type_param(): Parameter | undefined {
       return autopilot_data.parameters.find((p) => p.name === 'MNT1_TYPE')
     },


### PR DESCRIPTION
Copying the #3165 change to the camera gimbal page, to [finish fixing #2510](https://github.com/bluerobotics/BlueOS/issues/2510#issuecomment-2546206203).

## Summary by Sourcery

Enhancements:
- Allows setting the camera gimbal servo to any available channel, instead of being limited to channels 9 and higher.