### PR TITLE
core: tools: mavlink-server: Update to 0.4.0

### DIFF
--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.3.1"
+VERSION="0.4.0"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump mavlink-server version from 0.3.1 to 0.4.0 in bootstrap script