### PR TITLE
Add sentry SDK on BlueOS backend

### DIFF
--- a/core/libs/commonwealth/pyproject.toml
+++ b/core/libs/commonwealth/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "loguru==0.5.3",
     "psutil==5.7.2",
     "pykson==1.0.2",
+    "sentry-sdk==2.29.1",
     "starlette==0.27.0",
 ]
 

--- a/core/libs/commonwealth/src/commonwealth/utils/sentry_config.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/sentry_config.py
@@ -1,0 +1,51 @@
+import os
+import re
+from typing import Any, Dict, Optional
+
+import sentry_sdk
+
+
+def _get_sentry_config() -> Optional[Dict[str, Any]]:
+    """
+    Retrieves the Sentry configuration for the BlueOS backend project
+
+    Returns:
+        Optional[ClientConstructor]: The Sentry configuration if valid, otherwise None.
+    """
+
+    SENTRY_PROJECT = "BlueOS"
+    SENTRY_DSN = "https://d93d1be8ddb7d5e1f45fb1eeca287eac@o4507696465707008.ingest.us.sentry.io/4509446521683968"
+    VALID_TAG_PATTERN = r"^\d+\.\d+\.\d+-\d+-g[0-9a-f]{7,}$"
+
+    git_describe_tag = os.environ.get("GIT_DESCRIBE_TAGS")
+
+    if not git_describe_tag or not re.match(VALID_TAG_PATTERN, git_describe_tag):
+        return
+
+    release = f"{SENTRY_PROJECT}@{git_describe_tag}".replace("tags/", "").replace("/", ":")
+
+    return {
+        "dsn": SENTRY_DSN,
+        "release": release,
+        "traces_sample_rate": 1.0,
+        "trace_propagation_targets": [],
+        "send_default_pii": True,
+    }
+
+
+def init_sentry(name: Optional[str] = None) -> None:
+    sentry_config = _get_sentry_config()
+    if sentry_config:
+        sentry_sdk.init(server_name=name, **sentry_config)
+
+
+async def init_sentry_async(name: Optional[str] = None) -> None:
+    """
+    Initializes Sentry when used in an async context.
+
+    Per sentry's documentation, when using async context, the init function should be called within an async function.
+    https://docs.sentry.io/platforms/python/#configure
+    """
+    sentry_config = _get_sentry_config()
+    if sentry_config:
+        sentry_sdk.init(server_name=name, **sentry_config)

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -4,6 +4,7 @@ import logging
 
 from commonwealth.utils.general import is_running_as_root
 from commonwealth.utils.logs import InterceptHandler, init_logger
+from commonwealth.utils.sentry_config import init_sentry_async
 from loguru import logger
 from uvicorn import Config, Server
 
@@ -23,25 +24,32 @@ from api import application
 if not is_running_as_root():
     raise RuntimeError("AutoPilot manager needs to run with root privilege.")
 
-if __name__ == "__main__":
-    args = CommandLineArgs.from_args()
 
+async def main() -> None:
+    await init_sentry_async(SERVICE_NAME)
+
+    args = CommandLineArgs.from_args()
     if args.debug:
         logging.getLogger(SERVICE_NAME).setLevel(logging.DEBUG)
 
     logger.info("Releasing the AutoPilot Manager service.")
-    loop = asyncio.new_event_loop()
 
-    config = Config(app=application, loop=loop, host=args.host, port=args.port, log_config=None)
+    config = Config(app=application, host=args.host, port=args.port, log_config=None)
     server = Server(config)
 
     if args.sitl:
         autopilot.set_preferred_board(BoardDetector.detect_sitl())
     try:
-        loop.run_until_complete(autopilot.start_ardupilot())
+        await autopilot.start_ardupilot()
     except Exception as start_error:
         logger.exception(start_error)
-    loop.create_task(autopilot.auto_restart_ardupilot())
-    loop.create_task(autopilot.start_mavlink_manager_watchdog())
-    loop.run_until_complete(server.serve())
-    loop.run_until_complete(autopilot.kill_ardupilot())
+
+    asyncio.create_task(autopilot.auto_restart_ardupilot())
+    asyncio.create_task(autopilot.start_mavlink_manager_watchdog())
+
+    await server.serve()
+    await autopilot.kill_ardupilot()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/core/services/bag_of_holding/main.py
+++ b/core/services/bag_of_holding/main.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -6,9 +7,10 @@ from typing import Any, Dict
 
 import appdirs
 import dpath
-import uvicorn
+from uvicorn import Config, Server
 from commonwealth.utils.apis import GenericErrorHandlingRoute
 from commonwealth.utils.logs import InterceptHandler, init_logger
