### PR TITLE
cable-guy: only skipping adding dhcp server if the ip is on the interface, too

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -629,7 +629,11 @@ class EthernetManager:
         """
         if self._is_dhcp_server_running_on_interface(interface_name):
             dhcp_on_interface = self._dhcp_server_on_interface(interface_name)
-            if dhcp_on_interface.ipv4_gateway == ipv4_gateway and dhcp_on_interface.is_backup_server == backup:
+            if (
+                dhcp_on_interface.ipv4_gateway == ipv4_gateway
+                and dhcp_on_interface.is_backup_server == backup
+                and self._is_ip_on_interface(interface_name, ipv4_gateway)
+            ):
                 logger.warning(
                     f"DHCP server with gateway '{ipv4_gateway}' and backup '{backup}' already exists on interface '{interface_name}'"
                 )


### PR DESCRIPTION
From #3301

## Summary by Sourcery

Bug Fixes:
- Include an interface IP existence check when determining whether to skip adding a DHCP server