### PR TITLE
Fixing JSON typo in SITLFrame

### DIFF
--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -58,7 +58,7 @@ class SITLFrame(str, Enum):
     SCRIMMAGE = "scrimmage"
     WEBOTS = "webots"
     JSON = "JSON"
-    UNDEFINED = " undefined"
+    UNDEFINED = "undefined"
 
 
 def get_sitl_platform_name(machine_arch: str) -> str:

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -57,7 +57,7 @@ class SITLFrame(str, Enum):
     AIRSIM = "airsim"
     SCRIMMAGE = "scrimmage"
     WEBOTS = "webots"
-    JSON = " JSON"
+    JSON = "JSON"
     UNDEFINED = " undefined"
 
 


### PR DESCRIPTION
Quick fix to the typo mentioned in #3419

## Summary by Sourcery

Fix erroneous leading spaces in SITLFrame enum string values

Bug Fixes:
- Remove leading space from JSON enum value
- Remove leading space from UNDEFINED enum value