### PR TITLE
cable-guy: only skipping adding dhcp server if the ip is on the interface, too

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -771,7 +771,11 @@ class EthernetManager:
         """
         if self._is_dhcp_server_running_on_interface(interface_name):
             dhcp_on_interface = self._dhcp_server_on_interface(interface_name)
-            if dhcp_on_interface.ipv4_gateway == ipv4_gateway and dhcp_on_interface.is_backup_server == backup:
+            if (
+                dhcp_on_interface.ipv4_gateway == ipv4_gateway
+                and dhcp_on_interface.is_backup_server == backup
+                and self._is_ip_on_interface(interface_name, ipv4_gateway)
+            ):
                 logger.warning(
                     f"DHCP server with gateway '{ipv4_gateway}' and backup '{backup}' already exists on interface '{interface_name}'"
                 )


### PR DESCRIPTION
This fixes an issue where after booting , the vehicle loses the eth0 ip and blueos doesnt try to restore it.

## Summary by Sourcery

Ensure DHCP server is only considered already present when its gateway IP is configured on the interface, allowing BlueOS to restore lost eth0 IP after boot.

Bug Fixes:
- Only skip adding a DHCP server when the gateway IP is actually present on the interface to prevent losing the eth0 IP after boot.
