### PR TITLE
autopilot_manager: check if we are running on a pi4 for NavigatorPì4

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/linux/navigator.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/linux/navigator.py
@@ -1,7 +1,7 @@
 import platform
 from typing import Any, List
 
-from commonwealth.utils.commands import load_file
+from commonwealth.utils.commands import CpuType, get_cpu_type, load_file
 from elftools.elf.elffile import ELFFile
 
 from flight_controller_detector.linux.linux_boards import LinuxFlightController
@@ -25,10 +25,6 @@ class Navigator(LinuxFlightController):
                     name = "Navigator64"
                     plat = Platform.Navigator64
         super().__init__(**data, name=name, platform=plat)
-
-    def is_pi5(self) -> bool:
-        with open("/proc/cpuinfo", "r", encoding="utf-8") as f:
-            return "Raspberry Pi 5" in f.read()
 
     def detect(self) -> bool:
         return False
@@ -54,7 +50,7 @@ class NavigatorPi5(Navigator):
         ]
 
     def detect(self) -> bool:
-        if not self.is_pi5():
+        if not get_cpu_type() == CpuType.PI5:
             return False
         return all(self.check_for_i2c_device(bus, address) for address, bus in self.devices.values())
 
@@ -91,6 +87,6 @@ class NavigatorPi4(Navigator):
         raise RuntimeError("Unknown release, unable to map ports")
 
     def detect(self) -> bool:
-        if self.is_pi5():
+        if not get_cpu_type() == CpuType.PI4:
             return False
         return all(self.check_for_i2c_device(bus, address) for address, bus in self.devices.values())

--- a/core/services/ardupilot_manager/flight_controller_detector/linux/navigator.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/linux/navigator.py
@@ -1,7 +1,8 @@
 import platform
 from typing import Any, List
 
-from commonwealth.utils.commands import CpuType, get_cpu_type, load_file
+from commonwealth.utils.commands import load_file
+from commonwealth.utils.general import CpuType, get_cpu_type
 from elftools.elf.elffile import ELFFile
 
 from flight_controller_detector.linux.linux_boards import LinuxFlightController


### PR DESCRIPTION
This will make it so the detection doesn't run on pi3 and other boards
waiting for CI to test it

## Summary by Sourcery

Add Raspberry Pi 4 detection method for NavigatorPi4 flight controller

New Features:
- Implement a method to detect Raspberry Pi 4 specifically in the flight controller detection logic

Enhancements:
- Modify the detection logic to explicitly check for Raspberry Pi 4 hardware