### PR TITLE
core: services: helper: main: Fix website_status.error always being None

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -458,8 +458,8 @@ class Helper:
             logger.debug(f"{log_msg}: Online.")
             website_status.online = True
         else:
-            logger.warning(f"{log_msg}: Offline: {website_status.error}.")
             website_status.error = response.error
+            logger.warning(f"{log_msg}: Offline: {website_status.error}.")
 
         return website_status
 


### PR DESCRIPTION
This is a backport of #3516 into 1.4

## Summary by Sourcery

Bug Fixes:
- Set website_status.error before logging to ensure the error is not always None in check_website