### PR TITLE
Frontend: ServoFunctionEditorDialog.vue: make sliders text not-selectable

### DIFF
--- a/core/frontend/src/components/parameter-editor/ServoFunctionEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ServoFunctionEditorDialog.vue
@@ -492,6 +492,7 @@ export default Vue.extend({
   border-radius: 4px;
   font-size: 12px;
   white-space: nowrap;
+  user-select: none;
   text-align: center;
 }
 </style>


### PR DESCRIPTION
This is a backport of #3442 into 1.4

## Summary by Sourcery

Enhancements:
- Make slider text in ServoFunctionEditorDialog non-selectable