### PR TITLE
core: tools: mavlink-server: Update to 0.5.8

### DIFF
--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.5.7"
+VERSION="0.5.8"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
Add zenoh scheme and encoding information

## Summary by Sourcery

Update mavlink-server to version 0.5.8 to incorporate the new zenoh scheme and encoding information

New Features:
- Add zenoh scheme and encoding information to mavlink-server

Enhancements:
- Bump mavlink-server version to 0.5.8 in bootstrap script