### PR TITLE
Fix unresolved imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     'func-style': ['error', 'declaration'],
     'import/extensions': 'off',
     'import/order': 'off',
+    'import/no-unresolved': 'error',
     'max-len': ['error', { code: 120 }],
     'no-alert': 'off',
     'no-bitwise': 'off',
@@ -101,6 +102,9 @@ module.exports = {
       },
       node: {
         extensions: ['.js', '.json', '.jsx', '.ts', '.tsx', '.vue'],
+      },
+      vite: {
+        viteConfig: require('./vite.config').viteConfigObj, // named export of the Vite config object.
       },
     },
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
     'no-bitwise': 'off',
     'no-console': 'off',
     'no-continue': 'off',
-    "no-else-return": ["error", { "allowElseIf": false }],
+    'no-else-return': ['error', { allowElseIf: false }],
     'no-extra-parens': ['error', 'all'],
     'no-mixed-operators': 'off',
     // modified https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L339

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -86,6 +86,7 @@
     "@vue/eslint-config-typescript": "^11.0.2",
     "eslint": "^8.33.0",
     "eslint-import-resolver-typescript": "^3.5.3",
+    "eslint-import-resolver-vite": "^2.1.0",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-simple-import-sort": "^10.0.0",

--- a/core/frontend/src/types/autopilot/px4/metadata-fetcher.ts
+++ b/core/frontend/src/types/autopilot/px4/metadata-fetcher.ts
@@ -41,7 +41,11 @@ async function fetchPX4Metadata(): Promise<PX4ParametersMetadata[]> {
   try {
     metadata = await fetchPX4MetadataFromBoard()
   } catch (e) {
-    metadata = (await import('@/PX4-parameters/master/parameters.json')).parameters
+    const response = await fetch('/PX4-parameters/master/parameters.json');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch PX4 metadata: ${response.statusText}`);
+    }
+    metadata = (await response.json()).parameters;
   }
 
   return metadata as PX4ParametersMetadata[]

--- a/core/frontend/tsconfig.json
+++ b/core/frontend/tsconfig.json
@@ -15,7 +15,6 @@
     "baseUrl": ".",
     "experimentalDecorators": true,
     "types": [
-      "webpack-env",
       "vite/client"
     ],
     "paths": {

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -19,6 +19,14 @@ const assert = require('assert');
 // TODO: check if it works with https once we have something that does
 assert.ok(SERVER_ADDRESS.startsWith('http://'), 'SERVER_ADDRESS must start with http://');
 
+export const viteConfigObj = {
+  resolve: {
+    alias: {
+      _: path.resolve(__dirname, 'src'),
+    },
+  },
+}
+
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   return {


### PR DESCRIPTION
Solves this:
![image](https://github.com/user-attachments/assets/767641b0-aec5-4060-86ca-115225549c7a)

I saw that part of our config came from moving to vite, then I searched for vite projects and saw that they were using `eslint-import-resolver-vite`. Then I configured it following their [docs](https://www.npmjs.com/package/eslint-import-resolver-vite), and it worked.

As a side quest, I made unresolved imports throw error in build time, and the build failed on the autopilot import part, so I moved it to a runtime fetch (@Williangalvani is this correct?).

## Summary by Sourcery

Fixes unresolved imports by configuring eslint to work with vite aliases. Additionally, moves the autopilot import to a runtime fetch to prevent build errors.