### PR TITLE
Wifi: use fetch_secrets=False on get_saved_wifi_networks

### DIFF
--- a/core/services/wifi/wifi_handlers/networkmanager/networkmanager.py
+++ b/core/services/wifi/wifi_handlers/networkmanager/networkmanager.py
@@ -455,7 +455,7 @@ class NetworkManagerWifi(AbstractWifiManager):
             for conn_path in await self._nm_settings.connections:
                 try:
                     settings = NetworkConnectionSettings(conn_path, self._bus)
-                    profile = await settings.get_profile()
+                    profile = await settings.get_profile(fetch_secrets=False)
 
                     if not profile.wireless or not profile.wireless.ssid:
                         continue


### PR DESCRIPTION
This prevents unnecessary changes to profiles by NetworkManager

Helps #3185