### PR TITLE
core: services: helper: main: Fix github check port

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -85,7 +85,7 @@ class Website(Enum):
     GitHub = {
         "hostname": "github.com",
         "path": "/",
-        "port": 80,
+        "port": 443,
     }
 
 


### PR DESCRIPTION
This is a backport of #3514 into 1.4

## Summary by Sourcery

Bug Fixes:
- Use port 443 for GitHub service checks instead of 80