### PR TITLE
core: frontend: kraken: ExtensionCreationModal: move save/create button to right side

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -77,17 +77,21 @@
               </v-btn>
             </template>
           </json-editor>
-          <v-spacer />
-          <v-btn
-            color="primary"
-            class="mr-4"
-            :disabled="!valid_permissions"
-            @click="saveExtension"
-          >
-            {{ is_editing ? 'Save' : 'Create' }}
-          </v-btn>
         </v-form>
       </v-card-text>
+      <v-card-actions
+        class="pt-1"
+      >
+        <v-spacer />
+        <v-btn
+          color="primary"
+          class="mr-4"
+          :disabled="!valid_permissions"
+          @click="saveExtension"
+        >
+          {{ is_editing ? 'Save' : 'Create' }}
+        </v-btn>
+      </v-card-actions>
     </v-card>
   </v-dialog>
 </template>


### PR DESCRIPTION
Relevant to #3127

<img width="701" alt="Screenshot 2025-05-07 at 6 46 39 pm" src="https://github.com/user-attachments/assets/ab3df40b-a57b-41f3-a8f3-7e98bfd58c71" />

## Summary by Sourcery

Enhancements:
- Relocated the extension save/create button to a separate v-card-actions section