### PR TITLE
core:frontend:FirmwareManager: Add BL board info

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -73,6 +73,7 @@
         <theme-tray-menu />
         <system-checker-tray-menu />
         <vehicle-reboot-required-tray-menu />
+        <on-board-computer-required-tray-menu />
         <pirate-mode-tray-menu />
         <internet-tray-menu />
         <wifi-tray-menu />
@@ -403,6 +404,7 @@ import Alerter from './components/app/Alerter.vue'
 import BackendStatusChecker from './components/app/BackendStatusChecker.vue'
 import InternetTrayMenu from './components/app/InternetTrayMenu.vue'
 import NewVersionNotificator from './components/app/NewVersionNotificator.vue'
+import OnBoardComputerRequiredTrayMenu from './components/app/OnBoardComputerRequiredTrayMenu.vue'
 import PiradeModeTrayMenu from './components/app/PirateModeTrayMenu.vue'
 import PowerMenu from './components/app/PowerMenu.vue'
 import ReportMenu from './components/app/ReportMenu.vue'
@@ -453,6 +455,7 @@ export default Vue.extend({
     'new-version-notificator': NewVersionNotificator,
     SystemCheckerTrayMenu,
     VehicleRebootRequiredTrayMenu,
+    OnBoardComputerRequiredTrayMenu,
     Wizard: defineAsyncComponent(() => import('@/components/wizard/Wizard.vue')),
   },
 

--- a/core/frontend/src/components/app/OnBoardComputerRebootMenu.vue
+++ b/core/frontend/src/components/app/OnBoardComputerRebootMenu.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-card
+    class="d-flex flex-column align-center pa-3"
+    outlined
+    width="350"
+  >
+    <v-alert
+      type="info"
+      icon="mdi-skull-crossbones"
+      elevation="1"
+      text
+    >
+      On-board computer reboot is necessary.
+    </v-alert>
+    <v-btn
+      @click="rebootOnBoardComputer"
+    >
+      Reboot On-board Computer
+    </v-btn>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import commander from '@/store/commander'
+
+export default Vue.extend({
+  name: 'OnBoardComputerRebootMenu',
+  methods: {
+    rebootOnBoardComputer() {
+      commander.rebootOnBoardComputer()
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/app/OnBoardComputerRequiredTrayMenu.vue
+++ b/core/frontend/src/components/app/OnBoardComputerRequiredTrayMenu.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-menu
+    v-if="commander.on_board_computer_reboot_required"
+    v-model="show_menu"
+    :close-on-content-click="false"
+    nudge-left="200"
+    nudge-bottom="25"
+  >
+    <template
+      #activator="{ on, attrs }"
+    >
+      <v-card
+        id="pirate-mode-tray-menu-button"
+        class="px-1"
+        elevation="0"
+        color="transparent"
+        v-bind="attrs"
+        v-on="on"
+      >
+        <v-icon
+          class="blinking"
+        >
+          mdi-restart-alert
+        </v-icon>
+      </v-card>
+    </template>
+    <on-board-computer-reboot-menu
+      @vehicleRebootCalled="showMenu(false)"
+    />
+  </v-menu>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import commander from '@/store/commander'
+
+import OnBoardComputerRebootMenu from './OnBoardComputerRebootMenu.vue'
+
+export default Vue.extend({
+  name: 'OnBoardComputerRequiredTrayMenu',
+  components: {
+    OnBoardComputerRebootMenu,
+  },
+  data: () => ({
+    commander,
+    show_menu: false,
+  }),
+  methods: {
+    showMenu(show: boolean): void {
+      this.show_menu = show
+    },
+  },
+})
+</script>
+
+<style scoped>
+  .blinking {
+    animation-name: blinking;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+  }
+
+  @keyframes blinking {
+    100% {color: red;}
+    75% {color: yellow;}
+    50% {color: red;}
+    25% {color: yellow;}
+    0% {color: red;}
+  }
+
+  .white-shadow {
+    text-shadow: 0 0 3px #FFF;
+  }
+</style>

--- a/core/frontend/src/components/app/PowerMenu.vue
+++ b/core/frontend/src/components/app/PowerMenu.vue
@@ -129,6 +129,7 @@ export default Vue.extend({
       settings,
       service_status: Status.None,
       show_dialog: false,
+      commander,
     }
   },
   computed: {
@@ -152,6 +153,17 @@ export default Vue.extend({
     },
     show_spinner(): boolean {
       return this.service_status !== Status.None && this.service_status !== Status.PowerOff
+    },
+  },
+  watch: {
+    'commander.on_board_computer_immediate_reboot': {
+      immediate: true,
+      handler(newValue: boolean) {
+        if (newValue) {
+          this.showDialog(true)
+          this.reboot()
+        }
+      },
     },
   },
   methods: {


### PR DESCRIPTION
* Add auto detection of bricked boards (Only bootloader boards available)
* Allow board selection in case of bricked board detected and auto select by default first bootloader board available
* Add tooltip info for user that board is corrupted and how to recover

NOTE: All yellow arrows and texts related to arrows are added on the screenshot only to explanation.

Case 1: Only BL board detected, user is either in Normal or Pirate mode and SITL is not explicitly selected:
![image](https://github.com/user-attachments/assets/423954fb-3c9d-4e41-9f00-569b444e64f0)

Case 2: Case 1 is a pre-requirement, user tried to re-flash firmware but it failed, instruct a reboot of onboard computer so USB controller on board is reset.
![image](https://github.com/user-attachments/assets/09684eb4-6d42-41cf-92cf-0d873a89be36)

Extra: Added reboot on board computer needed.
![image](https://github.com/user-attachments/assets/aec30237-aa04-46fe-b2f2-b196d57690f0)

## Summary by Sourcery

Handle cases where only bootloader boards are detected by prompting the user with recovery instructions, enabling board selection, and providing an onboard computer reboot workflow through new store actions and UI components.

New Features:
- Auto-detect when only bootloader boards are available and display a warning with recovery instructions
- Allow user to select among bootloader boards and default to the first detected bootloader board
- Offer a button and tooltip to reboot the onboard computer after a failed firmware install
- Implement a Vuex commander module to track and trigger onboard computer reboot state
- Add tray menu and dialog components to notify the user and execute onboard computer reboot

Enhancements:
- Automatically request an onboard computer reboot when firmware installation fails on corrupted firmware
- Integrate the reboot-required flag into the PowerMenu and global app components