### PR TITLE
1.4: Fix QGC integration

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -106,7 +106,7 @@ find /usr/blueos/userdata -type f -exec chmod a+rw {} \;
 PRIORITY_SERVICES=(
     'autopilot',0,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
     'cable_guy',0,"$SERVICES_PATH/cable_guy/main.py"
-    'video',0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --stun-server stun://stun.l.google.com:19302 --verbose"
+    'video',0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --mavlink-camera-component-id-range=100-105 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --stun-server stun://stun.l.google.com:19302 --verbose"
     'mavlink2rest',0,"mavlink2rest --connect=udpout:127.0.0.1:14001 --server [::]:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.19.1"
+VERSION="t3.19.2"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
From #3318

## Summary by Sourcery

Persist Cable Guy defaults on startup, tighten duplicate DHCP server checks, and bump mavlink-camera-manager bootstrap version to t3.19.2

Bug Fixes:
- Prevent adding a DHCP server if one with the same gateway, backup mode, and interface IP already exists

Enhancements:
- Persist default Cable Guy manager settings to disk immediately upon initialization

Build:
- Update mavlink-camera-manager bootstrap script from version t3.19.1 to t3.19.2