### PR TITLE
core:libs:commonwealth: Change to bind-dynamic

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
+++ b/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
@@ -94,7 +94,7 @@ class Dnsmasq:
             f"--interface={self._interface}",
             f"--dhcp-range={self._ipv4_lease_range[0]},{self._ipv4_lease_range[1]},{self._subnet_mask},{self._lease_time}",  # fmt: skip
             "--dhcp-option=option:router",
-            "--bind-interfaces",
+            "--bind-dynamic",
             "--dhcp-option=option6:information-refresh-time,6h",
             "--dhcp-rapid-commit",
             "--cache-size=1500",


### PR DESCRIPTION
Fix #3242

This allows `dnsmasq` to run even though the interface is not totally configured or up.

## Summary by Sourcery

Enhancements:
- Modify DHCP server binding strategy to use dynamic interface binding instead of strict interface binding

## Summary by Sourcery

Modify dnsmasq DHCP server binding strategy to use dynamic interface binding

Bug Fixes:
- Resolve issue #3242 by allowing dnsmasq to run even when the network interface is not fully configured

Enhancements:
- Change dnsmasq configuration from strict interface binding to dynamic interface binding