### PR TITLE
autopilot manager: fix auto_restart_autopilot() race condition

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -499,8 +499,12 @@ class AutoPilotManager(metaclass=Singleton):
             """Checks if given process is using a Ardupilot's firmware file, for any known platform."""
             for platform in Platform:
                 firmware_path = self.firmware_manager.firmware_path(platform)
-                if str(firmware_path) in " ".join(process.cmdline()):
-                    return True
+                try:
+                    if str(firmware_path) in " ".join(process.cmdline()):
+                        return True
+                except psutil.NoSuchProcess:
+                    # process may have died before we could call cmdline()
+                    pass
             return False
 
         return list(filter(is_ardupilot_process, psutil.process_iter()))


### PR DESCRIPTION
This is a backport of #3401 into 1.4

## Summary by Sourcery

Bug Fixes:
- Wrap process.cmdline() call in a try/except to prevent crashes when the process terminates before inspection