### PR TITLE
[cable-guy] Add Routes API

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -50,11 +50,11 @@ class EthernetManager:
 
     result: List[NetworkInterface] = []
 
-    _manager: PydanticManager = PydanticManager(SERVICE_NAME, settings.SettingsV1)
+    _manager: PydanticManager = PydanticManager(SERVICE_NAME, settings.SettingsV2)
 
     @property
-    def _settings(self) -> settings.SettingsV1:
-        return cast(settings.SettingsV1, self._manager.settings)
+    def _settings(self) -> settings.SettingsV2:
+        return cast(settings.SettingsV2, self._manager.settings)
 
     def __init__(self) -> None:
         self._dhcp_servers: List[DHCPServerManager] = []

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -2,6 +2,7 @@ import asyncio
 import re
 import subprocess
 import time
+from ipaddress import ip_network
 from socket import AddressFamily
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
@@ -26,6 +27,9 @@ from typedefs import (
     NetworkInterfaceMetricApi,
     Route,
 )
+
+# TODO: Replace this by `from pydantic import IPvAnyAddress, IPvAnyNetwork` once we update to pydantic v2
+from typedefs_pydantic_network_shin import IPvAnyAddress, IPvAnyNetwork
 
 __all__ = [
     "AddressMode",
@@ -570,6 +574,115 @@ class EthernetManager:
             number_of_disconnections=interface.carrier_down_count,
             priority=priority,
         )
+
+    def add_route(self, interface_name: str, route: Route) -> None:
+        self._execute_route("add", interface_name, route)
+
+    def remove_route(self, interface_name: str, route: Route) -> None:
+        self._execute_route("del", interface_name, route)
+
+    def _execute_route(self, action: str, interface_name: str, route: Route) -> None:
+        try:
+            interface_index = self._get_interface_index(interface_name)
+            gateway = self.__class__._normalize_gateway(route.destination_parsed, route.next_hop_parsed)
+
+            self.ipr.route(
+                action,
+                oif=interface_index,
+                dst=str(route.destination_parsed),
+                gateway=str(gateway) if gateway else None,
+                metrics={"metric": route.priority} if route.priority else None,
+            )
+
+            act = "Removed" if action == "del" else "Added" if action == "add" else action
+            logger.info(f"{act} route to {route.destination_parsed} via {gateway} on {interface_name}")
+        except Exception as e:
+            act = "Remove" if action == "del" else "Add" if action == "add" else action
+            logger.error(f"Failed to {act} route: {e}")
+            raise
+
+        # Update settings
+        current_interface = self.get_interface_by_name(interface_name)
+        for current_route in current_interface.routes:
+            if current_route.destination_parsed == route.destination_parsed and current_route.gateway == route.gateway:
+                current_route.managed = route.managed
+        self._update_interface_settings(interface_name, current_interface)
+
+    def get_routes(self, interface_name: str, ignore_unmanaged: bool = True) -> Set[Route]:
+        try:
+            interface_index = self._get_interface_index(interface_name)
+            raw_routes = self.ipr.get_routes(oif=interface_index)
+        except Exception as err:
+            logger.error(f"Failed to get routes for {interface_name}: {err}")
+            return set()
+
+        saved_iface = self.get_saved_interface_by_name(interface_name)
+        saved_routes = saved_iface.routes if saved_iface is not None else []
+
+        routes: Set[Route] = set()
+        for raw_route in raw_routes:
+            try:
+                route = self._parse_route(raw_route)
+
+            except Exception as err:
+                logger.error(f"Failed to parse route record {raw_route}: {err}")
+                continue
+
+            # Synchronize the 'managed' attribute
+            for saved_route in saved_routes:
+                if saved_route == route:
+                    route.managed = saved_route.managed
+
+            if ignore_unmanaged and not route.managed:
+                continue
+
+            routes.add(route)
+
+        return routes
+
+    def _parse_route(
+        self,
+        raw_route: Any,
+    ) -> Route:
+        raw_destination: Optional[str] = raw_route.get_attr("RTA_DST")
+        raw_prefixlen: int = raw_route["dst_len"]
+        raw_gateway: Optional[str] = raw_route.get_attr("RTA_GATEWAY")
+        raw_priority: int = raw_route.get_attr("RTA_PRIORITY")
+
+        # Parse destination
+        if raw_destination is None:
+            net = "0.0.0.0/0" if raw_route["family"] == AddressFamily.AF_INET else "::/0"
+        else:
+            net = f"{raw_destination}/{raw_prefixlen}"
+        destination = IPvAnyNetwork(ip_network(net))
+
+        # Parse gateway
+        gateway = (
+            self.__class__._normalize_gateway(destination, IPvAnyAddress(raw_gateway))
+            if raw_gateway is not None
+            else None
+        )
+
+        route = Route(
+            destination=str(destination),
+            gateway=str(gateway) if gateway else None,
+            priority=raw_priority,
+        )
+
+        return route
+
+    @staticmethod
+    def _normalize_gateway(destination: IPvAnyNetwork, gateway: Optional[IPvAnyAddress]) -> Optional[IPvAnyAddress]:
+        if gateway is None:
+            return None
+
+        if destination.version == 4 and gateway.version != 4:
+            raise ValueError(f"Gateway {gateway} must be IPv4 for destination {destination}")
+
+        if destination.version == 6 and gateway.version != 6:
+            raise ValueError(f"Gateway {gateway} must be IPv6 for destination {destination}")
+
+        return gateway
 
     def _is_ip_on_interface(self, interface_name: str, ip_address: str) -> bool:
         interface = self.get_interface_by_name(interface_name)

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -131,6 +131,27 @@ class EthernetManager:
                 logger.info(f"Triggering dynamic IP acquisition for interface '{interface.name}'.")
                 self.trigger_dynamic_ip_acquisition(interface.name)
 
