### PR TITLE
core: libs: commonwealth: utils: logs: Move log to run as client

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/logs.py
@@ -92,7 +92,10 @@ def create_log_sink(service_name: str) -> Callable[[_handler.Message], None]:
     Returns:
         A function that can be used as a loguru sink
     """
-    session = zenoh.open(zenoh.Config())
+    zenoh_config = zenoh.Config()
+    zenoh_config.insert_json5("mode", json.dumps("client"))
+    zenoh_config.insert_json5("connect/endpoints", json.dumps(["tcp/127.0.0.1:7447"]))
+    session = zenoh.open(zenoh_config)
     topic = f"services/{service_name}/log"
 
     def sink(message: _handler.Message) -> None:


### PR DESCRIPTION
Green is client:
![image](https://github.com/user-attachments/assets/dc01fe67-e562-4e74-bda6-f74e73d4fa8c)


Enhancements:
- Configure the log sink to open the zenoh session in client mode with a default TCP endpoint