### PR TITLE
core: tools: install-system-tools: Remove linux2rest

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -110,6 +110,7 @@ COPY run-service.sh /usr/bin/run-service
 COPY --from=download-binaries \
     /usr/bin/blueos_startup_update.py \
     /usr/bin/bridges \
+    /usr/bin/linux2rest \
     /usr/bin/machineid-cli \
     /usr/bin/mavlink2rest \
     /usr/bin/mavlink-server \

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -7,7 +7,6 @@ set -e
 TOOLS=(
     ardupilot_tools
     filebrowser
-    linux2rest
     logviewer
     mavlink_camera_manager
     scripts


### PR DESCRIPTION
Already installed by install-static-binaries

## Summary by Sourcery

Chores:
- Exclude linux2rest from the core/tools/install-system-tools.sh since it’s already installed by install-static-binaries