### PR TITLE
core: services: ardupilot_manager: mavlink_proxy: Save mavlink-server logs

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -40,7 +40,10 @@ class MAVLinkServer(AbstractRouter):
         filtered_endpoints = Endpoint.filter_enabled(self.endpoints())
         endpoints = " ".join([convert_endpoint(endpoint) for endpoint in [master_endpoint, *filtered_endpoints]])
 
-        return f"{self.binary()} {endpoints}"
+        if not self.log_path:
+            self.log_path = "/var/logs/blueos/services/mavlink-server/"
+
+        return f"{self.binary()} {endpoints} --log-path={self.log_path}"
 
     @staticmethod
     def name() -> str:

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -297,6 +297,7 @@ async def serial_test_mavlink_server(
     master_endpoints = create_endpoints_with_offset(valid_master_endpoints, 0)
 
     mavlink_server = MAVLinkServer()
+    mavlink_server.log_path = "./logs"
     assert mavlink_server.name() == "MAVLink-Server", "Name does not match."
     assert re.search(r"\d+.\d+.\d+", str(mavlink_server.version())) is not None, "Version does not follow pattern."
 


### PR DESCRIPTION
A bit dirty, but quick.

The clean way would be to pass it via CLI

Closes #3338

## Summary by Sourcery

Enhancements:
- Add --log-path argument to MAVLinkServer invocation to direct logs to the specified directory