### PR TITLE
backend: Update zenoh to latest version

### DIFF
--- a/core/libs/commonwealth/pyproject.toml
+++ b/core/libs/commonwealth/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "aiohttp==3.7.4",
     "appdirs==1.4.4",
-    "eclipse-zenoh==1.4.0",
+    "eclipse-zenoh==1.5.0",
     "loguru==0.5.3",
     "psutil==5.7.2",
     "pykson==1.0.2",

--- a/core/tools/zenoh/bootstrap.sh
+++ b/core/tools/zenoh/bootstrap.sh
@@ -4,7 +4,7 @@
 set -e
 
 PROJECT_NAME="zenoh"
-VERSION="1.3.4"
+VERSION="1.5.0"
 BINARIES=(
   "zenoh"
   "zenoh-plugin-webserver"


### PR DESCRIPTION
Update everything besides frontend to 1.5.0
The frontend requires a major change since the api changed a lot, will work around it in the next PR