### PR TITLE
Core:Services:cable_guy: Add explicity casts in IP comparisons

### DIFF
--- a/core/services/cable_guy/networksetup.py
+++ b/core/services/cable_guy/networksetup.py
@@ -46,7 +46,7 @@ class AbstractNetworkHandler:
         # Check if IP already exists on the interface
         existing_addrs = self.ipr.get_addr(index=interface_index)
         for addr in existing_addrs:
-            if addr.get_attr("IFA_ADDRESS") == ip:
+            if str(addr.get_attr("IFA_ADDRESS")) == str(ip):
                 logger.info(f"IP '{ip}' already exists on interface '{interface_name}', skipping addition.")
                 return
 


### PR DESCRIPTION
Make sure comparisons between possible IPv4Address objects and strings works as intended since comparing two identical IPv4Address and string IP will result always in fail.
This should fix problems like static IP configured for DHCP Server / Backup DHCP Server but not spinning up due to conflicts with watchdog

## Summary by Sourcery

Add explicit string casts in IP comparisons to ensure correct matching between IPv4Address objects and string IPs across Cable Guy modules

Bug Fixes:
- Cast both operands to string in IP comparisons within manager methods to fix mismatches in static IP, DHCP server, and interface checks
- Apply string casting when checking existing interface addresses in networksetup to prevent redundant additions

## Summary by Sourcery

Fix IP comparison mismatches by casting IPv4Address objects and string IPs to strings before comparing across Cable Guy manager and networksetup modules.

Bug Fixes:
- Use str() casts in all IP comparison logic in core/services/cable_guy/manager.py to correctly compare IPv4Address objects and string IPs in add, remove, list, and DHCP server routines.
- Apply the same str() comparison fix in core/services/cable_guy/networksetup.py to prevent duplicate static IP detection failures.