### PR TITLE
zenoh: Add metadata information

### DIFF
--- a/core/frontend/src/components/zenoh-inspector/ZenohNetwork.vue
+++ b/core/frontend/src/components/zenoh-inspector/ZenohNetwork.vue
@@ -60,7 +60,7 @@ import {
   Config, QueryTarget, Receiver, RecvErr, ReplyError,
   Sample, Session,
 } from '@eclipse-zenoh/zenoh-ts'
-import cytoscape from 'cytoscape'
+import cytoscape, { Core } from 'cytoscape'
 import fcose from 'cytoscape-fcose'
 import Vue from 'vue'
 
@@ -82,7 +82,7 @@ export default Vue.extend({
   data() {
     return {
       session: null as Session | null,
-      cy: null as typeof cytoscape | null,
+      cy: null as Core | null,
       loading: false,
       networkData: {
         nodes: [] as NetworkNode[],

--- a/core/libs/commonwealth/src/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/logs.py
@@ -93,6 +93,8 @@ def create_log_sink(service_name: str) -> Callable[[_handler.Message], None]:
         A function that can be used as a loguru sink
     """
     zenoh_config = zenoh.Config()
+    zenoh_config.insert_json5("adminspace", json.dumps({"enabled": True}))
+    zenoh_config.insert_json5("metadata", json.dumps({"name": service_name}))
     zenoh_config.insert_json5("mode", json.dumps("client"))
     zenoh_config.insert_json5("connect/endpoints", json.dumps(["tcp/127.0.0.1:7447"]))
     session = zenoh.open(zenoh_config)

--- a/core/tools/zenoh/blueos-zenoh.json5
+++ b/core/tools/zenoh/blueos-zenoh.json5
@@ -1,4 +1,10 @@
 {
+  adminspace: {
+    enabled: true
+  },
+  metadata: {
+    name: "vehicle"
+  },
   plugins: {
     rest: { http_port: 7117 },
     remote_api: { websocket_port: 7118 }


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

## Summary by Sourcery

Add metadata support across the Zenoh network inspector and logging utilities to enrich node information and graph labeling.

New Features:
- Display optional node names and generic metadata fields in the Zenoh network graph
- Perform per-node queries to fetch and merge detailed metadata during network discovery
- Configure the logging sink to include service name metadata and enable adminspace

Enhancements:
- Use a dedicated label field (name or id) for cytoscape node labels and refine cytoscape typing