### PR TITLE
Install: update blueos.service to start after docker

### DIFF
--- a/install/configs/blueos.service
+++ b/install/configs/blueos.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Start BlueOS on boot
+After=docker.service
+Requires=docker.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
this takes blueos out of blame and out of the critical chain, too:
```
pi@blueos:~ $ systemd-analyze blame
6.819s NetworkManager-wait-online.service
3.357s docker.service
1.185s raspi-config.service
 634ms e2scrub_reap.service
 626ms containerd.service
 514ms dev-mmcblk0p2.device
 424ms blueos.service
 416ms ModemManager.service
 366ms rpi-eeprom-update.service
 351ms NetworkManager.service
 253ms avahi-daemon.service
 251ms bluetooth.service
 241ms polkit.service
 229ms systemd-logind.service
 226ms ssh.service
 221ms dbus.service
 198ms systemd-modules-load.service
 187ms dphys-swapfile.service
 184ms networking.service
 159ms user@1000.service
 147ms wpa_supplicant.service
 147ms systemd-udev-trigger.service
 132ms keyboard-setup.service
 132ms systemd-fsck@dev-disk-by\x2dpartuuid-2e57db04\x2d01.service
 127ms sshswitch.service
 120ms systemd-journal-flush.service
  93ms systemd-timesyncd.service
  84ms systemd-journald.service
  80ms systemd-tmpfiles-setup-dev.service
  78ms systemd-udevd.service
  72ms modprobe@drm.service
  63ms dev-mqueue.mount
  62ms sys-kernel-debug.mount
  61ms triggerhappy.service
  61ms sys-kernel-tracing.mount
  59ms fake-hwclock.service
  57ms systemd-binfmt.service
  55ms systemd-tmpfiles-setup.service
  55ms kmod-static-nodes.service
  54ms modprobe@configfs.service
  52ms systemd-remount-fs.service
  50ms modprobe@fuse.service
  47ms systemd-rfkill.service
  47ms systemd-sysusers.service
  40ms systemd-random-seed.service
  32ms alsa-restore.service
  29ms proc-sys-fs-binfmt_misc.mount
  29ms run-rpc_pipefs.mount
  20ms rpc-statd-notify.service
  20ms systemd-update-utmp.service
  15ms systemd-user-sessions.service
  14ms rc-local.service
  13ms systemd-sysctl.service
  12ms console-setup.service
  10ms ifupdown-pre.service
  10ms sys-fs-fuse-connections.mount
   9ms systemd-update-utmp-runlevel.service
   8ms sys-kernel-config.mount
   7ms user-runtime-dir@1000.service
   7ms boot-firmware.mount
   4ms modprobe@dm_mod.service
   3ms modprobe@efi_pstore.service
   3ms modprobe@loop.service
 871us docker.socket
 
 ```
 
 
 ```
pi@blueos:~ $ systemd-analyze critical-chain
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

multi-user.target @13.039s
└─docker.service @9.205s +3.357s
  └─network-online.target @9.186s
    └─NetworkManager-wait-online.service @2.365s +6.819s
      └─NetworkManager.service @1.985s +351ms
        └─dbus.service @1.741s +221ms
          └─basic.target @1.731s
            └─sockets.target @1.731s
              └─docker.socket @1.730s +871us
                └─sysinit.target @1.727s
                  └─systemd-timesyncd.service @1.620s +93ms
                    └─systemd-tmpfiles-setup.service @1.540s +55ms
                      └─local-fs.target @1.529s
                        └─run-docker-netns-default.mount @11.210s
                          └─local-fs-pre.target @682ms
                            └─systemd-tmpfiles-setup-dev.service @600ms +80ms
                              └─systemd-sysusers.service @550ms +47ms
                                └─systemd-remount-fs.service @483ms +52ms
                                  └─systemd-journald.socket @421ms
                                    └─system.slice @379ms
                                      └─-.slice @379ms
                                      ```