### PR TITLE
core: services: ardupilot_manager: mavlink_proxy: Filter out disabled endpoints

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -37,7 +37,8 @@ class MAVLinkServer(AbstractRouter):
                 return f"zenoh:{endpoint.place}:{endpoint.argument}"
             raise ValueError(f"Endpoint of type {endpoint.connection_type} not supported on MAVLink-Server.")
 
-        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in [master_endpoint, *self.endpoints()]])
+        filtered_endpoints = Endpoint.filter_enabled(self.endpoints())
+        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in [master_endpoint, *filtered_endpoints]])
 
         return f"{self.binary()} {endpoints}"
 

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVP2P.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVP2P.py
@@ -35,7 +35,8 @@ class MAVP2P(AbstractRouter):
                 return f"udpc:{endpoint.place}:{endpoint.argument}"
             raise ValueError(f"Endpoint of type {endpoint.connection_type} not supported on MAVP2P.")
 
-        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in [master_endpoint, *self.endpoints()]])
+        filtered_endpoints = Endpoint.filter_enabled(self.endpoints())
+        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in [master_endpoint, *filtered_endpoints]])
 
         return f"{self.binary()} {endpoints} --streamreq-disable"
 


### PR DESCRIPTION
I just noticed that disabled endpoints were being added to the Mavlink Server.

## Summary by Sourcery

Filter out disabled endpoints from MAVLink proxy configurations

Bug Fixes:
- Prevent disabled endpoints from being added to MAVLink Server and MAVP2P configurations

Enhancements:
- Modify endpoint filtering to only include enabled endpoints in MAVLink proxy command generation