### PR TITLE
Backports/1.4/dockerhub workaround

### DIFF
--- a/core/services/versionchooser/test_versionchooser.py
+++ b/core/services/versionchooser/test_versionchooser.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from utils.chooser import VersionChooser
+from utils.dockerhub import TagFetcher, TagMetadata
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -236,3 +237,41 @@ async def test_set_version_json_exception(json_mock: mock.MagicMock) -> None:
         result = await chooser.set_version("bluerobotics/blueos-core", "master")
         assert result.status == 500
         assert len(json_mock.mock_calls) > 0
+
+
+class TestTagFetcher:
+    """Test class for TagFetcher functionality"""
+
+    @pytest.mark.asyncio
+    async def test_fetch_real_blueos_core_tags(self) -> None:
+        """Integration test: Fetch real tags from bluerobotics/blueos-core repository"""
+        fetcher = TagFetcher()
+
+        try:
+            errors, tags = await fetcher.fetch_remote_tags("bluerobotics/blueos-core", [])
+
+            # Verify we got some tags back
+            assert isinstance(tags, list)
+            assert len(tags) > 0, "Should have found some tags for bluerobotics/blueos-core"
+
+            # Verify tag structure
+            for tag in tags[:3]:  # Check first 3 tags
+                assert isinstance(tag, TagMetadata)
+                assert tag.repository == "bluerobotics/blueos-core"
+                assert tag.image == "blueos-core"
+                assert tag.tag is not None
+                assert len(tag.tag) > 0
+                assert tag.last_modified is not None
+                assert tag.digest is not None
+
+            # Should find the 'master' tag
+            tag_names = [tag.tag for tag in tags]
+            assert "master" in tag_names, f"Expected to find 'master' tag in tags: {tag_names[:10]}"
+
+            # Errors should be empty string if successful
+            if errors:
+                print(f"Non-fatal errors during fetch: {errors}")
+
+        except Exception as e:
+            # If this fails due to network issues, skip the test
+            pytest.skip(f"Could not fetch tags from DockerHub, likely network issue: {e}")

--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -110,6 +110,22 @@ class TagFetcher:
                 my_architecture = get_current_arch()
                 valid_images = []
                 for tag in tags:
+                    images = tag["images"]
+                    if len(images) == 0:
+                        # this is a hack to deal with https://github.com/docker/hub-feedback/issues/2484
+                        # we lost the ability to properly identify the images as we dont have the digest,
+                        # and also the ability to filter for compatible architectures.
+                        # so we just add the tag and hope for the best.
+                        tag = TagMetadata(
+                            repository=repository,
+                            image=repository.split("/")[-1],
+                            tag=tag["name"],
+                            last_modified=tag["last_updated"],
+                            sha=None,
+                            digest="------",
+                        )
+                        valid_images.append(tag)
+                        continue
                     for image in tag["images"]:
                         if image["architecture"] == my_architecture:
                             tag = TagMetadata(


### PR DESCRIPTION
This is a backport of #3490 into 1.4

## Summary by Sourcery

Backport DockerHub workaround into 1.4 by synthesizing TagMetadata for tags without image entries and adding an integration test to ensure TagFetcher fetches and validates remote tags correctly.

New Features:
- Add TestTagFetcher integration test to verify real DockerHub tag fetching and metadata structure

Bug Fixes:
- Implement workaround for Docker Hub API issue #2484 by creating placeholder TagMetadata for tags with empty image lists

Enhancements:
- Improve fetch_remote_tags to handle tags lacking image records by generating fallback metadata with a dummy digest

Tests:
- Include asynchronous test in test_versionchooser.py that fetches real tags, validates metadata fields, and skips on network errors