### PR TITLE
core:frontend:BackAlley: Add try fetch again

### DIFF
--- a/core/frontend/src/components/kraken/BackAlleyTab.vue
+++ b/core/frontend/src/components/kraken/BackAlleyTab.vue
@@ -238,6 +238,12 @@
           <v-card-title class="mb-5">
             {{ internet_offline ? 'Vehicle is not connected to the internet.' : 'Failed to fetch extension manifest.' }}
           </v-card-title>
+          <v-btn
+            color="primary"
+            @click="$emit('refresh')"
+          >
+            Try Again
+          </v-btn>
         </div>
       </v-container>
     </v-card>

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -106,6 +106,7 @@
       :installed-extensions="installed_extensions"
       @clicked="showModal"
       @update="update"
+      @refresh="fetchManifest"
     />
     <BazaarTab
       v-show="is_bazaar_tab"


### PR DESCRIPTION
Allows users to try fetch manifest again in case of fail

![image](https://github.com/user-attachments/assets/64b43bb3-2296-45dd-ac62-daf986ba56e0)

## Summary by Sourcery

New Features:
- Adds a 'Try Again' button to the BackAlleyTab component, allowing users to retry fetching the extension manifest if the initial attempt fails.