### PR TITLE
core: frontend: components: speedtest: NetworkSpeedTest: Remove timeout for upload/download operations

### DIFF
--- a/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
+++ b/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
@@ -219,12 +219,18 @@ export default Vue.extend({
             `network-test: Upload: ${speed_Mb.toFixed(2)}Mbps ${percentage.toFixed(2)}% ${seconds.toFixed(2)}s`,
           )
           this.setSpeed(speed_Mb)
+
+          // For some reason, this code never reaches finally block
+          // So we need to check if the upload is done
+          if (percentage > 99) {
+            this.updateState(State.Done)
+          }
         },
       }).catch((error) => {
         const message = `Failed to do speed test: ${error.message}`
         notifier.pushError('NETWORK_SPEED_TEST_UPLOAD', message)
         console.error(message)
-      }).finally(() => this.updateState(State.Done))
+      })
     },
     checkDownloadSpeed(): void {
       const one_hundred_mega_bytes = 100 * 2 ** 20

--- a/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
+++ b/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
@@ -200,7 +200,6 @@ export default Vue.extend({
       back_axios({
         method: 'post',
         url: '/network-test/post_file',
-        timeout: 20000,
         data: this.upload_buffer,
         onUploadProgress: (progress_event) => {
           if (start_time === undefined) {
@@ -234,7 +233,6 @@ export default Vue.extend({
       back_axios({
         method: 'get',
         url: '/network-test/get_file',
-        timeout: 20000,
         data: {
           size: one_hundred_mega_bytes,
           avoid_cache: new Date().getTime(),


### PR DESCRIPTION
The operation can take a long unpredictable time based on the network 

Fix #3249

## Summary by Sourcery

Bug Fixes:
- Remove fixed 20-second timeout for network speed test operations to allow for longer network tests