### PR TITLE
frontend: wifi: add refresh wifi list button

### DIFF
--- a/core/frontend/src/components/wifi/WifiManager.vue
+++ b/core/frontend/src/components/wifi/WifiManager.vue
@@ -11,6 +11,15 @@
       <v-toolbar-title>Wifi</v-toolbar-title>
       <v-spacer />
       <v-btn
+        v-tooltip="'Refresh'"
+        icon
+        color="gray"
+        hide-details="auto"
+        @click="$emit('refresh-request')"
+      >
+        <v-icon>mdi-refresh</v-icon>
+      </v-btn>
+      <v-btn
         v-tooltip="'Toggle hotspot'"
         icon
         :color="hotspot_status ? 'success' : 'gray'"

--- a/core/frontend/src/components/wifi/WifiTrayMenu.vue
+++ b/core/frontend/src/components/wifi/WifiTrayMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <wifi-updater v-if="!wifi_service_disabled" />
+    <wifi-updater v-if="!wifi_service_disabled" ref="wifiUpdater" />
     <v-menu
       :close-on-content-click="false"
       nudge-left="500"
@@ -29,7 +29,7 @@
           </v-icon>
         </v-card>
       </template>
-      <wifi-manager v-if="!wifi_service_disabled" />
+      <wifi-manager v-if="!wifi_service_disabled" @refresh-request="onRefreshRequest" />
       <v-card
         v-else
         elevation="1"
@@ -87,6 +87,12 @@ export default Vue.extend({
     commander.getEnvironmentVariables().then((environment_variables) => {
       this.disabled_services = ((environment_variables?.BLUEOS_DISABLE_SERVICES as string) ?? '').split(',') as string[]
     })
+  },
+  methods: {
+    onRefreshRequest(): void {
+      wifi.setAvailableNetworks(null)
+      this.$refs.wifiUpdater?.fetchAvailableNetworks()
+    },
   },
 })
 </script>


### PR DESCRIPTION
fix #1863 

<img width="511" height="78" alt="image" src="https://github.com/user-attachments/assets/afe996c4-2365-49a0-8eb5-d5c8604ec1a0" />

Refresh:
https://github.com/user-attachments/assets/93d98ccc-7d2c-4e47-8589-a8b09eafcc67


## Summary by Sourcery

Add a manual refresh button to the WifiManager component and wire it up in the WifiTrayMenu to reload available networks on demand

New Features:
- Add a refresh icon button to the WifiManager toolbar that emits a refresh-request event
- Handle the refresh-request in WifiTrayMenu by calling fetchAvailableNetworks on the wifi-updater component