### PR TITLE
Ping: handle timeouts as failures (backport)

### DIFF
--- a/core/services/ping/pingdriver.py
+++ b/core/services/ping/pingdriver.py
@@ -41,7 +41,11 @@ class PingDriver:
             ping = PingDevice()
             ping.connect_serial(self.ping.port.device, baud)
             for _ in range(attempts):
-                device_info = ping.request(COMMON_DEVICE_INFORMATION, timeout=0.1)
+                device_info = None
+                try:
+                    device_info = ping.request(COMMON_DEVICE_INFORMATION, timeout=0.1)
+                except Exception as e:
+                    logger.warning(f"Failed to request device information during baudrate detection: {e}")
                 if device_info is None:
                     failures += 1
                     if failures > max_failures:


### PR DESCRIPTION
backporting #3430 to stable.
for extra-safety, It would be nice if @vshie tested it before we merge

## Summary by Sourcery

Enhancements:
- Wrap ping.request calls in detect_highest_baud with exception handling to log failures and count timeouts as failures