### PR TITLE
core: services: helper: main: Control number of worker for scan_ports based on hardware

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -23,7 +23,9 @@ from bs4 import BeautifulSoup
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.decorators import temporary_cache
 from commonwealth.utils.general import (
+    CpuType,
     blueos_version,
+    get_cpu_type,
     local_hardware_identifier,
     local_unique_identifier,
 )
@@ -427,7 +429,12 @@ class Helper:
         ports.difference_update(Helper.SKIP_PORTS, known_ports)
 
         # The detect_services run several of requests sequentially, so we are capping the amount of executors to lower the peaks on the CPU usage
-        with futures.ThreadPoolExecutor(max_workers=2) as executor:
+        if get_cpu_type() == CpuType.PI3 or len(ports) == 0:
+            max_workers = 2
+        else:
+            max_workers = len(ports)
+
+        with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             tasks = [executor.submit(Helper.detect_service, port) for port in ports]
             services = {task.result() for task in futures.as_completed(tasks)}
 


### PR DESCRIPTION
This is a backport of #3362 into  1.4

## Summary by Sourcery

Enhancements:
- Dynamically set ThreadPoolExecutor max_workers in scan_ports based on CPU type and number of ports