### PR TITLE
Backports/1.4/add logs to mavlink server

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -40,7 +40,10 @@ class MAVLinkServer(AbstractRouter):
         filtered_endpoints = Endpoint.filter_enabled(self.endpoints())
         endpoints = " ".join([convert_endpoint(endpoint) for endpoint in [master_endpoint, *filtered_endpoints]])
 
-        return f"{self.binary()} {endpoints}"
+        if not self.log_path:
+            self.log_path = "/var/logs/blueos/services/mavlink-server/"
+
+        return f"{self.binary()} {endpoints} --log-path={self.log_path}"
 
     @staticmethod
     def name() -> str:

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -9,6 +9,7 @@ from mavlink_proxy.Endpoint import Endpoint, EndpointType
 class MAVLinkServer(AbstractRouter):
     def __init__(self) -> None:
         super().__init__()
+        self.log_path: Optional[str] = None
 
     def _get_version(self) -> Optional[str]:
         binary = self.binary()


### PR DESCRIPTION
This is a backport of #3340 and #3342 into 1.4

## Summary by Sourcery

New Features:
- Initialize a log_path attribute in MAVLinkServer and include a --log-path argument with a default path when constructing the server command.