### PR TITLE
core: frontend: VideoStreamCreationDialog: use even default UDP ports

### DIFF
--- a/core/frontend/src/components/video-manager/VideoStreamCreationDialog.vue
+++ b/core/frontend/src/components/video-manager/VideoStreamCreationDialog.vue
@@ -439,13 +439,13 @@ export default Vue.extend({
         case StreamType.UDP:
           if (!this.stream_endpoints[index].includes('udp://')) {
             // Vue.set() forces the update of a nested property
-            Vue.set(this.stream_endpoints, index, `udp://${this.user_ip_address}:${5600 + index}`)
+            Vue.set(this.stream_endpoints, index, `udp://${this.user_ip_address}:${5600 + 2 * index}`)
           }
           break
         case StreamType.UDP265:
           if (!this.stream_endpoints[index].includes('udp265://')) {
             // Vue.set() forces the update of a nested property
-            Vue.set(this.stream_endpoints, index, `udp265://${this.user_ip_address}:${5600 + index}`)
+            Vue.set(this.stream_endpoints, index, `udp265://${this.user_ip_address}:${5600 + 2 * index}`)
           }
           break
         case StreamType.RTSP:


### PR DESCRIPTION
This is a backport of #3375 into 1.4

## Summary by Sourcery

Enhancements:
- Use even default UDP ports for VideoStreamCreationDialog by adjusting the port calculation for UDP and UDP265 streams.