### PR TITLE
frontend: add missing route for extensionv2

### DIFF
--- a/core/frontend/src/router/index.ts
+++ b/core/frontend/src/router/index.ts
@@ -124,6 +124,11 @@ const routes: Array<RouteConfig> = [
     component: ExtensionView,
   },
   {
+    path: '/extensionv2/:name',
+    name: 'Named Extensions (v2)',
+    component: ExtensionView,
+  },
+  {
     path: '/tools/extensions-manager',
     name: 'Extension Manager',
     component: defineAsyncComponent(() => import('../views/ExtensionManagerView.vue')),

--- a/core/frontend/src/views/ExtensionView.vue
+++ b/core/frontend/src/views/ExtensionView.vue
@@ -45,11 +45,15 @@ export default Vue.extend({
       if (helper.services.length === 0) {
         return undefined
       }
-      return helper.services.filter(
-        (service) => service?.metadata?.sanitized_name === this.$route.params.name,
-      )[0]?.port ?? null
+      return this.service?.port ?? null
+    },
+    supports_v2(): boolean {
+      return this.service?.metadata?.works_in_relative_paths ?? false
     },
     service_path(): string {
+      if (this.supports_v2) {
+        return `/extensionv2/${this.$route.params.name}`
+      }
       return `${window.location.protocol}//${window.location.hostname}:${this.detected_port}`
       + `/${this.remaining_path ?? ''}`
       + `?time=${this.cache_busting_time}`


### PR DESCRIPTION
This is a backport of #3460 into 1.4

## Summary by Sourcery

Add support for the new extensionv2 route in the frontend by registering the route and updating path computation in ExtensionView.

New Features:
- Register a new '/extensionv2/:name' route named 'Named Extensions (v2)'
- Introduce a supports_v2 computed property to detect v2 compatibility

Enhancements:
- Simplify port lookup by returning service.port directly
- Update service_path to use the v2 route when supported, falling back to the original URL otherwise