### PR TITLE
Core: Libs: Commonwealth: Add on_settings_created

### DIFF
--- a/core/libs/commonwealth/commonwealth/settings/bases/pydantic_base.py
+++ b/core/libs/commonwealth/commonwealth/settings/bases/pydantic_base.py
@@ -87,6 +87,11 @@ class PydanticSettings(BaseModel):
             except ValidationError as e:
                 raise BadSettingsFile(f"Settings file contains invalid data: {e}") from e
 
+    def on_settings_created(self, _: pathlib.Path) -> None:
+        # Base implementation for users, usually this is not needed, but mainly on SettingsV1 users may want to populate
+        # from maybe another source and this callback can be used
+        return
+
     def save(self, file_path: pathlib.Path) -> None:
         """Save settings to file
 
@@ -96,6 +101,10 @@ class PydanticSettings(BaseModel):
         # Path for settings file does not exist, lets ensure that it does
         parent_path = file_path.parent.absolute()
         parent_path.mkdir(parents=True, exist_ok=True)
+
+        if not file_path.exists():
+            # We call this to allow users to initialize the settings from another source if needed
+            self.on_settings_created(file_path)
 
         with open(file_path, "w", encoding="utf-8") as settings_file:
             logger.debug(f"Saving settings on: {file_path}")


### PR DESCRIPTION
This allows for PydanticSettings classes to perform some initialization work when a new settings file is created is a pre requirement for #3232 since we will need to copy the settings from existing `settings.json` to initialize the PydanticSettings stack and keep the original one as backup for downgrading.

## Summary by Sourcery

Add a new callback method `on_settings_created` to PydanticSettings to support initialization when a new settings file is created

New Features:
- Introduce an `on_settings_created` method in PydanticSettings that allows custom initialization when a new settings file is generated

Enhancements:
- Extend the settings loading mechanism to provide a hook for additional setup when a settings file is first created