### PR TITLE
[1.4] Ardupilot_tools: update built-in ardusub to 4.5.3

### DIFF
--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -24,18 +24,18 @@ static_files = [
     StaticFile(
         defaults_folder,
         "ardupilot_navigator",
-        "https://firmware.ardupilot.org/Sub/stable-4.5.0/navigator/ardusub",
+        "https://firmware.ardupilot.org/Sub/stable-4.5.3/navigator/ardusub",
     ),
     StaticFile(
         defaults_folder,
         "ardupilot_navigator64",
-        "https://firmware.ardupilot.org/Sub/stable-4.5.1/navigator64/ardusub",
+        "https://firmware.ardupilot.org/Sub/stable-4.5.3/navigator64/ardusub",
     ),
     StaticFile(
-        defaults_folder, "ardupilot_pixhawk1", "https://firmware.ardupilot.org/Sub/stable-4.5.0/Pixhawk1/ardusub.apj"
+        defaults_folder, "ardupilot_pixhawk1", "https://firmware.ardupilot.org/Sub/stable-4.5.3/Pixhawk1/ardusub.apj"
     ),
     StaticFile(
-        defaults_folder, "ardupilot_pixhawk4", "https://firmware.ardupilot.org/Sub/stable-4.5.0/Pixhawk4/ardusub.apj"
+        defaults_folder, "ardupilot_pixhawk4", "https://firmware.ardupilot.org/Sub/stable-4.5.3/Pixhawk4/ardusub.apj"
     ),
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update built-in ArduSub firmware URLs to version 4.5.3 for navigator, navigator64, Pixhawk1, and Pixhawk4.