### PR TITLE
Backports/1.4/routes api

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -621,7 +621,7 @@ class EthernetManager:
             logger.info(f"{act} route to {route.destination_parsed} via {gateway} on {interface_name}")
         except Exception as e:
             act = "Remove" if action == "del" else "Add" if action == "add" else action
-            logger.error(f"Failed to {act} route: {e}")
+            logger.error(f"Failed to {act} route {route.destination_parsed} via {gateway} on {interface_name}: {e}")
             raise
 
         # Update settings

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -133,6 +133,27 @@ class EthernetManager:
                 logger.info(f"Triggering dynamic IP acquisition for interface '{interface.name}'.")
                 self.trigger_dynamic_ip_acquisition(interface.name)
 
+            # Handle routes configuration
+            self._set_routes_configuration(interface)
+
+    def _set_routes_configuration(self, interface: NetworkInterface) -> None:
+        try:
+            current_routes = self.get_routes(interface.name, ignore_unmanaged=True)
+            desired_routes = interface.routes
+
+            # Remove old routes
+            for current_route in current_routes:
+                if current_route not in desired_routes:
+                    self.remove_route(interface.name, current_route)
+
+            # Add new routes
+            for desired_route in desired_routes:
+                if desired_route not in current_routes:
+                    self.add_route(interface.name, desired_route)
+
+        except Exception as error:
+            logger.error(f"Routes configuration failed: {error}")
+
     def _get_wifi_interfaces(self) -> List[str]:
         """Get wifi interface list
 

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -696,7 +696,7 @@ class EthernetManager:
         """
 
         mismatches: Set[NetworkInterface] = set()
-        current = self.get_ethernet_interfaces()
+        current_interfaces = self.get_ethernet_interfaces()
         if len(self._settings.content) == 0:
             logger.debug("No saved configuration found")
             logger.debug(f"Current configuration: {self._settings}")
@@ -704,25 +704,27 @@ class EthernetManager:
 
         saved_interfaces = {interface.name: interface for interface in self._settings.content}
 
-        for interface in current:
-            if interface.name not in saved_interfaces:
-                logger.debug(f"Interface {interface.name} not in saved configuration, skipping")
+        for current_interface in current_interfaces:
+            if current_interface.name not in saved_interfaces:
+                logger.debug(f"Interface {current_interface.name} not in saved configuration, skipping")
                 continue
+            saved_interface = saved_interfaces[current_interface.name]
 
-            for address in saved_interfaces[interface.name].addresses:
-                if address.mode == AddressMode.Client:
-                    if not any(addr.mode == AddressMode.Client for addr in interface.addresses):
-                        logger.info(f"Mismatch detected for {interface.name}: missing dhcp client address")
-                        mismatches.add(saved_interfaces[interface.name])
+            for saved_address in saved_interface.addresses:
+                if saved_address.mode == AddressMode.Client:
+                    if not any(addr.mode == AddressMode.Client for addr in current_interface.addresses):
+                        logger.info(f"Mismatch detected for {current_interface.name}: missing dhcp client address")
+                        mismatches.add(saved_interface)
                 # Handle Server and Unmanaged modes
-                elif address.mode in [AddressMode.Server, AddressMode.Unmanaged]:
-                    if address not in interface.addresses:
+                elif saved_address.mode in [AddressMode.Server, AddressMode.Unmanaged]:
+                    if saved_address not in current_interface.addresses:
                         logger.info(
-                            f"Mismatch detected for {interface.name}: "
-                            f"saved address {address.ip} ({address.mode}) not found in current addresses "
-                            f"[{', '.join(f'{addr.ip} ({addr.mode})' for addr in interface.addresses)}]"
+                            f"Mismatch detected for {current_interface.name}: "
+                            f"saved address {saved_address.ip} ({saved_address.mode}) not found in current addresses "
+                            f"[{', '.join(f'{addr.ip} ({addr.mode})' for addr in current_interface.addresses)}]"
                         )
