### PR TITLE
core: tools: mavlink-server: Update to 0.3.2

### DIFF
--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.3.1"
+VERSION="0.3.2"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
[Release notes](https://github.com/bluerobotics/mavlink-server/releases/tag/0.3.2)

## Summary by Sourcery

Chores:
- Update mavlink-server to version 0.3.2.