### PR TITLE
Version Chooser: deal (badly) with dockerhub api changes

### DIFF
--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -110,6 +110,22 @@ class TagFetcher:
                 my_architecture = get_current_arch()
                 valid_images = []
                 for tag in tags:
+                    images = tag["images"]
+                    if len(images) == 0:
+                        # this is a hack to deal with https://github.com/docker/hub-feedback/issues/2484
+                        # we lost the ability to properly identify the images as we dont have the digest,
+                        # and also the ability to filter for compatible architectures.
+                        # so we just add the tag and hope for the best.
+                        tag = TagMetadata(
+                            repository=repository,
+                            image=repository.split("/")[-1],
+                            tag=tag["name"],
+                            last_modified=tag["last_updated"],
+                            sha=None,
+                            digest="------",
+                        )
+                        valid_images.append(tag)
+                        continue
                     for image in tag["images"]:
                         if image["architecture"] == my_architecture:
                             tag = TagMetadata(


### PR DESCRIPTION
"Fix" #3489 
<img width="389" height="327" alt="Screenshot 2025-08-13 at 06 46 54" src="https://github.com/user-attachments/assets/9fe7ed0e-7ad3-4a5d-8e3b-b9c5f91209ff" />

## Summary by Sourcery

Handle DockerHub API change by falling back to placeholder TagMetadata for tags with no image data and add an integration test to validate TagFetcher against a real repository

Bug Fixes:
- Add fallback logic in fetch_remote_tags to include tags with empty "images" by creating placeholder TagMetadata entries

Tests:
- Introduce TestTagFetcher integration test to fetch and verify real tags from DockerHub for bluerobotics/blueos-core, skipping on network issues