### PR TITLE
core: tools: mavlink2rest: Update to t0.11.24

### DIFF
--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="t0.11.23"
+VERSION="t0.11.24"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink2rest"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump mavlink2rest version from t0.11.23 to t0.11.24 in bootstrap script