### PR TITLE
ardupilot_manager: create shortcut for script directory when using linux

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -579,6 +579,7 @@ class AutoPilotManager(metaclass=Singleton):
 
             if flight_controller.platform.type == PlatformType.Linux:
                 assert isinstance(flight_controller, LinuxFlightController)
+                flight_controller.setup()
                 await self.start_linux_board(flight_controller)
             elif flight_controller.platform.type == PlatformType.Serial:
                 await self.start_serial(flight_controller)

--- a/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Type
 
 from smbus2 import SMBus
@@ -7,6 +8,9 @@ from typedefs import FlightController, PlatformType, Serial
 
 class LinuxFlightController(FlightController):
     """Linux-based Flight-controller board."""
+
+    STANDARD_SCRIPT_DIRECTORY_PATH = "/root/.config/ardupilot-manager/firmware/scripts"
+    LUA_SCRIPT_DIRECTORY_PATH = "/shortcuts/lua_scripts"
 
     @property
     def type(self) -> PlatformType:
@@ -25,6 +29,13 @@ class LinuxFlightController(FlightController):
             return True
         except OSError:
             return False
+
+    def setup(self) -> None:
+        os.makedirs(self.STANDARD_SCRIPT_DIRECTORY_PATH, exist_ok=True)
+        try:
+            os.symlink(self.STANDARD_SCRIPT_DIRECTORY_PATH, self.LUA_SCRIPT_DIRECTORY_PATH)
+        except FileExistsError:
+            pass
 
     @classmethod
     def get_all_boards(cls) -> List[Type["LinuxFlightController"]]:


### PR DESCRIPTION
This is a backport of #3445 into 1.4

## Summary by Sourcery

Create and expose a standard script directory and a symlink shortcut for Lua scripts on Linux flight controllers

New Features:
- Add STANDARD_SCRIPT_DIRECTORY_PATH and LUA_SCRIPT_DIRECTORY_PATH constants to LinuxFlightController
- Implement setup method to create the standard script directory and a symlink at /shortcuts/lua_scripts
- Invoke the setup method when starting a Linux flight controller