+            # Handle routes configuration
+            self._set_routes_configuration(interface)
+
+    def _set_routes_configuration(self, interface: NetworkInterface) -> None:
+        try:
+            current_routes = self.get_routes(interface.name, ignore_unmanaged=True)
+            desired_routes = interface.routes
+
+            # Remove old routes
+            for current_route in current_routes:
+                if current_route not in desired_routes:
+                    self.remove_route(interface.name, current_route)
+
+            # Add new routes
+            for desired_route in desired_routes:
+                if desired_route not in current_routes:
+                    self.add_route(interface.name, desired_route)
+
+        except Exception as error:
+            logger.error(f"Routes configuration failed: {error}")
+
     def _get_wifi_interfaces(self) -> List[str]:
         """Get wifi interface list
 

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -24,6 +24,7 @@ from typedefs import (
     NetworkInterface,
     NetworkInterfaceMetric,
     NetworkInterfaceMetricApi,
+    Route,
 )
 
 __all__ = [
@@ -308,6 +309,7 @@ class EthernetManager:
             saved_interface = NetworkInterface(
                 name=interface_name,
                 addresses=[],
+                routes=[],
             )
 
         new_address = InterfaceAddress(ip=ip, mode=mode)
@@ -411,7 +413,11 @@ class EthernetManager:
                 if interface_metric:
                     priority = interface_metric.priority
 
-            interface_data = NetworkInterface(name=interface, addresses=valid_addresses, info=info, priority=priority)
+            routes = self.get_routes(interface, ignore_unmanaged=False)
+
+            interface_data = NetworkInterface(
+                name=interface, addresses=valid_addresses, info=info, priority=priority, routes=list(routes)
+            )
             # Check if it's valid and add to the result
             if self.validate_interface_data(interface_data, filter_wifi):
                 result += [interface_data]
@@ -505,7 +511,9 @@ class EthernetManager:
         for interface in interfaces:
             saved_interface = self.get_saved_interface_by_name(interface.name)
             if saved_interface is None:
-                saved_interface = NetworkInterface(name=interface.name, addresses=[], priority=interface.priority)
+                saved_interface = NetworkInterface(
+                    name=interface.name, addresses=[], priority=interface.priority, routes=[]
+                )
             saved_interface.priority = interface.priority
             self._update_interface_settings(interface.name, saved_interface)
 
@@ -647,7 +655,7 @@ class EthernetManager:
 
         saved_interface = self.get_saved_interface_by_name(interface_name)
         if saved_interface is None:
-            saved_interface = NetworkInterface(name=interface_name, addresses=[], priority=None)
+            saved_interface = NetworkInterface(name=interface_name, addresses=[], priority=None, routes=[])
 
         self._update_interface_settings(interface_name, saved_interface)
 

--- a/core/services/cable_guy/config.py
+++ b/core/services/cable_guy/config.py
@@ -1,6 +1,7 @@
 # This file is used to define general configurations for the app
 
-from typedefs import AddressMode, InterfaceAddress, NetworkInterface
+from typedefs import AddressMode, InterfaceAddress, NetworkInterface, Route
+from typedefs_pydantic_network_shin import IPvAnyNetwork
 
 SERVICE_NAME = "cable-guy"
 
@@ -12,6 +13,14 @@ DEFAULT_NETWORK_INTERFACES = [
             InterfaceAddress(ip="192.168.2.2", mode=AddressMode.BackupServer),
             InterfaceAddress(ip="0.0.0.0", mode=AddressMode.Client),
         ],
+        routes=[
+            Route(
+                destination=str(IPvAnyNetwork("224.0.0.0/4")),
+                gateway=None,
+                priority=None,
+                managed=True,
+            )
+        ],
     ),
-    NetworkInterface(name="usb0", addresses=[InterfaceAddress(ip="192.168.3.1", mode=AddressMode.Server)]),
+    NetworkInterface(name="usb0", addresses=[InterfaceAddress(ip="192.168.3.1", mode=AddressMode.Server)], routes=[]),
 ]

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -17,6 +17,7 @@ from uvicorn import Config, Server
 from api.dns import DnsData
 from api.manager import EthernetManager, NetworkInterface, NetworkInterfaceMetricApi
 from config import SERVICE_NAME
+from typedefs import Route
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)
@@ -116,6 +117,29 @@ def retrieve_host_dns() -> Any:
 def update_host_dns(dns_data: DnsData) -> Any:
     """REST API endpoint to update the host DNS configuration."""
     manager.dns.update_host_nameservers(dns_data)
+
+
+@app.post("/route", summary="Add route to interface.")
+@version(1, 0)
+def add_route(interface_name: str, route: Route) -> Any:
+    """REST API endpoint to add route."""
+    manager.add_route(interface_name, route)
+    manager.save()
+
+
+@app.delete("/route", summary="Remove route from interface.")
+@version(1, 0)
+def remove_route(interface_name: str, route: Route) -> Any:
+    """REST API endpoint remove route."""
+    manager.remove_route(interface_name, route)
+    manager.save()
+
+
+@app.get("/route", summary="Get the interface routes.")
+@version(1, 0)
+def get_route(interface_name: str) -> List[Route]:
+    """REST API endpoint to get routes."""
+    return list(manager.get_routes(interface_name, ignore_unmanaged=False))
 
 
 app = VersionedFastAPI(

--- a/core/services/cable_guy/typedefs.py
+++ b/core/services/cable_guy/typedefs.py
@@ -1,7 +1,11 @@
 from enum import Enum
+from ipaddress import ip_network
 from typing import List, Optional
 
 from pydantic import BaseModel
+
+# TODO: Replace this by `from pydantic import IPvAnyAddress, IPvAnyNetwork` once we update to pydantic v2
+from typedefs_pydantic_network_shin import IPvAnyAddress, IPvAnyNetwork
 
 
 class AddressMode(str, Enum):
@@ -31,7 +35,57 @@ class InterfaceInfo(BaseModel):
     priority: int
 
 
-class NetworkInterface(BaseModel):
+class Route(BaseModel):
+    destination: str  # TODO: change this to IPvAnyNetwork from pydantic v2
+    gateway: Optional[str] = None  # TODO: change this to IPvAnyAddress from pydantic v2
+    priority: Optional[int] = None
+    managed: bool = False
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Route):
+            return NotImplemented
+        return self.destination == other.destination and self.gateway == other.gateway
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.destination,
+                self.gateway,
+            )
+        )
+
+    # TODO: Remove this once we update self.destination type
+    @property
+    def destination_parsed(self) -> IPvAnyNetwork:
+        return IPvAnyNetwork(self.destination)
+
+    # TODO: Remove this once we update self.destination type
+    @destination_parsed.setter
+    def destination_parsed(self, ip: IPvAnyNetwork) -> None:
+        self.destination = str(ip)
+
+    # TODO: Remove this once we update self.next_hop type
+    @property
+    def next_hop_parsed(self) -> Optional[IPvAnyAddress]:
+        if self.gateway is None:
+            return None
+        return IPvAnyAddress(self.gateway)
+
+    # TODO: Remove this once we update self.next_hop type
+    @next_hop_parsed.setter
+    def next_hop_parsed(self, ip: Optional[IPvAnyAddress]) -> None:
+        self.gateway = str(ip) if ip else None
+
+    @property
+    def is_default(self) -> bool:
+        return ip_network(self.destination).is_unspecified
+
+    @property
+    def is_multicast(self) -> bool:
+        return ip_network(self.destination).is_multicast
+
+
+class NetworkInterfaceV1(BaseModel):
     name: str
     addresses: List[InterfaceAddress]
     info: Optional[InterfaceInfo] = None
@@ -39,6 +93,10 @@ class NetworkInterface(BaseModel):
 
     def __hash__(self) -> int:
         return hash(self.name) + sum(hash(address) for address in self.addresses)
+
+
+class NetworkInterface(NetworkInterfaceV1):
+    routes: List[Route]
 
 
 class NetworkInterfaceMetric(BaseModel):

--- a/core/services/cable_guy/typedefs_pydantic_network_shin.py
+++ b/core/services/cable_guy/typedefs_pydantic_network_shin.py
@@ -1,0 +1,99 @@
+"""
+    TODO: Update to pydantic v2 to get rid of this sad file.
+    
+    This is a temporary shin to be replaced by pydantic IPvAnyAddress,
+    IPvAnyInterface and IPvAnyNetwork. This is needed because the Routes code
+    requires the differentiation embedded in those types (like that
+    '192.168.2.1' can't be used in place of a '192.168.2.0/24'). Yes, we
+    should be using the pydantic types in the Route, but our current pydantic
+    version doeesn't allow us to serialize the underlying types, so we must
+    keep them as 'str' in the Route properties while using these weak shins
+    in the manager implementations. This whole file should will be deleted
+    once we update to pydantic v2. The necessary glue between the Route props
+    and the manager code is spread both in typedefs and in the manager code,
+    like using str(ip_address('192.168.2.1')) when instantiating a Route,
+    and accessing Route.destination_parsed instead of Route.destiantion --
+    all quick things to adjust once the pydantic update takes place.
+"""
+
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+    ip_address,
+    ip_interface,
+    ip_network,
+)
+from typing import Any, Union
+
+
+class IPvAnyAddress:
+    def __init__(self, ip: Union[str, IPv4Address, IPv6Address]):
+        self._value: Union[IPv4Address, IPv6Address] = ip_address(ip)
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def __repr__(self) -> str:
+        return f"IPvAnyAddress('{self._value}')"
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IPvAnyAddress):
+            return self._value == other._value
+        return self._value == ip_address(other)
+
+    def __json__(self) -> str:
+        return str(self)
+
+    @property
+    def version(self) -> int:
+        return ip_address(self._value).version
+
+
+class IPvAnyInterface:
+    def __init__(self, ip: Union[str, IPv4Interface, IPv6Interface]):
+        self._value: Union[IPv4Interface, IPv6Interface] = ip_interface(ip)
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def __repr__(self) -> str:
+        return f"IPvAnyInterface('{self._value}')"
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IPvAnyInterface):
+            return self._value == other._value
+        return self._value == ip_interface(other)
+
+    def __json__(self) -> str:
+        return str(self)
+
+    @property
+    def version(self) -> int:
+        return ip_interface(self._value).version
+
+
+class IPvAnyNetwork:
+    def __init__(self, ip: Union[str, IPv4Network, IPv6Network]):
+        self._value: Union[IPv4Network, IPv6Network] = ip_network(ip)
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def __repr__(self) -> str:
+        return f"IPvAnyNetwork('{self._value}')"
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IPvAnyNetwork):
+            return self._value == other._value
+        return self._value == ip_network(other)
+
+    def __json__(self) -> str:
+        return str(self)
+
+    @property
+    def version(self) -> int:
+        return ip_network(self._value).version


### PR DESCRIPTION
This PR introduces a new feature: the Routes API, which allow us to add/delete arbitrary routes, like a default, or a multicast.

---

## Examples

### Example 1: Add an (unmanaged) default route to `eth0` interface with priority of 1500:
```bash
curl -X 'POST' \
  'http://192.168.2.4:9090/v1.0/route?interface_name=eth0' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
        "destination": "0.0.0.0/0",
        "gateway": "192.168.2.1",
        "priority": 1500,
        "managed": false
      }'
```

### Example 2: Add a multicast route to `eth0` interface and track it:

```bash
curl -X 'POST' \
  'http://192.168.2.4:9090/v1.0/route?interface_name=eth0' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
        "destination": "224.0.0.0/4",
        "gateway": null,
        "priority": null,
        "managed": true
      }'
```

---

Notes:

1. The `managed` property is a contract to allow compatibility with other managers, meaning that:
  (I) we won't track changes made by other software;
  (II) we won't try to recreate once it's deleted by other software;

2. While this Route represents kernel routes with minimal abstraction, it has a conflict with the way we are dealing with "interface priorities". The latter is an abstract and simplified way of changing the priority of each route, and it will not respect the priority set by the introduced Routes API. This has little effect now, but the right thing is to upgrade all the interface priority API to use the Routes API internally, or conform to its nuances -- each interface has associated routes, and each route has a defined priority (`0` being the default). An interface might not have any route, though, which should be respected. To keep this PR simple (because we need the multicast route for radcam), I'm _not_ addressing this conflict here.

## Summary by Sourcery

Introduce a REST API for managing network routes associated with network interfaces.

New Features:
- Add API endpoints (`POST`, `DELETE`, `GET /route`) to manage network routes.
- Allow distinguishing between managed and unmanaged routes.
- Include route information when retrieving network interface details.
- Persist route configurations in settings.
- Add a default multicast route to the default `eth0` configuration.