### PR TITLE
core: frontend: MainView: Fix translation of Digital Twin

### DIFF
--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -137,7 +137,6 @@ export default Vue.extend({
             h: 1.2,
           },
           style: {
-            transform: 'translateY(-45%)',
             maxHeight: '300px',
           },
           props: {


### PR DESCRIPTION
Before:

<img width="1374" height="709" alt="image" src="https://github.com/user-attachments/assets/33af59da-a509-40df-b88d-684d55fabc73" />


After:

<img width="970" height="468" alt="image" src="https://github.com/user-attachments/assets/2d3199f0-ff4a-4aee-976a-2d017f59f762" />

## Summary by Sourcery

Bug Fixes:
- Eliminate the 'translateY(-45%)' transform from the Digital Twin component style to fix its display alignment.