### PR TITLE
[1.4] install.sh: disable NetworkManager-wait-online.service

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -255,6 +255,9 @@ rm -rf /var/lib/systemd/random-seed /loader/random-seed
 echo "creating dns link"
 sudo ln --force /etc/resolv.conf /etc/resolv.conf.host
 
+echo "disabling NetworkManager-wait-online.service"
+systemctl disable NetworkManager-wait-online.service || true
+
 echo "Installation finished successfully."
 echo "You can access after the reboot:"
 echo "- The computer webpage: http://blueos-avahi.local"


### PR DESCRIPTION
Cherry-pick from #3323

## Summary by Sourcery

Enhancements:
- Disable NetworkManager-wait-online.service at the end of installation script.