### PR TITLE
Backports/1.4/allow motor remapping

### DIFF
--- a/core/frontend/src/components/vehiclesetup/PwmSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/PwmSetup.vue
@@ -50,9 +50,7 @@
                   width="100%"
                   height="65"
                   class="ma-0 pa-0"
-                  @mouseover="highlight = [
-                    stringToUserFriendlyText(printParam(getParam(`SERVO${motor.servo}_FUNCTION`))),
-                  ]"
+                  @mouseover="highlightMotor(motor)"
                   @mouseleave="highlight = default_highlight"
                 >
                   <td width="20%">
@@ -399,6 +397,13 @@ export default Vue.extend({
     this.uninstallListeners()
   },
   methods: {
+    highlightMotor(motor: MotorTestTarget) {
+      if (this.is_rover) {
+        this.highlight = [this.stringToUserFriendlyText(printParam(this.getParam(`SERVO${motor.servo}_FUNCTION`)))]
+      } else {
+        this.highlight = [`Motor${motor.servo}`]
+      }
+    },
     convert_servo_name(name: string) {
       return name.replace('SERVO', 'Output ').replace('_FUNCTION', '')
     },


### PR DESCRIPTION
This is a backport of #3447 into 1.4

## Summary by Sourcery

Backport support for remapping servo outputs to logical motor indices in the PWM setup component of version 1.4.

New Features:
- Allow servo outputs to be remapped to distinct logical motor numbers in the PWM setup interface

Enhancements:
- Add a motor property to MotorTestTarget and separately parse servo and motor numbers
- Display the servo-to-motor mapping in the UI when they differ
- Introduce a highlightMotor method for consistent hover highlighting
- Sort the available motors list by logical motor index