### PR TITLE
Core: Services: Cable Guy: Locks API calls to run concurrently with watchdog

### DIFF
--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -37,13 +37,15 @@ app.router.route_class = GenericErrorHandlingRoute
 @app.get("/ethernet", response_model=List[NetworkInterface], summary="Retrieve ethernet interfaces.")
 @version(1, 0)
 @temporary_cache(timeout_seconds=10)
-def retrieve_ethernet_interfaces() -> Any:
+@EthernetManager.operation
+async def retrieve_ethernet_interfaces() -> Any:
     """REST API endpoint to retrieve the configured ethernet interfaces."""
     return manager.get_ethernet_interfaces()
 
 
 @app.post("/ethernet", response_model=NetworkInterface, summary="Configure a ethernet interface.")
 @version(1, 0)
+@EthernetManager.operation
 async def configure_interface(interface: NetworkInterface = Body(...)) -> Any:
     """REST API endpoint to configure a new ethernet interface or modify an existing one."""
     await manager.set_configuration(interface)
@@ -54,21 +56,24 @@ async def configure_interface(interface: NetworkInterface = Body(...)) -> Any:
 @app.get("/interfaces", response_model=List[NetworkInterface], summary="Retrieve all network interfaces.")
 @version(1, 0)
 @temporary_cache(timeout_seconds=1)
-def retrieve_interfaces() -> Any:
+@EthernetManager.operation
+async def retrieve_interfaces() -> Any:
     """REST API endpoint to retrieve the all network interfaces."""
     return manager.get_interfaces()
 
 
 @app.post("/set_interfaces_priority", summary="Set interface priority")
 @version(1, 0)
-def set_interfaces_priority(interfaces: List[NetworkInterfaceMetricApi]) -> Any:
+@EthernetManager.operation
+async def set_interfaces_priority(interfaces: List[NetworkInterfaceMetricApi]) -> Any:
     """REST API endpoint to set the interface priority."""
     return manager.set_interfaces_priority(interfaces)
 
 
 @app.post("/address", summary="Add IP address to interface.")
 @version(1, 0)
-def add_address(interface_name: str, ip_address: str) -> Any:
+@EthernetManager.operation
+async def add_address(interface_name: str, ip_address: str) -> Any:
     """REST API endpoint to add a static IP address to an ethernet interface."""
     manager.add_static_ip(interface_name, ip_address)
     manager.save()
@@ -76,7 +81,8 @@ def add_address(interface_name: str, ip_address: str) -> Any:
 
 @app.delete("/address", summary="Delete IP address from interface.")
 @version(1, 0)
-def delete_address(interface_name: str, ip_address: str) -> Any:
+@EthernetManager.operation
+async def delete_address(interface_name: str, ip_address: str) -> Any:
     """REST API endpoint to delete an IP address from an ethernet interface."""
     manager.remove_ip(interface_name, ip_address)
     manager.save()
@@ -84,6 +90,7 @@ def delete_address(interface_name: str, ip_address: str) -> Any:
 
 @app.post("/dhcp", summary="Add local DHCP server to interface.")
 @version(1, 0)
+@EthernetManager.operation
 async def add_dhcp_server(interface_name: str, ipv4_gateway: str, is_backup_server: bool = False) -> Any:
     """REST API endpoint to enable/disable local DHCP server."""
     manager.add_dhcp_server_to_interface(interface_name, ipv4_gateway, is_backup_server)
@@ -92,7 +99,8 @@ async def add_dhcp_server(interface_name: str, ipv4_gateway: str, is_backup_serv
 
 @app.delete("/dhcp", summary="Remove local DHCP server from interface.")
 @version(1, 0)
-def remove_dhcp_server(interface_name: str) -> Any:
+@EthernetManager.operation
+async def remove_dhcp_server(interface_name: str) -> Any:
     """REST API endpoint to enable/disable local DHCP server."""
     manager.remove_dhcp_server_from_interface(interface_name)
     manager.save()
@@ -100,7 +108,8 @@ def remove_dhcp_server(interface_name: str) -> Any:
 
 @app.post("/dynamic_ip", summary="Trigger reception of dynamic IP.")
 @version(1, 0)
-def trigger_dynamic_ip_acquisition(interface_name: str) -> Any:
+@EthernetManager.operation
+async def trigger_dynamic_ip_acquisition(interface_name: str) -> Any:
     """REST API endpoint to trigger interface to receive a new dynamic IP."""
     manager.trigger_dynamic_ip_acquisition(interface_name)
     manager.save()
@@ -108,21 +117,24 @@ def trigger_dynamic_ip_acquisition(interface_name: str) -> Any:
 
 @app.get("/host_dns", summary="Retrieve host DNS configuration.")
 @version(1, 0)
-def retrieve_host_dns() -> Any:
+@EthernetManager.operation
+async def retrieve_host_dns() -> Any:
     """REST API endpoint to retrieve the host DNS configuration."""
     return manager.dns.retrieve_host_nameservers()
 
 
 @app.post("/host_dns", summary="Update host DNS configuration.")
 @version(1, 0)
-def update_host_dns(dns_data: DnsData) -> Any:
+@EthernetManager.operation
+async def update_host_dns(dns_data: DnsData) -> Any:
     """REST API endpoint to update the host DNS configuration."""
     manager.dns.update_host_nameservers(dns_data)
 
 
 @app.post("/route", summary="Add route to interface.")
 @version(1, 0)
-def add_route(interface_name: str, route: Route) -> Any:
+@EthernetManager.operation
+async def add_route(interface_name: str, route: Route) -> Any:
     """REST API endpoint to add route."""
     manager.add_route(interface_name, route)
     manager.save()
@@ -130,7 +142,8 @@ def add_route(interface_name: str, route: Route) -> Any:
 
 @app.delete("/route", summary="Remove route from interface.")
 @version(1, 0)
-def remove_route(interface_name: str, route: Route) -> Any:
+@EthernetManager.operation
+async def remove_route(interface_name: str, route: Route) -> Any:
     """REST API endpoint remove route."""
     manager.remove_route(interface_name, route)
     manager.save()
@@ -138,7 +151,8 @@ def remove_route(interface_name: str, route: Route) -> Any:
 
 @app.get("/route", summary="Get the interface routes.")
 @version(1, 0)
-def get_route(interface_name: str) -> List[Route]:
+@EthernetManager.operation
+async def get_route(interface_name: str) -> List[Route]:
     """REST API endpoint to get routes."""
     return list(manager.get_routes(interface_name, ignore_unmanaged=False))
 


### PR DESCRIPTION
WIP: This will block watchdog from running when any API operation is being performed, effectively converting to a sync behavior. Some operations may be able to run properly without the lock, needs test for evaluation.

## Summary by Sourcery

Serialize Cable Guy API operations alongside the watchdog loop to prevent concurrent execution and potential race conditions.

Enhancements:
- Add an asyncio operation_mutex and `operation` decorator to EthernetManager to serialize async API calls.
- Wrap the watchdog loop body in the operation_mutex to block API operations while the watchdog runs.
- Apply the `operation` decorator to all EthernetManager-driven API endpoint handlers.