+from commonwealth.utils.sentry_config import init_sentry_async
 from fastapi import Body, FastAPI, HTTPException
 from fastapi import Path as FastPath
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -108,6 +110,15 @@ async def root() -> HTMLResponse:
     return HTMLResponse(content=html_content, status_code=200)
 
 
-if __name__ == "__main__":
+async def main() -> None:
+    await init_sentry_async(SERVICE_NAME)
+
     # Running uvicorn with log disabled so loguru can handle it
-    uvicorn.run(app, host="0.0.0.0", port=9101, log_config=None)
+    config = Config(app=app, host="0.0.0.0", port=9101, log_config=None)
+    server = Server(config)
+
+    await server.serve()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/core/services/bridget/main.py
+++ b/core/services/bridget/main.py
@@ -1,10 +1,12 @@
 #! /usr/bin/env python3
+import asyncio
 import logging
 from typing import Any, List
 
-import uvicorn
+from uvicorn import Config, Server
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.logs import InterceptHandler, init_logger
+from commonwealth.utils.sentry_config import init_sentry_async
 from fastapi import FastAPI, status
 from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
@@ -75,6 +77,15 @@ async def read_items() -> Any:
     return HTMLResponse(content=html_content, status_code=200)
 
 
-if __name__ == "__main__":
+async def main() -> None:
+    await init_sentry_async(SERVICE_NAME)
+
     # Running uvicorn with log disabled so loguru can handle it
-    uvicorn.run(app, host="0.0.0.0", port=27353, log_config=None)
+    config = Config(app=app, host="0.0.0.0", port=27353, log_config=None)
+    server = Server(config)
+
+    await server.serve()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/core/services/log_zipper/main.py
+++ b/core/services/log_zipper/main.py
@@ -12,9 +12,12 @@ from typing import List
 
 from commonwealth.utils.general import available_disk_space_mb, delete_everything
 from commonwealth.utils.logs import InterceptHandler, init_logger
+from commonwealth.utils.sentry_config import init_sentry
 from loguru import logger
 
 SERVICE_NAME = "log-zipper"
+
+init_sentry(SERVICE_NAME)
 
 
 def zip_files(files: List[str], output_path: str) -> None:

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -531,6 +531,7 @@ dependencies = [
     { name = "loguru" },
     { name = "psutil" },
     { name = "pykson" },
+    { name = "sentry-sdk" },
     { name = "starlette" },
 ]
 
@@ -542,6 +543,7 @@ requires-dist = [
     { name = "loguru", specifier = "==0.5.3" },
     { name = "psutil", specifier = "==5.7.2" },
     { name = "pykson", url = "https://github.com/patrickelectric/pykson/archive/refs/tags/1.0.2.tar.gz" },
+    { name = "sentry-sdk", specifier = "==2.29.1" },
     { name = "starlette", specifier = "==0.27.0" },
 ]
 
@@ -1640,6 +1642,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/6c/a536cc008f38fd83b3c1b98ce19ead13b746b5588c9a0cb9dd9f6ea434bc/semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc", size = 214988, upload-time = "2023-10-09T11:58:25.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/77/0cc7a8a3bc7e53d07e8f47f147b92b0960e902b8254859f4aee5c4d7866b/semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4", size = 17099, upload-time = "2023-10-09T11:58:24.128Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/67/d552a5f8e5a6a56b2feea6529e2d8ccd54349084c84176d5a1f7295044bc/sentry_sdk-2.29.1.tar.gz", hash = "sha256:8d4a0206b95fa5fe85e5e7517ed662e3888374bdc342c00e435e10e6d831aa6d", size = 325518, upload-time = "2025-05-19T14:27:38.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/e5/da07b0bd832cefd52d16f2b9bbbe31624d57552602c06631686b93ccb1bd/sentry_sdk-2.29.1-py2.py3-none-any.whl", hash = "sha256:90862fe0616ded4572da6c9dadb363121a1ae49a49e21c418f0634e9d10b4c19", size = 341553, upload-time = "2025-05-19T14:27:36.882Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Initialize Sentry in each backend service using new commonwealth utils and standardize service startup logic with async main() functions

New Features:
- Integrate Sentry SDK for error monitoring across BlueOS backend services
- Add async and sync Sentry initialization hooks in commonwealth utilities

Enhancements:
- Refactor all service entrypoints to use async main() with asyncio.run and centralized Server/Config or AppRunner startup patterns
- Replace manual event loop management and uvicorn.run invocations with unified async startup flows

Build:
- Add sentry-sdk as a project dependency