### PR TITLE
core:(frontend/startup): Modify Cloud token system

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -46,6 +46,10 @@
                 "bind": "/root/.docker",
                 "mode": "rw"
             },
+            "/root/.majortom": {
+                "bind": "/root/.majortom",
+                "mode": "rw"
+            },
             "/etc/blueos": {
                 "bind": "/etc/blueos",
                 "mode": "rw"

--- a/core/tools/blueos_startup_update/blueos_startup_update.py
+++ b/core/tools/blueos_startup_update/blueos_startup_update.py
@@ -33,6 +33,7 @@ DELTA_JSON = {
             "/home/pi/.ssh": {"bind": "/home/pi/.ssh", "mode": "rw"},
             "/home/pi/.docker": {"bind": "/home/pi/.docker", "mode": "rw"},
             "/root/.docker": {"bind": "/root/.docker", "mode": "rw"},
+            "/root/.majortom": {"bind": "/root/.majortom", "mode": "rw"},
             "/run/udev": {"bind": "/run/udev", "mode": "ro"},
             "/sys/": {"bind": "/sys/", "mode": "rw"},
             "/usr/blueos/bin": {"bind": "/usr/blueos/bin", "mode": "rw"},


### PR DESCRIPTION
* Change to save cloud token system in independent file instead of the bag
* Add docker binds for file

## Summary by Sourcery

Modify the cloud token system to persist tokens in a dedicated file with fallback and cleanup logic, integrate filebrowser operations, and update Docker binds for the new storage path.

Enhancements:
- Persist Major Tom cloud token to a dedicated file instead of the Vuex bag
- Implement filebrowser-based read, write, and cleanup methods for token management
- Retain backward compatibility by falling back to bag storage when no token file exists

Build:
- Add Docker bind mount for "/root/.majortom" to support file-based token storage