### PR TITLE
core: services: helper: main: Fix github check port

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -86,7 +86,7 @@ class Website(Enum):
     GitHub = {
         "hostname": "github.com",
         "path": "/",
-        "port": 80,
+        "port": 443,
     }
 
 


### PR DESCRIPTION
This can be test with 
```sh
echo -e "GET / HTTP/1.1\r\nHost: github.com\r\nUser-Agent: python\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: close\r\n\r\n" \
  | nc github.com 80


echo -e "GET / HTTP/1.1\r\nHost: github.com\r\nUser-Agent: python\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: close\r\n\r\n" \
  | nc github.com 443
```

## Summary by Sourcery

Bug Fixes:
- Use port 443 instead of 80 for GitHub health checks