### PR TITLE
Backports/1.3/dockerhub workaround

### DIFF
--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -33,7 +33,7 @@
     "date-fns": "^2.23.0",
     "file-saver": "^2.0.5",
     "fuse.js": "^6.6.2",
-    "gl-matrix": "JoaoMario109/gl-matrix#v3.4.x-extended-package",
+    "gl-matrix": "joaomariolago/gl-matrix#v3.4.x-extended-package",
     "gsap": "^3.12.3",
     "http-status-codes": "^2.2.0",
     "image-js": "^0.35.3",

--- a/core/services/versionchooser/test_versionchooser.py
+++ b/core/services/versionchooser/test_versionchooser.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from utils.chooser import VersionChooser
+from utils.dockerhub import TagFetcher, TagMetadata
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -236,3 +237,41 @@ async def test_set_version_json_exception(json_mock: mock.MagicMock) -> None:
         result = await chooser.set_version("bluerobotics/blueos-core", "master")
         assert result.status == 500
         assert len(json_mock.mock_calls) > 0
+
+
+class TestTagFetcher:
+    """Test class for TagFetcher functionality"""
+
+    @pytest.mark.asyncio
+    async def test_fetch_real_blueos_core_tags(self) -> None:
+        """Integration test: Fetch real tags from bluerobotics/blueos-core repository"""
+        fetcher = TagFetcher()
+
+        try:
+            errors, tags = await fetcher.fetch_remote_tags("bluerobotics/blueos-core", [])
+
+            # Verify we got some tags back
+            assert isinstance(tags, list)
+            assert len(tags) > 0, "Should have found some tags for bluerobotics/blueos-core"
+
+            # Verify tag structure
+            for tag in tags[:3]:  # Check first 3 tags
+                assert isinstance(tag, TagMetadata)
+                assert tag.repository == "bluerobotics/blueos-core"
+                assert tag.image == "blueos-core"
+                assert tag.tag is not None
+                assert len(tag.tag) > 0
+                assert tag.last_modified is not None
+                assert tag.digest is not None
+
+            # Should find the 'master' tag
+            tag_names = [tag.tag for tag in tags]
+            assert "master" in tag_names, f"Expected to find 'master' tag in tags: {tag_names[:10]}"
+
+            # Errors should be empty string if successful
+            if errors:
+                print(f"Non-fatal errors during fetch: {errors}")
+
+        except Exception as e:
+            # If this fails due to network issues, skip the test
+            pytest.skip(f"Could not fetch tags from DockerHub, likely network issue: {e}")

--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -102,6 +102,22 @@ class TagFetcher:
                 my_architecture = get_current_arch()
                 valid_images = []
                 for tag in tags:
+                    images = tag["images"]
+                    if len(images) == 0:
+                        # this is a hack to deal with https://github.com/docker/hub-feedback/issues/2484
+                        # we lost the ability to properly identify the images as we dont have the digest,
+                        # and also the ability to filter for compatible architectures.
+                        # so we just add the tag and hope for the best.
+                        tag = TagMetadata(
+                            repository=repository,
+                            image=repository.split("/")[-1],
+                            tag=tag["name"],
+                            last_modified=tag["last_updated"],
+                            sha=None,
+                            digest="------",
+                        )
+                        valid_images.append(tag)
+                        continue
                     for image in tag["images"]:
                         if image["architecture"] == my_architecture:
                             tag = TagMetadata(


### PR DESCRIPTION
This is a backport of #3490 into 1.3

## Summary by Sourcery

Backport the DockerHub workaround to handle missing images and add integration tests for tag fetching

Enhancements:
- Handle empty DockerHub image lists by creating placeholder TagMetadata entries with dummy digests
- Introduce TestTagFetcher integration test to verify fetching and validating tags from DockerHub

Tests:
- Add integration test class TestTagFetcher for TagFetcher functionality