### PR TITLE
frontend: add a warning when MavP2P is selected

### DIFF
--- a/core/frontend/src/components/autopilot/EndpointManager.vue
+++ b/core/frontend/src/components/autopilot/EndpointManager.vue
@@ -24,6 +24,17 @@
           >
             <v-radio v-for="router in available_routers" :key="router" :label="router" :value="router" />
           </v-radio-group>
+          <v-alert
+            v-if="selected_router === 'MAVP2P'"
+            outline
+            text
+            dense
+            type="warning"
+          >
+            <p>
+              MAVP2P has been presenting issues and is not currently recommended.
+            </p>
+          </v-alert>
         </v-card-text>
       </v-card>
       <v-divider


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/91cec15d-e467-402d-b240-f28b37153c10)

## Summary by Sourcery

Adds a warning message to the frontend when the MAVP2P router is selected, advising users that it's not currently recommended due to ongoing issues.