### PR TITLE
Frontend: InlineParameterEditor: make parameters value update when dragging the sliders

### DIFF
--- a/core/frontend/src/components/parameter-editor/InlineParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/InlineParameterEditor.vue
@@ -178,7 +178,7 @@ export default Vue.extend({
   watch: {
     param(newParam) {
       this.internal_new_value = newParam?.value ?? 0
-      this.internal_new_value_as_string = this.internal_new_value.toString()
+      this.internal_new_value_as_string = String(this.internal_new_value)
     },
     is_form_valid(valid) {
       this.$emit('form-valid-change', valid)
@@ -200,6 +200,7 @@ export default Vue.extend({
       this.updateSelectedFlags()
       if (this.last_sent_value === undefined) {
         this.internal_new_value = this.param_value
+        this.internal_new_value_as_string = String(this.internal_new_value)
       }
     },
   },


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/f3b81a61-28b1-4c3e-b725-bb0bfd46bbda


after:


https://github.com/user-attachments/assets/ca65bd96-ea1c-4bbc-81d7-46c727f76eb6

fix #3268

## Summary by Sourcery

Bug Fixes:
- Synchronize internal_new_value_as_string with internal_new_value on slider initialization to reflect the current numeric value in the input field