### PR TITLE
core: services: ardupilot_manager: Enable GCS Server Link by default

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -61,7 +61,7 @@ class AutoPilotManager(metaclass=Singleton):
                 place="0.0.0.0",
                 argument=14550,
                 persistent=True,
-                enabled=False,
+                enabled=True,
             ),
             Endpoint(
                 name="GCS Client Link",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change the default configuration to enable the GCS Server Link automatically