-                        mismatches.add(saved_interfaces[interface.name])
+                        mismatches.add(saved_interface)
+
         return mismatches
 
     async def watchdog(self) -> None:

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -50,11 +50,11 @@ class EthernetManager:
 
     result: List[NetworkInterface] = []
 
-    _manager: PydanticManager = PydanticManager(SERVICE_NAME, settings.SettingsV1)
+    _manager: PydanticManager = PydanticManager(SERVICE_NAME, settings.SettingsV2)
 
     @property
-    def _settings(self) -> settings.SettingsV1:
-        return cast(settings.SettingsV1, self._manager.settings)
+    def _settings(self) -> settings.SettingsV2:
+        return cast(settings.SettingsV2, self._manager.settings)
 
     def __init__(self) -> None:
         self._dhcp_servers: List[DHCPServerManager] = []

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -24,6 +24,7 @@ from typedefs import (
     NetworkInterface,
     NetworkInterfaceMetric,
     NetworkInterfaceMetricApi,
+    Route,
 )
 
 __all__ = [
@@ -310,6 +311,7 @@ class EthernetManager:
             saved_interface = NetworkInterface(
                 name=interface_name,
                 addresses=[],
+                routes=[],
             )
 
         new_address = InterfaceAddress(ip=ip, mode=mode)
@@ -413,7 +415,11 @@ class EthernetManager:
                 if interface_metric:
                     priority = interface_metric.priority
 
-            interface_data = NetworkInterface(name=interface, addresses=valid_addresses, info=info, priority=priority)
+            routes = self.get_routes(interface, ignore_unmanaged=False)
+
+            interface_data = NetworkInterface(
+                name=interface, addresses=valid_addresses, info=info, priority=priority, routes=list(routes)
+            )
             # Check if it's valid and add to the result
             if self.validate_interface_data(interface_data, filter_wifi):
                 result += [interface_data]
@@ -507,7 +513,9 @@ class EthernetManager:
         for interface in interfaces:
             saved_interface = self.get_saved_interface_by_name(interface.name)
             if saved_interface is None:
-                saved_interface = NetworkInterface(name=interface.name, addresses=[], priority=interface.priority)
+                saved_interface = NetworkInterface(
+                    name=interface.name, addresses=[], priority=interface.priority, routes=[]
+                )
             saved_interface.priority = interface.priority
             self._update_interface_settings(interface.name, saved_interface)
 
@@ -653,7 +661,7 @@ class EthernetManager:
 
         saved_interface = self.get_saved_interface_by_name(interface_name)
         if saved_interface is None:
-            saved_interface = NetworkInterface(name=interface_name, addresses=[], priority=None)
+            saved_interface = NetworkInterface(name=interface_name, addresses=[], priority=None, routes=[])
 
         self._update_interface_settings(interface_name, saved_interface)
 

--- a/core/services/cable_guy/config.py
+++ b/core/services/cable_guy/config.py
@@ -1,6 +1,7 @@
 # This file is used to define general configurations for the app
 
-from typedefs import AddressMode, InterfaceAddress, NetworkInterface
+from typedefs import AddressMode, InterfaceAddress, NetworkInterface, Route
+from typedefs_pydantic_network_shin import IPvAnyNetwork
 
 SERVICE_NAME = "cable-guy"
 
@@ -12,6 +13,14 @@ DEFAULT_NETWORK_INTERFACES = [
             InterfaceAddress(ip="192.168.2.2", mode=AddressMode.BackupServer),
             InterfaceAddress(ip="0.0.0.0", mode=AddressMode.Client),
         ],
+        routes=[
+            Route(
+                destination=str(IPvAnyNetwork("224.0.0.0/4")),
+                gateway=None,
+                priority=None,
+                managed=True,
+            )
+        ],
     ),
