### PR TITLE
nginx: fix 404

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -50,6 +50,9 @@ http {
 
         add_header Access-Control-Allow-Origin *;
 
+        # Custom 404 handler that serves Vue.js app with proper 404 status
+        error_page 404 @fallback;
+
         # Endpoint used for backend status checks.
         # It will always return an empty 204 response when online.
         location = /status {
@@ -201,7 +204,7 @@ http {
 
         location / {
             root /home/pi/frontend;
-            try_files $uri $uri/ /index.html;
+            try_files $uri $uri/ =404;
             autoindex on;
             # allow frontend to see files using json
             autoindex_format json;
@@ -243,6 +246,13 @@ http {
             expires -1;
             add_header Cache-Control no-store;
             add_header Access-Control-Allow-Origin *;
+        }
+
+        # Fallback location for Vue.js SPA - serves index.html with 404 status
+        location @fallback {
+            root /home/pi/frontend;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+            try_files /index.html =404;
         }
 
         # Helper to redirect services to their port


### PR DESCRIPTION
This is a backport of #3451 into 1.4

## Summary by Sourcery

Backport the SPA 404 handler fix into the 1.4 branch by updating the Nginx configuration to serve the Vue.js app with a proper 404 status.

Bug Fixes:
- Ensure Nginx returns a 404 status instead of serving the index page unconditionally for missing assets

Enhancements:
- Add an error_page directive to route 404 errors to a custom @fallback location
- Introduce a @fallback location that serves index.html with no-cache headers and proper 404 response
- Update the root location try_files directive to return 404 on missing files