### PR TITLE
Core: Services: Autopilot Manager: Add check for async function prior to awaiting in index_to_http_exception

### DIFF
--- a/core/services/ardupilot_manager/api/v1/routers/index.py
+++ b/core/services/ardupilot_manager/api/v1/routers/index.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 from functools import wraps
@@ -31,10 +32,14 @@ autopilot = AutoPilotManager()
 
 
 def index_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., Any]:
+    is_async = asyncio.iscoroutinefunction(endpoint)
+
     @wraps(endpoint)
     async def wrapper(*args: Tuple[Any], **kwargs: dict[str, Any]) -> Any:
         try:
-            return await endpoint(*args, **kwargs)
+            if is_async:
+                return await endpoint(*args, **kwargs)
+            return endpoint(*args, **kwargs)
         except HTTPException as error:
             raise error
         except Exception as error:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add a check to determine if a function is asynchronous before using 'await' in 'index_to_http_exception' to prevent runtime errors.