### PR TITLE
core:services:kraken: Fix ContainerUsageModel type

### DIFF
--- a/core/services/kraken/harbor/models.py
+++ b/core/services/kraken/harbor/models.py
@@ -10,5 +10,5 @@ class ContainerModel(BaseModel):
 
 class ContainerUsageModel(BaseModel):
     cpu: float
-    memory: float
-    disk: int
+    memory: float | str
+    disk: int | str


### PR DESCRIPTION
* `memory` and `disk` fields can be a value of "N/A" and not only the numeric types

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the 'memory' and 'disk' fields in the ContainerUsageModel could not accept string values like 'N/A'.