### PR TITLE
kraken: use gh-pages for fetching the manifest

### DIFF
--- a/core/services/kraken/config.py
+++ b/core/services/kraken/config.py
@@ -6,7 +6,7 @@ DEFAULT_MANIFESTS = [
     {
         "identifier": "bluerobotics-production",
         "name": "BlueOS Extensions Repository",
-        "url": "https://raw.githubusercontent.com/bluerobotics/BlueOS-Extensions-Repository/refs/heads/gh-pages/manifest.json",
+        "url": "https://bluerobotics.github.io/BlueOS-Extensions-Repository/manifest.json",
     },
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Switch manifest URL to the GitHub Pages-hosted manifest