### PR TITLE
core: services: ardupilot_manager: mavlink_proxy: Define missing self.log_path for MAVLinkServer

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -9,6 +9,7 @@ from mavlink_proxy.Endpoint import Endpoint, EndpointType
 class MAVLinkServer(AbstractRouter):
     def __init__(self) -> None:
         super().__init__()
+        self.log_path: Optional[str] = None
 
     def _get_version(self) -> Optional[str]:
         binary = self.binary()


### PR DESCRIPTION
….

## Summary by Sourcery

Enhancements:
- Add self.log_path initialization in MAVLinkServer.__init__