### PR TITLE
Unprotect ping360 endpoint

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -117,7 +117,7 @@ class AutoPilotManager(metaclass=Singleton):
                 place="0.0.0.0",
                 argument=14660,
                 persistent=True,
-                protected=True,
+                protected=False,
             ),
         ]
 


### PR DESCRIPTION
Closes #3312

## Summary by Sourcery

Bug Fixes:
- Change ping360 endpoint configuration to set protected=False