### PR TITLE
core: libs: commonwealth: Disable dnsmasq route advertisement

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
+++ b/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
@@ -93,7 +93,7 @@ class Dnsmasq:
             "--no-daemon",
             f"--interface={self._interface}",
             f"--dhcp-range={self._ipv4_lease_range[0]},{self._ipv4_lease_range[1]},{self._subnet_mask},{self._lease_time}",  # fmt: skip
-            f"--dhcp-option=option:router,{self._ipv4_gateway}",
+            "--dhcp-option=option:router",
             "--bind-interfaces",
             "--dhcp-option=option6:information-refresh-time,6h",
             "--dhcp-rapid-commit",


### PR DESCRIPTION
Closes #3223

## Summary by Sourcery

Disables the advertisement of router information in dnsmasq DHCP server configurations. This change prevents dnsmasq from advertising itself as a router, which might be necessary in certain network configurations.