### PR TITLE
core: tools: Move mavlink-camera-manager from install-system-tools to install-static-tools

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -112,6 +112,7 @@ COPY --from=download-binaries \
     /usr/bin/bridges \
     /usr/bin/machineid-cli \
     /usr/bin/mavlink2rest \
+    /usr/bin/mavlink-camera-manager \
     /usr/bin/mavlink-server \
     /usr/bin/zenoh \
     /usr/bin/ttyd \

--- a/core/tools/install-static-binaries.sh
+++ b/core/tools/install-static-binaries.sh
@@ -11,6 +11,7 @@ TOOLS=(
     linux2rest
     machineid
     mavlink2rest
+    mavlink_camera_manager
     mavlink_server
     ttyd
     zenoh

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -9,7 +9,6 @@ TOOLS=(
     filebrowser
     linux2rest
     logviewer
-    mavlink_camera_manager
     scripts
     wifi
 )


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

## Summary by Sourcery

Relocate mavlink-camera-manager from the system tools installer to the static tools installer and update the Dockerfile accordingly.

Enhancements:
- Move mavlink-camera-manager entry from install-system-tools.sh to install-static-binaries.sh
- Include mavlink-camera-manager in the static tools list for installation

Build:
- Add mavlink-camera-manager to the Dockerfile copy directive for static tools