### PR TITLE
core: services: helper: main: Fix timeout for check_website

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -470,7 +470,7 @@ class Helper:
         port = int(str(site.value["port"]))
         path = str(site.value["path"])
 
-        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=10, method="GET")
+        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=5, method="GET")
         website_status = WebsiteStatus(site=site, online=False)
 
         log_msg = f"Running check_website for '{hostname}:{port}'"


### PR DESCRIPTION
The frontend timeout is 10 seconds, the backend run the tests in parallel, but since the website has a 10s window to reply, if one of the websites does not answer in time, it'll trigger connection unknown over limited.

## Summary by Sourcery

Enhancements:
- Reduce the HTTP request timeout in check_website from 10 seconds to 5 seconds