### PR TITLE
README: Remove trailing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ArduRover is an open-source, uncrewed boat platform. Whether you are commanding 
 
 ### **Submarines (ArduSub)**
 
-ArduSub is the go-to control system for remotely operated underwater vehicles (ROVs) 🐟. BlueOS offers seamless integration with ArduSub, enabling efficient management and operation of underwater vehicles. 
+ArduSub is the go-to control system for remotely operated underwater vehicles (ROVs) 🐟. BlueOS offers seamless integration with ArduSub, enabling efficient management and operation of underwater vehicles.
 
 [BlueROV2](https://bluerobotics.com/store/rov/bluerov2/) is supported out of the box.
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Remove trailing space at the end of the ArduSub description in README.md