### PR TITLE
Core:Frontend:StoreExtensionCard: Add beta marker

### DIFF
--- a/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
@@ -9,6 +9,23 @@
     class="store-extension-card"
   >
     <div
+      v-if="is_beta_only_extension"
+      class="beta-holder-container"
+    >
+      <v-chip
+        color="red"
+        small
+        label
+        text-color="white"
+        class="beta-chip"
+      >
+        <div style="width: 20px;" />
+        Beta
+        <div style="width: 20px;" />
+      </v-chip>
+    </div>
+
+    <div
       :style="img_background_style"
       class="img-background"
     />
@@ -211,6 +228,9 @@ export default Vue.extend({
       }
 
       return {}
+    },
+    is_beta_only_extension(): boolean {
+      return Object.values(this.extension.versions).every((version) => !isStable(version.tag))
     },
   },
   methods: {
@@ -481,4 +501,17 @@ export default Vue.extend({
   );
   pointer-events: none;
 }
+
+.beta-holder-container {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  transform: translate(50%, -50%) rotateZ(45deg);
+  z-index: 5 !important;
+}
+
+.beta-chip {
+  transform-origin: center;
+}
+
 </style>


### PR DESCRIPTION
Add a `beta` indicator in card for extensions that only have beta versions available, a beta version is the one in the format `x.y.z-beta.w`

![image](https://github.com/user-attachments/assets/eafa5fa7-75ac-4802-a35d-7bf0b32da444)

## Summary by Sourcery

New Features:
- Adds a beta indicator to the store extension card for extensions that only have beta versions available.