### PR TITLE
core: frontend: src: MainView.vue: fix incorrect vehicle rotations

### DIFF
--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -190,7 +190,7 @@ export default Vue.extend({
       const msg = mavlink_store_get(mavlink, 'ATTITUDE.messageData.message') as
         { roll: number; pitch: number; yaw: number } | undefined
       if (!msg) return '0deg 0deg 0deg'
-      return `${msg.roll}rad ${msg.pitch}rad ${msg.yaw}rad`
+      return `${msg.roll}rad ${-msg.pitch}rad ${-msg.yaw}rad`
     },
   },
   mounted() {


### PR DESCRIPTION
model-viewer's [orientation convention](https://modelviewer.dev/docs/index.html#entrydocs-scenegraph-attributes-orientation) has inverted pitch and yaw directions compared to the aeronautical frame used by MAVLink's [ATTITUDE](https://mavlink.io/en/messages/common.html#ATTITUDE) message.

## Summary by Sourcery

Bug Fixes:
- Negate pitch and yaw values when rendering vehicle orientation to correct frame convention mismatch