### PR TITLE
frontend: components: health: HealthTrayMenu: Add color to calibrate button

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -133,6 +133,7 @@
                   <v-btn
                     x-small
                     :to="{ name: 'Vehicle Setup', params: { tab: 'configure', subtab: sensor_name } }"
+                    color="primary"
                   >
                     Calibrate
                   </v-btn>


### PR DESCRIPTION
<img width="419" height="386" alt="image" src="https://github.com/user-attachments/assets/49596ddb-1fd7-4528-b8e1-155228feb175" />

## Summary by Sourcery

Enhancements:
- Add primary color prop to the Calibrate button in HealthTrayMenu component