### PR TITLE
Add BlueOS recorder

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -109,6 +109,7 @@ COPY run-service.sh /usr/bin/run-service
 # Copy binaries and necessary folders from download-binaries to this stage
 COPY --from=download-binaries \
     /usr/bin/blueos_startup_update.py \
+    /usr/bin/blueos-recorder \
     /usr/bin/bridges \
     /usr/bin/linux2rest \
     /usr/bin/machineid-cli \

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -133,6 +133,7 @@ SERVICES=(
     'nginx',250,"nice -18 nginx -g \"daemon off;\" -c $TOOLS_PATH/nginx/nginx.conf"
     'log_zipper',250,"nice -20 $SERVICES_PATH/log_zipper/main.py '/shortcuts/system_logs/\\\\*\\\\*/\\\\*.log' --max-age-minutes 60"
     'bag_of_holding',250,"$SERVICES_PATH/bag_of_holding/main.py"
+    'recorder',250,"blueos-recorder --recorder-path /usr/blueos/userdata/recorder"
 )
 
 tmux -f /etc/tmux.conf start-server

--- a/core/tools/install-static-binaries.sh
+++ b/core/tools/install-static-binaries.sh
@@ -13,6 +13,7 @@ TOOLS=(
     mavlink2rest
     mavlink_camera_manager
     mavlink_server
+    recorder
     ttyd
     zenoh
 )

--- a/core/tools/recorder/bootstrap.sh
+++ b/core/tools/recorder/bootstrap.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Immediately exit on errors
+set -e
+
+VERSION="0.0.2"
+PROJECT_NAME="blueos-recorder"
+REPOSITORY_ORG="bluerobotics"
+REPOSITORY_NAME="$PROJECT_NAME"
+REPOSITORY_URL="https://github.com/$REPOSITORY_ORG/$REPOSITORY_NAME"
+
+echo "Installing project $PROJECT_NAME version $VERSION"
+
+# Step 1: Prepare the download URL
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64 | amd64)
+    BUILD_NAME="x86_64-unknown-linux-musl"
+    ;;
+  armv7l | armhf)
+    BUILD_NAME="armv7-unknown-linux-musleabihf"
+    ;;
+  aarch64 | arm64)
+    BUILD_NAME="aarch64-unknown-linux-musl"
+    ;;
+  *)
+    echo "Architecture: $ARCH is unsupported, please create a new issue on https://github.com/bluerobotics/BlueOS/issues"
+    exit 1
+    ;;
+esac
+ARTIFACT_NAME="$PROJECT_NAME-$BUILD_NAME"
+echo "For architecture $ARCH, using build $BUILD_NAME"
+
+REMOTE_URL="$REPOSITORY_URL/releases/download/$VERSION/$ARTIFACT_NAME"
+echo "Remote URL is $REMOTE_URL"
+
+# Step 2: Prepare the installation path
+
+if [ -n "$VIRTUAL_ENV" ]; then
+    BIN_DIR="$VIRTUAL_ENV/bin"
+else
+    BIN_DIR="/usr/bin"
+fi
+mkdir -p "$BIN_DIR"
+
+BINARY_PATH="$BIN_DIR/$PROJECT_NAME"
+echo "Installing to $BINARY_PATH"
+
+# Step 3: Download and install
+
+wget -q "$REMOTE_URL" -O "$BINARY_PATH"
+chmod +x "$BINARY_PATH"
+
+echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
+
+echo "Finished installing $PROJECT_NAME"


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

## Summary by Sourcery

Add BlueOS recorder support by incorporating its binary into the Docker image, updating the static binaries installer, and supplying a versioned bootstrap installer for different CPU architectures.

New Features:
- Include blueos-recorder binary in the core Docker image
- Add recorder to the static binaries installation list
- Provide a bootstrap.sh installer script to download and install blueos-recorder for multiple architectures