### PR TITLE
core: services: helper: main: Fix website_status.error always being None

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -478,8 +478,8 @@ class Helper:
             logger.debug(f"{log_msg}: Online.")
             website_status.online = True
         else:
-            logger.warning(f"{log_msg}: Offline: {website_status.error}.")
             website_status.error = response.error
+            logger.warning(f"{log_msg}: Offline: {website_status.error}.")
 
         return website_status
 


### PR DESCRIPTION
WebsiteStatus is created and website_status.error is only set in the previous line