### PR TITLE
Add vscode launch file for remote debugging in the BlueOS container

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-vscode-remote.remote-containers",
+    "ms-vscode-remote.remote-ssh",
+  ],
+}

--- a/core/.vscode/extensions.json
+++ b/core/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.debugpy"
+  ]
+}

--- a/core/.vscode/launch.json
+++ b/core/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      // Use this to debug python code in the remote container
+      // Requires the "Remote development" extensions to be installed
+      // as well as the Python debugger extension in the container
+      "name": "Python Debugger in Remote Container: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "python": "/usr/blueos/venv/bin/python3"
+    }
+  ]
+}

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -106,6 +106,8 @@ COPY configuration/motd /etc/motd
 COPY start-blueos-core /usr/bin/start-blueos-core
 COPY run-service.sh /usr/bin/run-service
 
+COPY ./.vscode /home/pi/.vscode
+
 # Copy binaries and necessary folders from download-binaries to this stage
 COPY --from=download-binaries \
     /usr/bin/blueos_startup_update.py \


### PR DESCRIPTION
You should see this when opening the Repo. install the extensions.
<img width="357" height="118" alt="image" src="https://github.com/user-attachments/assets/f551f05b-28bf-4476-bf73-b4241d33be68" />
Ctrl+shift+p
type ssh and pick Connect to Host
<img width="423" height="142" alt="image" src="https://github.com/user-attachments/assets/9f19ee4b-3bb9-4f40-a43d-20e799748a8e" />

Enter the pi's host and user

<img width="576" height="136" alt="Screenshot 2025-08-05 at 12 13 36" src="https://github.com/user-attachments/assets/a62aedf2-bb32-4e35-bc44-6a5554f31543" />

Accept key and input password as needed.

The arrow button connects this vscode instance to the remote. the window button opens it in a new instance.
<img width="274" height="81" alt="Screenshot 2025-08-05 at 12 14 22" src="https://github.com/user-attachments/assets/d494cc60-dc3d-4555-b4f3-f2f1d969d33a" />
Wait as the server gets downloaded
<img width="508" height="123" alt="Screenshot 2025-08-05 at 12 15 13" src="https://github.com/user-attachments/assets/52340a1e-e151-4392-adb6-47ef8cde5a4d" />
<img width="551" height="158" alt="Screenshot 2025-08-05 at 12 16 10" src="https://github.com/user-attachments/assets/20ed2d93-6e5f-4676-8635-bd6313151eec" />
Switch to Dev containers once attached to the pi
<img width="317" height="319" alt="Screenshot 2025-08-05 at 12 16 50" src="https://github.com/user-attachments/assets/17b1a348-96e8-49d2-8319-c5602953b4cb" />
attach to the container
<img width="675" height="233" alt="Screenshot 2025-08-05 at 12 17 27" src="https://github.com/user-attachments/assets/58720c71-0808-4dee-b467-deceaa06df30" />
Install python debugger extension on the container.
<img width="657" height="277" alt="Screenshot 2025-08-05 at 12 20 02" src="https://github.com/user-attachments/assets/f35a24da-7b0b-422f-8d66-1a0b9e3d7bc0" />

Open /home/pi as a workspace. That's where our service files live, and where the vscode debugger configuration is being saved.

Open any .py file, go to the debugger tab, use this task
<img width="390" height="92" alt="image" src="https://github.com/user-attachments/assets/b8c792d7-0631-4e33-8924-b08552afa9b8" />

and start debugging =]
<img width="2044" height="1242" alt="Screenshot 2025-08-05 at 12 21 13" src="https://github.com/user-attachments/assets/0914bca6-eac6-4f08-87b9-e5eae05e7b06" />


Notes:
 - The steps for installing the vscode server and debugging extension on the container will need to be done every time the container starts, as changes to the container are not permanent.
- Make sure you BACKUP YOUR CHANGES! As the container is effemeral, your changes will be lost as soon as it restarts.

## Summary by Sourcery

New Features:
- Enable remote debugging in the BlueOS container via VS Code by adding a launch.json file and copying the .vscode directory into the container environment

## Summary by Sourcery

Enable remote debugging of services in the BlueOS container by bundling VS Code launch settings and extension recommendations into the container image

New Features:
- Add VS Code launch configuration for remote Python debugging inside the BlueOS container
- Include recommended VS Code extensions in the container via extensions.json

Enhancements:
- Update core Dockerfile to copy the .vscode directory into the /home/pi workspace