### PR TITLE
frontend: system-information: update temperature information periodically

### DIFF
--- a/core/frontend/src/components/system-information/SystemCondition.vue
+++ b/core/frontend/src/components/system-information/SystemCondition.vue
@@ -135,7 +135,6 @@ export default Vue.extend({
       system_information.fetchSystemInformation(FetchType.SystemCpuType)
       system_information.fetchSystemInformation(FetchType.SystemDiskType)
       system_information.fetchSystemInformation(FetchType.SystemMemoryType)
-      system_information.fetchSystemInformation(FetchType.SystemTemperatureType)
     }, 2000)
   },
   beforeDestroy() {

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -69,6 +69,10 @@ class SystemInformationStore extends VuexModule {
     { delay: 1000 },
   )
 
+  fetchTemperatureTask = new OneMoreTime(
+    { delay: 2000 },
+  )
+
   @Mutation
   appendKernelMessage(kernel_message: [KernelMessage]): void {
     this.kernel_message = this.kernel_message.concat(kernel_message)
@@ -207,6 +211,11 @@ class SystemInformationStore extends VuexModule {
   }
 
   @Action
+  async fetchTemperatureInformation(): Promise<void> {
+    await this.fetchSystemInformation(FetchType.SystemTemperatureType)
+  }
+
+  @Action
   async fetchSystemInformation(type: FetchType): Promise<void> {
     // Do not fetch system specific information if system is not populate yet
     // system type does not have optional fields, they need to be populate before fetching it
@@ -297,6 +306,7 @@ const system_information: SystemInformationStore = getModule(SystemInformationSt
 system_information.fetchSystem()
 system_information.fetchPlatformTask.setAction(system_information.fetchPlatform)
 system_information.fetchSystemNetworkTask.setAction(system_information.fetchNetworkInformation)
+system_information.fetchTemperatureTask.setAction(system_information.fetchTemperatureInformation)
 
 // It appears that the store is incompatible with websockets or callbacks.
 // Right now the only way to have it working is to have the websocket definition outside the store


### PR DESCRIPTION
fix: #3409 

Temperature information on the store was only updated when the user navigated to the System Information page. This caused the temperature displayed in the heartbeat widget to be outdated over time.

## Summary by Sourcery

Enable periodic updating of system temperature in the store to replace manual fetch on navigation and ensure the heartbeat widget always shows current temperature

Bug Fixes:
- Keep the heartbeat widget’s temperature display from becoming outdated by updating it periodically

Enhancements:
- Introduce a periodic fetchTemperatureTask in the SystemInformation store to poll temperature every 2 seconds
- Add a fetchTemperatureInformation action and wire it to the new polling task
- Remove redundant manual temperature fetch from the SystemCondition component