### PR TITLE
core: tools: mavlink-server: Update to 0.5.1

### DIFF
--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.4.0"
+VERSION="0.5.1"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
Full changelog: [0.5.0](https://github.com/bluerobotics/mavlink-server/releases/tag/0.5.0) + [0.5.1](https://github.com/bluerobotics/mavlink-server/releases/tag/0.5.1)

## Summary by Sourcery

Chores:
- Bump mavlink-server version from 0.4.0 to 0.5.0 in bootstrap script