### PR TITLE
Core: Frontend: ExtensionDetailsModal: Improve colors feedback for user

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
@@ -35,7 +35,10 @@
                 v-on="on"
               >
                 <v-list-item-content>
-                  <v-list-item-title v-text="item.text" />
+                  <v-list-item-title
+                    :style="item.value === installed ? { color: 'var(--v-success-darken1)' } : {}"
+                    v-text="item.value === installed ? `${item.text} (Active)` : item.text"
+                  />
                 </v-list-item-content>
               </div>
             </template>
@@ -49,7 +52,7 @@
             :disabled="!extension.is_compatible || !is_version_compatible"
             width="120px"
             height="40px"
-            color="primary"
+            :color="is_installed ? 'error' : 'primary'"
 
             v-bind="attrs"
             v-on="on"


### PR DESCRIPTION
* When user have current installed version make the uninstall button red to differentiate from the primary install color.

![image](https://github.com/user-attachments/assets/1349e132-9b8e-44c5-8bd3-586ff83836fc)

* When user opens the version drop down shows current installed version using `(Active)` marker and success-darken1 color.

![image](https://github.com/user-attachments/assets/0b26062d-15f1-4000-8564-424f8e43555a)
