### PR TITLE
ardupilot_manager: create shortcut for script directory when using linux

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -589,6 +589,7 @@ class AutoPilotManager(metaclass=Singleton):
 
             if flight_controller.platform.type == PlatformType.Linux:
                 assert isinstance(flight_controller, LinuxFlightController)
+                flight_controller.setup()
                 await self.start_linux_board(flight_controller)
             elif flight_controller.platform.type == PlatformType.Serial:
                 await self.start_serial(flight_controller)

--- a/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
@@ -1,3 +1,5 @@
+import os
+
 from typing import List, Type
 
 from smbus2 import SMBus
@@ -7,6 +9,9 @@ from typedefs import FlightController, PlatformType, Serial
 
 class LinuxFlightController(FlightController):
     """Linux-based Flight-controller board."""
+
+    STANDARD_SCRIPT_DIRECTORY_PATH = "/root/.config/ardupilot-manager/firmware/scripts"
+    LUA_SCRIPT_DIRECTORY_PATH = "/shortcuts/lua_scripts"
 
     @property
     def type(self) -> PlatformType:
@@ -25,6 +30,13 @@ class LinuxFlightController(FlightController):
             return True
         except OSError:
             return False
+
+    def setup(self) -> None:
+        os.makedirs(self.STANDARD_SCRIPT_DIRECTORY_PATH, exist_ok=True)
+        try:
+            os.symlink(self.STANDARD_SCRIPT_DIRECTORY_PATH, self.LUA_SCRIPT_DIRECTORY_PATH)
+        except FileExistsError:
+            pass
 
     @classmethod
     def get_all_boards(cls) -> List[Type["LinuxFlightController"]]:


### PR DESCRIPTION
fix: #2372 

<img width="1027" height="529" alt="image" src="https://github.com/user-attachments/assets/963b9462-5356-432c-827a-9fe9cdaee91f" />

Since paths may differ across different platforms, the shortcut is only created if the flight controller platform type is Linux.

## Summary by Sourcery

New Features:
- Add setup() in LinuxFlightController to create the firmware scripts directory and symlink at /shortcuts/lua_scripts for Linux platforms and call it during autopilot startup