### PR TITLE
core: frontend: widgets: Networking: Fix svg height

### DIFF
--- a/core/frontend/src/widgets/Networking.vue
+++ b/core/frontend/src/widgets/Networking.vue
@@ -118,6 +118,7 @@ export default Vue.extend({
 
 .pi-icon :deep(svg) {
   width: 35px;
+  height: 40px;
   margin-bottom: -10px;
 }
 


### PR DESCRIPTION
Fix #3271

## Summary by Sourcery

Bug Fixes:
- Corrected the height of SVG icons in the Networking widget to ensure proper rendering