### PR TITLE
Improve display information of serial ports

### DIFF
--- a/core/frontend/src/components/autopilot/AutopilotSerialConfiguration.vue
+++ b/core/frontend/src/components/autopilot/AutopilotSerialConfiguration.vue
@@ -27,7 +27,28 @@
             :height="'150px'"
             :device="data.item"
           />
-          {{ data.item }}
+          <table class="dense-table">
+            <tr>
+              <th>Path</th>
+              <td>{{ data.item }}</td>
+            </tr>
+            <tr v-if="deviceInfo(data.item)?.DEVNAME">
+              <th>Device</th>
+              <td>{{ deviceInfo(data.item)?.DEVNAME }}</td>
+            </tr>
+            <tr v-if="deviceInfo(data.item)?.ID_MODEL">
+              <th>Model</th>
+              <td>{{ deviceInfo(data.item)?.ID_MODEL }}</td>
+            </tr>
+            <tr v-if="deviceInfo(data.item)?.ID_USB_DRIVER">
+              <th>Driver</th>
+              <td>{{ deviceInfo(data.item)?.ID_USB_DRIVER }}</td>
+            </tr>
+            <tr v-if="deviceInfo(data.item)?.ID_SERIAL">
+              <th>Serial</th>
+              <td>{{ deviceInfo(data.item)?.ID_SERIAL }}</td>
+            </tr>
+          </table>
         </v-chip>
       </template>
       <template #selection="{ attrs, item, parent }">
@@ -36,7 +57,7 @@
           v-bind="attrs"
           small
         >
-          {{ item }}
+          {{ condensedDeviceInfo(item) }}
           <v-icon
             class="ml-1"
             small
@@ -73,7 +94,7 @@ import { OneMoreTime } from '@/one-more-time'
 import autopilot from '@/store/autopilot_manager'
 import system_information from '@/store/system-information'
 import { SerialEndpoint } from '@/types/autopilot'
-import { Dictionary } from '@/types/common'
+import { Dictionary, JSONValue } from '@/types/common'
 import back_axios from '@/utils/api'
 import { isIpAddress } from '@/utils/pattern_validators'
 
