### PR TITLE
Core:Frontend:StoreExtensionCard: Fix text overflowe in copanies names

### DIFF
--- a/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
@@ -41,11 +41,11 @@
 
           <v-card-subtitle class="px-3 py-2 ext-subtitles">
             <div
-              class="extension-name"
+              class="line-constrained extension-name"
             >
               {{ extension.name.toUpperCase() }}
             </div>
-            <div class="extension-description">
+            <div class="line-constrained extension-description">
               {{ extension.description }}
             </div>
           </v-card-subtitle>
@@ -66,7 +66,7 @@
         />
       </v-avatar>
       <div class="extension-creators">
-        <div class="extension-company">
+        <div class="line-constrained extension-company">
           {{ extension_company }}
         </div>
         <div class="extension-authors">
@@ -399,26 +399,27 @@ export default Vue.extend({
   z-index: 4 !important;
 }
 
+.line-constrained {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+}
+
 .extension-name {
   font-weight: bold;
   font-size: 18px;
   max-height: 1.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
+  line-clamp: 1;
   -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
 }
 
 .extension-description {
   color: gray;
   font-size: 14px;
   max-height: 3.6em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
 }
 
 .extension-creators {
@@ -430,6 +431,8 @@ export default Vue.extend({
 .extension-company {
   font-weight: bold;
   font-size: 14px;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
 }
 
 .extension-authors {


### PR DESCRIPTION
Some companies may have names that can overflow on the card

![image](https://github.com/user-attachments/assets/f6e376d8-f203-47f8-9429-6c95b0dc505c)

The PR limits the Company name to max one line and fixed to maximum width available on the card.

![image](https://github.com/user-attachments/assets/4c442acc-ad7e-41c4-b139-7e740da11da9)

## Summary by Sourcery

Enhancements:
- Limit the company name to a maximum of one line and the extension description to a maximum of two lines.