### PR TITLE
Backports/1.4/fix json typo sitl

### DIFF
--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -58,7 +58,7 @@ class SITLFrame(str, Enum):
     SCRIMMAGE = "scrimmage"
     WEBOTS = "webots"
     JSON = "JSON"
-    UNDEFINED = " undefined"
+    UNDEFINED = "undefined"
 
 
 def get_sitl_platform_name(machine_arch: str) -> str:

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -57,7 +57,7 @@ class SITLFrame(str, Enum):
     AIRSIM = "airsim"
     SCRIMMAGE = "scrimmage"
     WEBOTS = "webots"
-    JSON = " JSON"
+    JSON = "JSON"
     UNDEFINED = " undefined"
 
 


### PR DESCRIPTION
This is a backport of #3420 into 1.4

## Summary by Sourcery

Bug Fixes:
- Remove leading whitespace from JSON and UNDEFINED enum values in SITLFrame