-    NetworkInterface(name="usb0", addresses=[InterfaceAddress(ip="192.168.3.1", mode=AddressMode.Server)]),
+    NetworkInterface(name="usb0", addresses=[InterfaceAddress(ip="192.168.3.1", mode=AddressMode.Server)], routes=[]),
 ]

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -17,6 +17,7 @@ from uvicorn import Config, Server
 from api.dns import DnsData
 from api.manager import EthernetManager, NetworkInterface, NetworkInterfaceMetricApi
 from config import SERVICE_NAME
+from typedefs import Route
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)
@@ -116,6 +117,29 @@ def retrieve_host_dns() -> Any:
 def update_host_dns(dns_data: DnsData) -> Any:
     """REST API endpoint to update the host DNS configuration."""
     manager.dns.update_host_nameservers(dns_data)
+
+
+@app.post("/route", summary="Add route to interface.")
+@version(1, 0)
+def add_route(interface_name: str, route: Route) -> Any:
+    """REST API endpoint to add route."""
+    manager.add_route(interface_name, route)
+    manager.save()
+
+
+@app.delete("/route", summary="Remove route from interface.")
+@version(1, 0)
+def remove_route(interface_name: str, route: Route) -> Any:
+    """REST API endpoint remove route."""
+    manager.remove_route(interface_name, route)
+    manager.save()
+
+
+@app.get("/route", summary="Get the interface routes.")
+@version(1, 0)
+def get_route(interface_name: str) -> List[Route]:
+    """REST API endpoint to get routes."""
+    return list(manager.get_routes(interface_name, ignore_unmanaged=False))
 
 
 app = VersionedFastAPI(

--- a/core/services/cable_guy/typedefs.py
+++ b/core/services/cable_guy/typedefs.py
@@ -1,7 +1,11 @@
 from enum import Enum
+from ipaddress import ip_network
 from typing import List, Optional
 
 from pydantic import BaseModel
+
+# TODO: Replace this by `from pydantic import IPvAnyAddress, IPvAnyNetwork` once we update to pydantic v2
+from typedefs_pydantic_network_shin import IPvAnyAddress, IPvAnyNetwork
 
 
 class AddressMode(str, Enum):
@@ -31,7 +35,57 @@ class InterfaceInfo(BaseModel):
     priority: int
 
 
-class NetworkInterface(BaseModel):
+class Route(BaseModel):
+    destination: str  # TODO: change this to IPvAnyNetwork from pydantic v2
+    gateway: Optional[str] = None  # TODO: change this to IPvAnyAddress from pydantic v2
+    priority: Optional[int] = None
+    managed: bool = False
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Route):
+            return NotImplemented
+        return self.destination == other.destination and self.gateway == other.gateway
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.destination,
+                self.gateway,
+            )
+        )
+
+    # TODO: Remove this once we update self.destination type
+    @property
+    def destination_parsed(self) -> IPvAnyNetwork:
+        return IPvAnyNetwork(self.destination)
+
+    # TODO: Remove this once we update self.destination type
+    @destination_parsed.setter
+    def destination_parsed(self, ip: IPvAnyNetwork) -> None:
+        self.destination = str(ip)
+
+    # TODO: Remove this once we update self.next_hop type
+    @property
+    def next_hop_parsed(self) -> Optional[IPvAnyAddress]:
+        if self.gateway is None:
+            return None
+        return IPvAnyAddress(self.gateway)
+
+    # TODO: Remove this once we update self.next_hop type
+    @next_hop_parsed.setter
+    def next_hop_parsed(self, ip: Optional[IPvAnyAddress]) -> None:
+        self.gateway = str(ip) if ip else None
+
+    @property
+    def is_default(self) -> bool:
+        return ip_network(self.destination).is_unspecified
+
+    @property
+    def is_multicast(self) -> bool:
+        return ip_network(self.destination).is_multicast
+
+
+class NetworkInterfaceV1(BaseModel):
     name: str
     addresses: List[InterfaceAddress]
     info: Optional[InterfaceInfo] = None
@@ -39,6 +93,10 @@ class NetworkInterface(BaseModel):
 
     def __hash__(self) -> int:
         return hash(self.name) + sum(hash(address) for address in self.addresses)
