### PR TITLE
Fix comment typo in FirmwareDownload test

### DIFF
--- a/core/services/ardupilot_manager/firmware/test_FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareDownload.py
@@ -49,7 +49,7 @@ def test_firmware_download() -> None:
 
     assert firmware_download.download(Vehicle.Sub, Platform.SITL), "Failed to download SITL."
 
-    # skipt these tests for MacOS
+    # skip these tests for MacOS
     if platform.system() == "Darwin":
         pytest.skip("Skipping test for MacOS")
     # It'll fail if running in an arch different of ARM


### PR DESCRIPTION
## Summary
- correct a typo in firmware downloader test comment

## Testing
- `ruff check core/services/ardupilot_manager/firmware/test_FirmwareDownload.py`
- `mypy $(dirname setup.py) --cache-dir $(dirname setup.py)/__mypycache__` *(fails: Library stubs not installed for "requests")*
- `pytest core/services/ardupilot_manager/firmware/test_FirmwareDownload.py -q` *(fails: ModuleNotFoundError: No module named 'commonwealth')*

------
https://chatgpt.com/codex/tasks/task_e_683f4d3588e883218cc502887806d294