### PR TITLE
core: frontend: modelHelper code cleanup

### DIFF
--- a/core/frontend/src/components/vehiclesetup/viewers/modelHelper.ts
+++ b/core/frontend/src/components/vehiclesetup/viewers/modelHelper.ts
@@ -63,17 +63,19 @@ export function frame_name(vehicle_type: string, frame_type?: number, frame_subt
   }
 
 export async function checkModelOverrides() {
-    while (!autopilot.vehicle_type || !frame_type()) {
-      await sleep(100)
-    }
+    // Early return on global override
     const master_override = '/userdata/modeloverrides/ALL.glb'
-    const vehicle_override = `/userdata/modeloverrides/${vehicle_folder()}/${frame_name(autopilot.vehicle_type, frame_type())}.glb`
     try {
       await axios.head(master_override)
       return master_override
     } catch {
       console.log(`master override model not found at ${master_override}`)
     }
+    // See if there is a specific override for the connected vehicle type and frame
+    while (!autopilot.vehicle_type || !frame_type()) {
+      await sleep(100)
+    }
+    const vehicle_override = `/userdata/modeloverrides/${vehicle_folder()}/${frame_name(autopilot.vehicle_type, frame_type())}.glb`
     try {
       await axios.head(vehicle_override)
       return vehicle_override


### PR DESCRIPTION
- Fixed some weird indentation
- Improved checking sequence for model overrides, which may slightly improve performance when doing a global override

## Summary by Sourcery

Refactor modelHelper to tidy up indentation and optimize the model override lookup by checking for a global override before awaiting vehicle and frame readiness.

Enhancements:
- Fix indentation inconsistencies in vehicle_folder switch statements
- Reorder checkModelOverrides logic to attempt global override head request before waiting for vehicle_type and frame_type