+
+
+class NetworkInterface(NetworkInterfaceV1):
+    routes: List[Route]
 
 
 class NetworkInterfaceMetric(BaseModel):

--- a/core/services/cable_guy/typedefs_pydantic_network_shin.py
+++ b/core/services/cable_guy/typedefs_pydantic_network_shin.py
@@ -1,0 +1,99 @@
+"""
+    TODO: Update to pydantic v2 to get rid of this sad file.
+    
+    This is a temporary shin to be replaced by pydantic IPvAnyAddress,
+    IPvAnyInterface and IPvAnyNetwork. This is needed because the Routes code
+    requires the differentiation embedded in those types (like that
+    '192.168.2.1' can't be used in place of a '192.168.2.0/24'). Yes, we
+    should be using the pydantic types in the Route, but our current pydantic
+    version doeesn't allow us to serialize the underlying types, so we must
+    keep them as 'str' in the Route properties while using these weak shins
+    in the manager implementations. This whole file should will be deleted
+    once we update to pydantic v2. The necessary glue between the Route props
+    and the manager code is spread both in typedefs and in the manager code,
+    like using str(ip_address('192.168.2.1')) when instantiating a Route,
+    and accessing Route.destination_parsed instead of Route.destiantion --
+    all quick things to adjust once the pydantic update takes place.
+"""
+
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+    ip_address,
+    ip_interface,
+    ip_network,
+)
+from typing import Any, Union
+
+
+class IPvAnyAddress:
+    def __init__(self, ip: Union[str, IPv4Address, IPv6Address]):
+        self._value: Union[IPv4Address, IPv6Address] = ip_address(ip)
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def __repr__(self) -> str:
+        return f"IPvAnyAddress('{self._value}')"
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IPvAnyAddress):
+            return self._value == other._value
+        return self._value == ip_address(other)
+
+    def __json__(self) -> str:
+        return str(self)
+
+    @property
+    def version(self) -> int:
+        return ip_address(self._value).version
+
+
+class IPvAnyInterface:
+    def __init__(self, ip: Union[str, IPv4Interface, IPv6Interface]):
+        self._value: Union[IPv4Interface, IPv6Interface] = ip_interface(ip)
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def __repr__(self) -> str:
+        return f"IPvAnyInterface('{self._value}')"
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IPvAnyInterface):
+            return self._value == other._value
+        return self._value == ip_interface(other)
+
+    def __json__(self) -> str:
+        return str(self)
+
+    @property
+    def version(self) -> int:
+        return ip_interface(self._value).version
+
+
+class IPvAnyNetwork:
+    def __init__(self, ip: Union[str, IPv4Network, IPv6Network]):
+        self._value: Union[IPv4Network, IPv6Network] = ip_network(ip)
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def __repr__(self) -> str:
+        return f"IPvAnyNetwork('{self._value}')"
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IPvAnyNetwork):
+            return self._value == other._value
+        return self._value == ip_network(other)
+
+    def __json__(self) -> str:
+        return str(self)
+
+    @property
+    def version(self) -> int:
+        return ip_network(self._value).version


### PR DESCRIPTION
This is a backport of #3203 and #3311 into 1.4

## Summary by Sourcery

Backport route management support into 1.4: introduce Route model and settings V2, extend manager to handle route synchronization, and expose new REST endpoints for adding, removing, and listing interface routes.

New Features:
- Define Route model and extend NetworkInterface to include route lists
- Implement manager methods to add, remove, parse, and fetch interface routes
- Expose REST API endpoints (POST/DELETE/GET /route) for runtime route management
- Introduce SettingsV2 with migration logic to persist per-interface routes

Enhancements:
- Automatically synchronize routes when applying interface configurations
- Upgrade EthernetManager to use SettingsV2 by default
- Include routes in default interface configurations

Chores:
- Add temporary typedefs_pydantic_network_shin shim for IPvAnyAddress, IPvAnyNetwork until Pydantic v2 upgrade