### PR TITLE
core: frontend: views MainView: Only break around spaces

### DIFF
--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -54,6 +54,7 @@
                 >
                   <v-card-title
                     class="text-subtitle-2 font-weight-bold"
+                    style="word-break: break-word;"
                     v-text="title"
                   />
                   <v-avatar


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3d4dd48e-6b36-4854-af3e-219b08227d2d)

![image](https://github.com/user-attachments/assets/b3075d97-25f0-473f-846e-47e5248fc468)

## Summary by Sourcery

Bug Fixes:
- Limit word-wrapping in MainView titles to spaces to prevent mid-word breaks