### PR TITLE
core: Dockerfile: Update base to 0.2.2

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -23,7 +23,7 @@ set -e
 
 EOF
 
-FROM bluerobotics/blueos-base:0.2.1 AS base
+FROM bluerobotics/blueos-base:0.2.2 AS base
 
 # Download binaries
 FROM base AS download-binaries


### PR DESCRIPTION
[Changes](https://github.com/bluerobotics/blueos-docker-base/releases/tag/v0.2.2)

## Summary by Sourcery

Build:
- Bump base image in core Dockerfile from bluerobotics/blueos-base:0.2.1 to 0.2.2