### PR TITLE
[1.4] frontend: vehicle-setup: fix and simplify logic for checking if compasses are calibrated

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
@@ -236,12 +236,10 @@ export default Vue.extend({
           results[compass.param] = false
           continue
         }
-        const scale_param_name = `COMPASS_SCALE${compass_number}`
-        const scale_param = autopilot_data.parameter(scale_param_name)
         const is_at_default_offsets = offset_params.every((param) => param?.value === 0.0)
         const is_at_default_diagonals = diagonal_params.every((param) => param?.value === 0.0)
-        results[compass.param] = offset_params.isEmpty() || diagonal_params.isEmpty()
-          || !is_at_default_offsets || !is_at_default_diagonals || scale_param?.value !== 0.0
+        results[compass.param] = !offset_params.isEmpty() && !diagonal_params.isEmpty()
+          && (!is_at_default_offsets || !is_at_default_diagonals)
       }
       return results
     },


### PR DESCRIPTION
…sses are calibrated

## Summary by Sourcery

Refine the compass calibration check in the OnboardSensors component to rely solely on offsets and diagonals and remove the scale parameter check

Bug Fixes:
- Fix compass calibration detection logic to correctly determine calibration status based on offset and diagonal parameters

Enhancements:
- Simplify the calibration check by removing the obsolete scale parameter check and requiring both offset and diagonal parameter sets to be non-empty and non-default