### PR TITLE
ci: workflows: test-and-deploy: Update oven-sh/setup-bun to v2

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.0.3
 


### PR DESCRIPTION
Update to latest version to avoid warnings about actions/cache 
https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2

## Summary by Sourcery

CI:
- Upgrade oven-sh/setup-bun action from v1 to v2 to resolve potential warnings