### PR TITLE
core:services:cable-guy: Persist settings defaults

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -58,6 +58,8 @@ class EthernetManager:
 
     def __init__(self) -> None:
         self._dhcp_servers: List[DHCPServerManager] = []
+        # Make sure that default behavior changes will be persisted initially on the disk
+        self._manager.save()
 
     async def initialize(self) -> None:
         self.network_handler = await NetworkHandlerDetector().getHandler()


### PR DESCRIPTION
* Make sure default values on settings changes are initially persist on disk

From #3298

## Summary by Sourcery

Bug Fixes:
- Ensure default behavior changes are initially saved to disk on manager initialization