### PR TITLE
core: frontend: src: update ArduPilot barometer types

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/BaroCalib.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/BaroCalib.vue
@@ -120,7 +120,7 @@ export default Vue.extend({
       for (const baro of this.baros) {
         // BARO_SPEC_GRAV Only exist for underwater vehicles
         const spec_gravity_param = autopilot_data.parameter('BARO_SPEC_GRAV')
-        const water = ['MS5837', 'MS5611', 'KELLERLD'].includes(baro.deviceName ?? '--')
+        const water = ['MS5837_30BA', 'MS5837_02BA', 'MS5611', 'KELLERLD'].includes(baro.deviceName ?? '--')
         && autopilot.vehicle_type === 'Submarine' && baro.busType === BUS_TYPE.I2C
         && baro.bus === this.external_i2c_bus
         if (water) {

--- a/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
@@ -255,7 +255,7 @@ export default Vue.extend({
     is_water_baro(): Dictionary<boolean> {
       const results = {} as Dictionary<boolean>
       for (const baro of this.baros) {
-        if (['MS5837', 'MS5611', 'KELLERLD'].includes(baro.deviceName ?? '--')
+        if (['MS5837_30BA', 'MS5837_02BA', 'MS5611', 'KELLERLD'].includes(baro.deviceName ?? '--')
         && autopilot.vehicle_type === 'Submarine' && baro.busType === BUS_TYPE.I2C
         && baro.bus === this.external_i2c_bus) {
           results[baro.param] = true

--- a/core/frontend/src/utils/deviceid_decoder.ts
+++ b/core/frontend/src/utils/deviceid_decoder.ts
@@ -90,9 +90,13 @@ enum BARO_TYPE {
   ICP101XX = 0x0F,
   ICP201XX = 0x10,
   MS5607 = 0x11,
-  MS5837 = 0x12,
+  MS5837_30BA = 0x12,
   MS5637 = 0x13,
   BMP390 = 0x14,
+  BMP581 = 0x15,
+  SPA06 = 0x16,
+  AUAV = 0x17,
+  MS5837_02BA = 0x18,
 }
 
 enum AIRSPEED_TYPE {


### PR DESCRIPTION
- Adds Bar02 recognition, since [it is now supported in ArduPilot](https://github.com/ArduPilot/ardupilot/pull/29122)
- Adds the other latest barometer types, which hadn't been copied over yet

Note: untested (my hardware is still on a ship for the next couple of weeks).
Likely easiest to test switching between a Bar02 and Bar30 sensor, running the latest Dev release of ArduSub (with an autopilot reboot in between, since IIRC sensor initialisation only occurs at startup).

## Summary by Sourcery

Add support for newly introduced ArduPilot barometer models and update frontend detection accordingly.

Enhancements:
- Update BARO_TYPE enum to include MS5837_30BA, MS5837_02BA (Bar02), BMP581, SPA06, and AUAV types
- Adjust water barometer detection logic in BaroCalib.vue and OnboardSensors.vue to recognize the new MS5837 variants