### PR TITLE
core:frontend:CloudTrayMenu: Allow dev tokens

### DIFF
--- a/core/frontend/src/components/cloud/CloudTrayMenu.vue
+++ b/core/frontend/src/components/cloud/CloudTrayMenu.vue
@@ -286,12 +286,14 @@ export default Vue.extend({
       this.operation_error_title = title
       this.operation_error_message = String(error)
     },
-    async cleanMajorTomToken(): Promise<void> {
+    async cleanMajorTomBagToken(): Promise<void> {
       const data = await bag.getData('major_tom')
       if (data && data.token) {
         delete data.token
       }
       await bag.setData('major_tom', { ...data })
+    },
+    async cleanMajorTomFileToken(): Promise<void> {
       await filebrowser.deleteFile(MAJOR_TOM_CLOUD_TOKEN_FILE)
     },
     async fetchMajorTomData(): Promise<InstalledExtensionData> {
@@ -319,15 +321,19 @@ export default Vue.extend({
       }
 
       if (!await this.isMajorTomTokenValid(tokenToUse, true)) {
-        await this.cleanMajorTomToken()
+        /** We do not remove the token since it may be used in other parts as a developer token */
         tokenToUse = undefined
       } else if (tokenToUse !== undefined && tokenToUse !== fileToken) {
+        /** Copy bag token to file token */
         await this.updateMajorTomToken(tokenToUse)
       }
+      /** In any scenario we remove the bag token since it was used in older versions but may leak the token */
+      await this.cleanMajorTomBagToken()
 
       this.local_token = tokenToUse ?? ''
     },
     async updateMajorTomToken(token: string): Promise<void> {
+      await this.cleanMajorTomFileToken()
       await filebrowser.createFile(MAJOR_TOM_CLOUD_TOKEN_FILE.path, true)
       await filebrowser.writeToFile(MAJOR_TOM_CLOUD_TOKEN_FILE.path, token)
     },


### PR DESCRIPTION
* Do not remove a file token if it is invalid to allow other services that may use dev tokens to keep working
* Make sure token is removed from bag always since it was legacy behavior and may leak the token