### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.21.0

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.20.3"
+VERSION="t3.21.0"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
move to CDR, zenoh scheme and encoding information

## Summary by Sourcery

Enhancements:
- Bump bootstrap.sh VERSION variable to t3.21.0