### PR TITLE
github:sync-submodules: Block running on forks

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -9,6 +9,7 @@ name: Sync Submodules
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: github.repository == 'bluerobotics/BlueOS'
 
     permissions:
       contents: write


### PR DESCRIPTION
* Since this action may run on the forks it can create commits on master and make a mess when updating the fork.

## Summary by Sourcery

CI:
- Add an `if: github.repository == 'bluerobotics/BlueOS'` check to the sync-submodules job