### PR TITLE
core: services: helper: main: Fix timeout for check_website

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -450,7 +450,7 @@ class Helper:
         port = int(str(site.value["port"]))
         path = str(site.value["path"])
 
-        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=10, method="GET")
+        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=5, method="GET")
         website_status = WebsiteStatus(site=site, online=False)
 
         log_msg = f"Running check_website for '{hostname}:{port}'"


### PR DESCRIPTION
This is a backport of #3515 into 1.4

## Summary by Sourcery

Bug Fixes:
- Lower the default HTTP request timeout in check_website from 10s to 5s