### PR TITLE
core: frontend: components: autopilot: FirmwareManager: Do not allow empty file

### DIFF
--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -289,7 +289,7 @@ export default Vue.extend({
         return this.cloud_firmware_options_status === CloudFirmwareOptionsStatus.Chosen
       }
       if (this.upload_type === UploadType.File) {
-        return this.firmware_file !== null
+        return this.firmware_file != null
       }
       return true
     },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes an issue where empty firmware files could be submitted.