### PR TITLE
1.4: Cherry-pick 3254 [Enable QGC Server link by default]

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -61,7 +61,7 @@ class AutoPilotManager(metaclass=Singleton):
                 place="0.0.0.0",
                 argument=14550,
                 persistent=True,
-                enabled=False,
+                enabled=True,
             ),
             Endpoint(
                 name="GCS Client Link",


### PR DESCRIPTION
From: https://github.com/bluerobotics/BlueOS/pull/3254

The issue: When the backup DHCP server quicks in the client computer can switche from a static IP to a DHCP client (Tested in ubuntu 24.04), the IP changes from 192.168.2.1 to 192.168.2.*, and QGC fails to connect.
Another problem is that the GCS server endpoint 0.0.0.0:14550 on BlueOS is also not enabled, because of this, QGC doesn’t connect even if you manually set the vehicle’s IP and port.

This PR enables the GCS Server port to at least allow users to manually connect to the vehicle.

## Summary by Sourcery

Bug Fixes:
- Enable GCS server endpoint (0.0.0.0:14550) by default to allow QGC connections