### PR TITLE
core:tools:zenoh: Remove storage plugin

### DIFF
--- a/core/tools/zenoh/blueos-zenoh.json5
+++ b/core/tools/zenoh/blueos-zenoh.json5
@@ -1,19 +1,5 @@
 {
   plugins: {
-    storage_manager: {
-      volumes: {
-        fs: {},
-      },
-      storages: {
-        fs_storage: {
-          key_expr: "**",
-          volume: {
-            id: "fs",
-            dir: "fs"
-          }
-        }
-      }
-    },
     rest: { http_port: 7117 }
   }
 }


### PR DESCRIPTION
* Remove Zenoh Storage Plugin due to high CPU utilization

## Summary by Sourcery

Chores:
- Removes Zenoh Storage Plugin.