### PR TITLE
Frontend: ParamSets: fetch current board when mounted

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
@@ -73,6 +73,7 @@ import { SemVer } from 'semver'
 import Vue from 'vue'
 
 import * as AutopilotManager from '@/components/autopilot/AutopilotManagerUpdater'
+import { fetchCurrentBoard } from '@/components/autopilot/AutopilotManagerUpdater'
 import ParameterLoader from '@/components/parameter-editor/ParameterLoader.vue'
 import mavlink2rest from '@/libs/MAVLink2Rest'
 import {
@@ -138,6 +139,7 @@ export default Vue.extend({
     },
   },
   mounted() {
+    fetchCurrentBoard()
     this.loadParamSets()
   },
   methods: {


### PR DESCRIPTION
fixes an issue where, if the board information hasnt been set previously elsewhere, we are unable to filter the parameter sets

to be clearer: if you load the page directly (http://blueos.local/vehicle/setup/configure), it is unable to show the parameters