### PR TITLE
core: tools: mavlink-server: Update to 0.5.6

### DIFF
--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.5.5"
+VERSION="0.5.6"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
Run zenoh as a client

## Summary by Sourcery

Chores:
- Update bootstrap.sh to set VERSION from 0.5.5 to 0.5.6