### PR TITLE
frontend: vite.config: Add missing changeOrigin for version-chooser

### DIFF
--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -217,6 +217,7 @@ export default defineConfig(({ command, mode }) => {
         },
         '^/version-chooser': {
           target: SERVER_ADDRESS,
+          changeOrigin: true,
           onProxyRes: (proxyRes, request, response) => {
             proxyRes.on('data', (data) => {
               response.write(data)


### PR DESCRIPTION
All other endpoints have it, I had some problems with bun/yarn dev when running without it.