### PR TITLE
frontend: Add sentry sourcemap

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -63,7 +63,7 @@ jobs:
         run: bun --cwd ./core/frontend lint
 
       - name: Bun build
-        run: bun run --cwd ./core/frontend build
+        run: NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd ./core/frontend build
 
   deploy-docker-images:
     runs-on: ubuntu-latest

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -19,7 +19,7 @@ RUN <<-EOF
 set -e
 
     bun install --cwd /home/pi/frontend
-    bun run --cwd /home/pi/frontend build
+    NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd /home/pi/frontend build
 
 EOF
 

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@google/model-viewer": "^3.0.0",
     "@mdi/font": "^7.1.96",
+    "@sentry/vite-plugin": "^3.2.2",
     "@sentry/vue": "^8.25.0",
     "@types/file-saver": "^2.0.5",
     "@types/lodash": "^4.14.175",

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -2,6 +2,7 @@ import vue from '@vitejs/plugin-vue2'
 import { VuetifyResolver } from 'unplugin-vue-components/resolvers'
 import Components from 'unplugin-vue-components/vite'
 import { defineConfig, loadEnv } from 'vite'
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { VitePWA } from 'vite-plugin-pwa'
 const { name } = require('./package.json')
 
@@ -49,6 +50,11 @@ export default defineConfig(({ command, mode }) => {
         // Vue version of project.
         version: 2.7,
       }),
+      sentryVitePlugin({
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        org: "blue-robotics-c7",
+        project: "blueos",
+      })
     ],
     assetsInclude: ['**/*.gif', '**/*.glb', '**/*.png', '**/*.svg', '**/assets/ArduPilot-Parameter-Repository**.json'],
     resolve: {
@@ -58,6 +64,7 @@ export default defineConfig(({ command, mode }) => {
       },
     },
     build: {
+      sourcemap: true,
       rollupOptions: {
         input: {
           main: path.resolve(__dirname, 'index.html'),


### PR DESCRIPTION
## Summary by Sourcery

Enable Sentry sourcemap generation and upload during the build process to improve error tracking and debugging.

Build:
- Enable sourcemap generation during the build process.
- Add Sentry Vite plugin to upload sourcemaps to Sentry.
- Add @sentry/vite-plugin as a project dependency.