@@ -137,6 +158,17 @@ export default Vue.extend({
     this.update_ports(this.current_serial_ports)
   },
   methods: {
+    condensedDeviceInfo(path: string): string {
+      const info = this.deviceInfo(path)
+      const device = info.DEVNAME ?? path
+      const driver = info.ID_USB_DRIVER
+      const serial = info.ID_SERIAL
+      const names = [device, driver, serial].filter((name) => name !== undefined)
+      return names.join(' - ')
+    },
+    deviceInfo(path: string): JSONValue {
+      return system_information.serial?.ports?.find((port) => port.by_path === path)?.udev_properties ?? {}
+    },
     update_ports(new_ports: SerialEndpoint[]) {
       for (const port of new_ports) {
         if (this.ports[port.port] === undefined) {
@@ -203,3 +235,23 @@ export default Vue.extend({
   },
 })
 </script>
+
+<style scoped>
+.dense-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 13px;
+}
+.dense-table th,
+.dense-table td {
+  border: 1px solid;
+  padding: 2px 6px;
+  text-align: left;
+  vertical-align: middle;
+}
+.dense-table th {
+  font-weight: 600;
+  width: 1%;
+  white-space: nowrap;
+}
+</style>

--- a/core/frontend/src/components/common/DevicePathHelper.vue
+++ b/core/frontend/src/components/common/DevicePathHelper.vue
@@ -56,20 +56,20 @@ const standard_connector_map: Dictionary<string> = {
   '/dev/ttyAMA2': 'serial4',
   '/dev/ttyAMA3': 'serial5',
   // Pi4
-  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3:1.0-port0': 'top-left',
-  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.0-port0': 'bottom-left',
-  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.1:1.0-port0': 'top-right',
-  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.2:1.0-port0': 'bottom-right',
+  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3': 'top-left',
+  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4': 'bottom-left',
+  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.1': 'top-right',
+  '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.2': 'bottom-right',
   // Pi3
-  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.5:1.0-port0': 'bottom-right',
-  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.4:1.0-port0': 'top-right',
-  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.3:1.0-port0': 'bottom-left',
-  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.2:1.0-port0': 'top-left',
+  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.5:1': 'bottom-right',
+  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.4:1': 'top-right',
+  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.3:1': 'bottom-left',
+  '/dev/serial/by-path/platform-3f980000.usb-usb-0:1.2:1': 'top-left',
   // Pi5
-  '/dev/serial/by-path/platform-xhci-hcd.1-usb-0:1:1.0-port0': 'top-left',
-  '/dev/serial/by-path/platform-xhci-hcd.0-usb-0:1:1.0-port0': 'bottom-left',
-  '/dev/serial/by-path/platform-xhci-hcd.0-usb-0:2:1.0-port0': 'top-right',
-  '/dev/serial/by-path/platform-xhci-hcd.1-usb-0:2:1.0-port0': 'bottom-right',
+  '/dev/serial/by-path/platform-xhci-hcd.1-usb-0:1': 'top-left',
+  '/dev/serial/by-path/platform-xhci-hcd.0-usb-0:1': 'bottom-left',
+  '/dev/serial/by-path/platform-xhci-hcd.0-usb-0:2': 'top-right',
+  '/dev/serial/by-path/platform-xhci-hcd.1-usb-0:2': 'bottom-right',
 
 }
 
@@ -174,9 +174,9 @@ export default Vue.extend({
       }
     },
     board_connector() : string | undefined {
-      const connector = this.updated_connector_map[this.serial_port_path]
-      this.setSvgConnector(connector)
-      return connector
+      const usbRoot = this.serial_port_path.split('-port0')[0]
+      const connector = Object.entries(this.updated_connector_map).find(([key, _]) => usbRoot.includes(key))
+      return connector?.[1]
     },
   },
   mounted() {

--- a/core/frontend/src/components/common/DevicePathHelper.vue
+++ b/core/frontend/src/components/common/DevicePathHelper.vue
@@ -1,6 +1,9 @@
 <template>
   <div v-if="board_connector">
     <template v-if="inline">
+      <div v-if="usbOverlayInfo" class="usb-overlay">
+        {{ usbOverlayInfo }}
+      </div>
       <object
         :class="inline_name"
         type="image/svg+xml"
@@ -21,6 +24,9 @@
           mdi-eye
         </v-icon>
       </template>
+      <div v-if="usbOverlayInfo" class="usb-overlay">
+        {{ usbOverlayInfo }}
+      </div>
       <object
         :class="svgName"
         type="image/svg+xml"
@@ -178,6 +184,14 @@ export default Vue.extend({
       const connector = Object.entries(this.updated_connector_map).find(([key, _]) => usbRoot.includes(key))
       return connector?.[1]
     },
+    usbOverlayInfo(): string | null {
+      // This regex matches ...usb-0:1.4.3:1.0... and captures the last number before :1.0 (the hub port)
+      const match = this.serial_port_path.match(/usb-0:(?:[0-9]+\.)+([0-9]+):1\.0/)
+      if (match) {
+        return `Connected via hub, device is on hub port ${match[1]}`
+      }
+      return null
+    },
   },
   mounted() {
     // Wait for svg element to be loaded to set object
@@ -215,3 +229,18 @@ export default Vue.extend({
   },
 })
 </script>
+
+<style scoped>
+.usb-overlay {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 14px;
+  z-index: 10;
+  pointer-events: none;
+}
+</style>


### PR DESCRIPTION
before:
![Screenshot 2025-07-01 at 21 46 12](https://github.com/user-attachments/assets/6df60283-4dd0-4194-aa5a-1044b1b68aff)

after:
![Screenshot 2025-07-01 at 21 44 55](https://github.com/user-attachments/assets/e83d5414-4e85-4bd2-90e6-4465eb69a8af)

## Summary by Sourcery

Improve serial port display by presenting richer device metadata in both detailed and summarized views and enhance the DevicePathHelper component to indicate hub port connections with updated path mapping logic.

New Features:
- Display detailed udev metadata (path, device, model, driver, serial) in the serial port configuration list
- Show an overlay message on device path icons indicating the USB hub port connection

Enhancements:
- Add condensedDeviceInfo and deviceInfo methods to summarize and lookup port properties
- Refactor serial path mapping and board_connector logic to use generalized path segments
- Apply scoped CSS for a dense metadata table and a USB overlay badge