### PR TITLE
Fix blueos_startup_update wrongly applying dwc2 patches

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -13,6 +13,7 @@ from commonwealth.utils.decorators import temporary_cache
 
 
 class CpuType(str, Enum):
+    PI3 = "Raspberry Pi 3 (BCM2837)"
     PI4 = "Raspberry Pi 4 (BCM2711)"
     PI5 = "Raspberry Pi 5 (BCM2712)"
     Other = "Other"
@@ -37,6 +38,8 @@ def get_cpu_type() -> CpuType:
                 return CpuType.PI4
             if "Raspberry Pi 5" in line:
                 return CpuType.PI5
+            if "Raspberry Pi 3" in line:
+                return CpuType.PI3
     return CpuType.Other
 
 

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -263,6 +263,25 @@ def update_i2c4_symlink() -> bool:
     return False  # This patch doesn't require restart to take effect
 
 
+def revert_pi3_dwc2_config() -> bool:
+    """
+    Removes dwc2 configuration from cmdline.txt on Pi3.
+    This was being wrongly applied due to a bad host_cpu check.
+    """
+    if get_cpu_type() != CpuType.PI3:
+        return False
+    cmdline_content = load_file(cmdline_file).replace("\n", "").split(" ")
+    unpatched_cmdline_content = cmdline_content.copy()
+    cmdline_content = []
+    for item in unpatched_cmdline_content:
+        if "dwc2" not in item and "g_ether" not in item:
+            cmdline_content.append(item)
+    if unpatched_cmdline_content == cmdline_content:
+        return False
+    save_file(cmdline_file, " ".join(cmdline_content), "before_revert_pi3_dwc2_config")
+    return True
+
+
 def update_dwc2() -> bool:
     logger.info("Running dwc2 update..")
 
@@ -636,7 +655,8 @@ def main() -> int:
         ("cgroups", update_cgroups),
     ]
 
-    # this will always be pi4 as pi5 is not supported
+    if host_cpu == CpuType.PI3:
+        patches_to_apply.extend([("revert_dwc2", revert_pi3_dwc2_config)])
     if host_cpu == CpuType.PI4:
         patches_to_apply.extend([("navigator", update_navigator_overlays)])
 

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -660,7 +660,7 @@ def main() -> int:
     if host_cpu == CpuType.PI4:
         patches_to_apply.extend([("navigator", update_navigator_overlays)])
 
-    if host_cpu == CpuType.PI4 or CpuType.PI5:
+    if host_cpu in [CpuType.PI4, CpuType.PI5]:
         patches_to_apply.extend(
             [
                 ("dwc2", update_dwc2),

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -633,6 +633,7 @@ def main() -> int:
         ("ssh", fix_ssh_ownership),
         ("noIPV6", ensure_ipv6_disabled),
         ("swap", update_swap_size),
+        ("cgroups", update_cgroups),
     ]
 
     # this will always be pi4 as pi5 is not supported
@@ -642,7 +643,6 @@ def main() -> int:
     if host_cpu == CpuType.PI4 or CpuType.PI5:
         patches_to_apply.extend(
             [
-                ("cgroups", update_cgroups),
                 ("dwc2", update_dwc2),
                 ("i2c4", update_i2c4_symlink),
             ]


### PR DESCRIPTION
## Summary by Sourcery

Fix the issue of dwc2 patches being wrongly applied on Raspberry Pi 3 by implementing a function to revert these changes and enhance the CPU type detection to include Raspberry Pi 3.

Bug Fixes:
- Fix the incorrect application of dwc2 patches on Raspberry Pi 3 by adding a function to revert the configuration changes.

Enhancements:
- Add support for detecting Raspberry Pi 3 in the CPU type enumeration.