### PR TITLE
core: tools: bridges: Update to latest version with serial line break using empty datagram

### DIFF
--- a/core/tools/bridges/bootstrap.sh
+++ b/core/tools/bridges/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.10.2"
+VERSION="0.10.3"
 REPOSITORY_ORG="patrickelectric"
 REPOSITORY_NAME="bridges"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update bridges tool to version 0.10.3.