### PR TITLE
core:frontend:FirmwareManager: Remove timeout

### DIFF
--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -323,7 +323,6 @@ export default Vue.extend({
       this.install_status = InstallStatus.Installing
       const axios_request_config: AxiosRequestConfig = {
         method: 'post',
-        timeout: 180000,
       }
       if (this.upload_type === UploadType.Cloud) {
         // Populate request with data for cloud install

--- a/core/services/ardupilot_manager/api/v1/routers/index.py
+++ b/core/services/ardupilot_manager/api/v1/routers/index.py
@@ -176,11 +176,11 @@ async def install_firmware_from_url(
     # In some cases user might install a firmware that implies in a board change but this is not reflected,
     # so if the board is different from the current one, we change it.
     if (
-        auto_switch_board and
-        board and
-        autopilot.current_board and
-        autopilot.current_board.name != board.name and
-        FlightControllerFlags.is_bootloader not in board.flags
+        auto_switch_board
+        and board
+        and autopilot.current_board
+        and autopilot.current_board.name != board.name
+        and FlightControllerFlags.is_bootloader not in board.flags
     ):
         await autopilot.change_board(board)
 

--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -274,12 +274,12 @@ class AutoPilotManager(metaclass=Singleton):
         self._current_board = board
         if not self.firmware_manager.is_firmware_installed(self._current_board):
             if board.platform == Platform.Navigator:
-                self.firmware_manager.install_firmware_from_file(
+                await self.firmware_manager.install_firmware_from_file(
                     pathlib.Path("/root/blueos-files/ardupilot-manager/default/ardupilot_navigator"),
                     board,
                 )
             elif board.platform == Platform.Navigator64:
-                self.firmware_manager.install_firmware_from_file(
+                await self.firmware_manager.install_firmware_from_file(
                     pathlib.Path("/root/blueos-files/ardupilot-manager/default/ardupilot_navigator64"),
                     board,
                 )
@@ -393,7 +393,7 @@ class AutoPilotManager(metaclass=Singleton):
     async def start_sitl(self) -> None:
         self._current_board = BoardDetector.detect_sitl()
         if not self.firmware_manager.is_firmware_installed(self._current_board):
-            self.firmware_manager.install_firmware_from_params(Vehicle.Sub, self._current_board)
+            await self.firmware_manager.install_firmware_from_params(Vehicle.Sub, self._current_board)
         frame = self.load_sitl_frame()
         if frame == SITLFrame.UNDEFINED:
             frame = SITLFrame.VECTORED
@@ -646,19 +646,19 @@ class AutoPilotManager(metaclass=Singleton):
     def get_available_firmwares(self, vehicle: Vehicle, platform: Platform) -> List[Firmware]:
         return self.firmware_manager.get_available_firmwares(vehicle, platform)
 
-    def install_firmware_from_file(
+    async def install_firmware_from_file(
         self, firmware_path: pathlib.Path, board: FlightController, default_parameters: Optional[Parameters] = None
     ) -> None:
-        self.firmware_manager.install_firmware_from_file(firmware_path, board, default_parameters)
+        await self.firmware_manager.install_firmware_from_file(firmware_path, board, default_parameters)
 
-    def install_firmware_from_url(
+    async def install_firmware_from_url(
         self,
         url: str,
         board: FlightController,
         make_default: bool = False,
         default_parameters: Optional[Parameters] = None,
     ) -> None:
-        self.firmware_manager.install_firmware_from_url(url, board, make_default, default_parameters)
+        await self.firmware_manager.install_firmware_from_url(url, board, make_default, default_parameters)
 
-    def restore_default_firmware(self, board: FlightController) -> None:
-        self.firmware_manager.restore_default_firmware(board)
+    async def restore_default_firmware(self, board: FlightController) -> None:
+        await self.firmware_manager.restore_default_firmware(board)

--- a/core/services/ardupilot_manager/firmware/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareDownload.py
@@ -70,6 +70,7 @@ class FirmwareDownloader:
         name = pathlib.Path(urlparse(url).path).name
         filename = pathlib.Path(f"{FirmwareDownloader._generate_random_filename()}-{name}")
         try:
+            # TODO: Migrate pipeline to async and use aiohttp
             logger.debug(f"Downloading: {url}")
             urlretrieve(url, filename)
         except Exception as error:
@@ -90,6 +91,7 @@ class FirmwareDownloader:
         Returns:
             bool: True if file was downloaded and validated, False if not.
         """
+        # TODO: Migrate pipeline to async and use aiohttp
         with urlopen(FirmwareDownloader._manifest_remote) as http_response:
             manifest_gzip = http_response.read()
             manifest = gzip.decompress(manifest_gzip)

--- a/core/services/ardupilot_manager/firmware/FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareInstall.py
@@ -138,7 +138,7 @@ class FirmwareInstaller:
         ## For more information: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
         os.chmod(firmware_path, firmware_path.stat().st_mode | stat.S_IXOTH | stat.S_IXUSR | stat.S_IXGRP)
 
-    def install_firmware(
+    async def install_firmware(
         self,
         new_firmware_path: pathlib.Path,
         board: FlightController,
@@ -159,7 +159,7 @@ class FirmwareInstaller:
             if not board.path:
                 raise ValueError("Board path not available.")
             firmware_uploader.set_autopilot_port(pathlib.Path(board.path))
-            firmware_uploader.upload(new_firmware_path)
+            await firmware_uploader.upload(new_firmware_path)
             return
         if firmware_format == FirmwareFormat.ELF:
             # Using copy() instead of move() since the last can't handle cross-device properly (e.g. docker binds)

--- a/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
@@ -1,3 +1,4 @@
+import asyncio
 import pathlib
 import platform
 
@@ -10,30 +11,33 @@ from typedefs import FlightController, Platform, Vehicle
 
 
 def test_firmware_validation() -> None:
-    downloader = FirmwareDownloader()
-    installer = FirmwareInstaller()
+    async def firmware_validation_wrapper() -> None:
+        downloader = FirmwareDownloader()
+        installer = FirmwareInstaller()
 
-    # Pixhawk1 and Pixhawk4 APJ firmwares should always work
-    temporary_file = downloader.download(Vehicle.Sub, Platform.Pixhawk1)
-    installer.validate_firmware(temporary_file, Platform.Pixhawk1)
+        # Pixhawk1 and Pixhawk4 APJ firmwares should always work
+        temporary_file = downloader.download(Vehicle.Sub, Platform.Pixhawk1)
+        installer.validate_firmware(temporary_file, Platform.Pixhawk1)
 
-    temporary_file = downloader.download(Vehicle.Sub, Platform.Pixhawk4)
-    installer.validate_firmware(temporary_file, Platform.Pixhawk4)
+        temporary_file = downloader.download(Vehicle.Sub, Platform.Pixhawk4)
+        installer.validate_firmware(temporary_file, Platform.Pixhawk4)
 
-    # New SITL firmwares should always work, except for MacOS
-    # there are no SITL builds for MacOS
-    if platform.system() != "Darwin":
-        temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
-        installer.validate_firmware(temporary_file, Platform.SITL)
-
-    # Raise when validating Navigator firmwares (as test platform is x86)
-    temporary_file = downloader.download(Vehicle.Sub, Platform.Navigator)
-    with pytest.raises(InvalidFirmwareFile):
-        installer.validate_firmware(temporary_file, Platform.Navigator)
-
-    # Install SITL firmware
-    if platform.system() != "Darwin":
+        # New SITL firmwares should always work, except for MacOS
         # there are no SITL builds for MacOS
-        temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
-        board = FlightController(name="SITL", manufacturer="ArduPilot Team", platform=Platform.SITL)
-        installer.install_firmware(temporary_file, board, pathlib.Path(f"{temporary_file}_dest"))
+        if platform.system() != "Darwin":
+            temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
+            installer.validate_firmware(temporary_file, Platform.SITL)
+
+        # Raise when validating Navigator firmwares (as test platform is x86)
+        temporary_file = downloader.download(Vehicle.Sub, Platform.Navigator)
+        with pytest.raises(InvalidFirmwareFile):
+            installer.validate_firmware(temporary_file, Platform.Navigator)
+
+        # Install SITL firmware
+        if platform.system() != "Darwin":
+            # there are no SITL builds for MacOS
+            temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
+            board = FlightController(name="SITL", manufacturer="ArduPilot Team", platform=Platform.SITL)
+            await installer.install_firmware(temporary_file, board, pathlib.Path(f"{temporary_file}_dest"))
+
+    asyncio.run(firmware_validation_wrapper())


### PR DESCRIPTION
Uploader script by itself uses 3 minutes to timeout and kill the script, given that the full install process usually needs a download and cleanup if timeout, we shouldn't impose the timeout on the frontend since once axios release the request the process kill wont be successful on the backend.

## Summary by Sourcery

Migrate firmware upload and installation processes to use asynchronous programming, removing explicit timeout handling in the frontend

Enhancements:
- Refactor firmware upload and installation methods to use asyncio for better concurrency
- Remove explicit timeout configuration in frontend axios request

Chores:
- Update multiple service methods to be asynchronous
- Modify test cases to support async execution