### PR TITLE
Fix routes api

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -621,7 +621,7 @@ class EthernetManager:
             logger.info(f"{act} route to {route.destination_parsed} via {gateway} on {interface_name}")
         except Exception as e:
             act = "Remove" if action == "del" else "Add" if action == "add" else action
-            logger.error(f"Failed to {act} route: {e}")
+            logger.error(f"Failed to {act} route {route.destination_parsed} via {gateway} on {interface_name}: {e}")
             raise
 
         # Update settings


### PR DESCRIPTION
Now the multicast should be added.

To test it, run in BlueOS terminal:

```bash
route
```

and it should show a `224.0.0.0` route there.

## Summary by Sourcery

Improve route management to gracefully handle duplicate route additions and provide more detailed error logging

Bug Fixes:
- Silence NetlinkError EEXIST when adding an already existing route to prevent needless failures

Enhancements:
- Enhance error messages to include destination, gateway, and interface details when route operations fail