### PR TITLE
Core: Services: cable-guy: Complete migration from old settings to Pydantic to ensure migrations

### DIFF
--- a/core/services/cable_guy/config.py
+++ b/core/services/cable_guy/config.py
@@ -1,0 +1,17 @@
+# This file is used to define general configurations for the app
+
+from typedefs import AddressMode, InterfaceAddress, NetworkInterface
+
+SERVICE_NAME = "cable-guy"
+
+# If no valid configuration is found, this will be used as the default
+DEFAULT_NETWORK_INTERFACES = [
+    NetworkInterface(
+        name="eth0",
+        addresses=[
+            InterfaceAddress(ip="192.168.2.2", mode=AddressMode.BackupServer),
+            InterfaceAddress(ip="0.0.0.0", mode=AddressMode.Client),
+        ],
+    ),
+    NetworkInterface(name="usb0", addresses=[InterfaceAddress(ip="192.168.3.1", mode=AddressMode.Server)]),
+]

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-import argparse
 import asyncio
 import logging
 import os
@@ -16,43 +15,13 @@ from loguru import logger
 from uvicorn import Config, Server
 
 from api.dns import DnsData
-from api.manager import (
-    AddressMode,
-    EthernetManager,
-    InterfaceAddress,
-    NetworkInterface,
-    NetworkInterfaceMetricApi,
-)
+from api.manager import EthernetManager, NetworkInterface, NetworkInterfaceMetricApi
 from config import SERVICE_NAME
-
-parser = argparse.ArgumentParser(description="CableGuy service for Blue Robotics BlueOS")
-parser.add_argument(
-    "--default_config",
-    dest="default_config",
-    type=str,
-    default="bluerov2",
-    choices=["bluerov2"],
-    help="Specify configuration to use if settings file cannot be loaded or is not found. Defaults to 'bluerov2'.",
-)
-
-args = parser.parse_args()
-
-if args.default_config == "bluerov2":
-    default_configs = [
-        NetworkInterface(
-            name="eth0",
-            addresses=[
-                InterfaceAddress(ip="192.168.2.2", mode=AddressMode.BackupServer),
-                InterfaceAddress(ip="0.0.0.0", mode=AddressMode.Client),
-            ],
-        ),
-        NetworkInterface(name="usb0", addresses=[InterfaceAddress(ip="192.168.3.1", mode=AddressMode.Server)]),
-    ]
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)
 
-manager = EthernetManager(default_configs)
+manager = EthernetManager()
 
 app = FastAPI(
     title="Cable Guy API",

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -23,8 +23,7 @@ from api.manager import (
     NetworkInterface,
     NetworkInterfaceMetricApi,
 )
-
-SERVICE_NAME = "cable-guy"
+from config import SERVICE_NAME
 
 parser = argparse.ArgumentParser(description="CableGuy service for Blue Robotics BlueOS")
 parser.add_argument(

--- a/core/services/cable_guy/networksetup.py
+++ b/core/services/cable_guy/networksetup.py
@@ -211,7 +211,6 @@ class BookwormHandler(AbstractNetworkHandler):
         interface_index = self.ipr.link_lookup(ifname=interface_name)[0]
         self.ipr.addr("del", index=interface_index, address=ip, prefixlen=24)
 
-    # pylint: disable=too-many-nested-blocks
     def set_interfaces_priority(self, interfaces: List[NetworkInterfaceMetricApi]) -> None:
         """Sets network interface priority using IPRoute.
 

--- a/core/services/cable_guy/typedefs.py
+++ b/core/services/cable_guy/typedefs.py
@@ -34,8 +34,8 @@ class InterfaceInfo(BaseModel):
 class NetworkInterface(BaseModel):
     name: str
     addresses: List[InterfaceAddress]
-    info: Optional[InterfaceInfo]
-    priority: Optional[int]
+    info: Optional[InterfaceInfo] = None
+    priority: Optional[int] = None
 
     def __hash__(self) -> int:
         return hash(self.name) + sum(hash(address) for address in self.addresses)


### PR DESCRIPTION
Fix #3231
Depends on #3235

When updating to one of [1.4.0-beta.17](https://github.com/bluerobotics/BlueOS/releases/tag/1.4.0-beta.17) or [1.4.0-beta.18](https://github.com/bluerobotics/BlueOS/releases/tag/1.4.0-beta.18) and after downgrading it to other lower version it makes cable-guy break due to invalid settings and not configure network properly.

NOTE: Tested on PI4, but aditional test would be good before merge, mainly to make sure cable-guy functionality was not affected.

## Summary by Sourcery

Migrate cable-guy service settings to Pydantic to improve settings management and ensure compatibility across different versions

Bug Fixes:
- Resolve settings migration issues that previously caused network configuration problems when downgrading BlueOS versions

Enhancements:
- Refactor settings management to use Pydantic for more robust configuration handling
- Improve settings migration mechanism to handle version changes

Chores:
- Create a new config.py file to centralize service configuration
- Simplify settings loading and saving logic

## Summary by Sourcery

Migrate cable-guy service settings to Pydantic for improved configuration management and version compatibility

New Features:
- Implement a new settings migration mechanism using Pydantic

Bug Fixes:
- Resolve settings migration issues that caused network configuration problems when downgrading BlueOS versions

Enhancements:
- Refactor settings management to use Pydantic for more robust configuration handling
- Improve settings migration mechanism to handle version changes

Chores:
- Create a centralized configuration file for service settings
- Simplify settings loading and saving logic