### PR TITLE
Fix blueos startup update pi3

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -13,6 +13,7 @@ from commonwealth.utils.decorators import temporary_cache
 
 
 class CpuType(str, Enum):
+    PI3 = "Raspberry Pi 3 (BCM2837)"
     PI4 = "Raspberry Pi 4 (BCM2711)"
     PI5 = "Raspberry Pi 5 (BCM2712)"
     Other = "Other"
@@ -37,6 +38,8 @@ def get_cpu_type() -> CpuType:
                 return CpuType.PI4
             if "Raspberry Pi 5" in line:
                 return CpuType.PI5
+            if "Raspberry Pi 3" in line:
+                return CpuType.PI3
     return CpuType.Other
 
 

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -633,6 +633,7 @@ def main() -> int:
         ("ssh", fix_ssh_ownership),
         ("noIPV6", ensure_ipv6_disabled),
         ("swap", update_swap_size),
+        ("cgroups", update_cgroups),
     ]
 
     # this will always be pi4 as pi5 is not supported
@@ -642,7 +643,6 @@ def main() -> int:
     if host_cpu == CpuType.PI4 or CpuType.PI5:
         patches_to_apply.extend(
             [
-                ("cgroups", update_cgroups),
                 ("dwc2", update_dwc2),
                 ("i2c4", update_i2c4_symlink),
             ]

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -668,7 +668,7 @@ def main() -> int:
     if host_cpu == CpuType.PI4:
         patches_to_apply.extend([("navigator", update_navigator_overlays)])
 
-    if host_cpu == CpuType.PI4 or CpuType.PI5:
+    if host_cpu in [CpuType.PI4, CpuType.PI5]:
         patches_to_apply.extend(
             [
                 ("dwc2", update_dwc2),


### PR DESCRIPTION
Closes #3236

## Summary by Sourcery

Improve BlueOS startup update script for Raspberry Pi 3 by adding specific configuration and update handling

New Features:
- Add support for Raspberry Pi 3 in CPU type detection
- Implement specific update and cleanup functions for Raspberry Pi 3

Bug Fixes:
- Fix incorrect configuration application for Raspberry Pi 3
- Remove incorrectly applied dwc2 module configuration on Pi3

Enhancements:
- Refactor boot configuration handling functions to use more generic 'section' terminology
- Add support for detecting and handling Raspberry Pi 3 specific configurations