### PR TITLE
frontend: widgets: Networking: Update margin for mbps

### DIFF
--- a/core/frontend/src/widgets/Networking.vue
+++ b/core/frontend/src/widgets/Networking.vue
@@ -7,7 +7,7 @@
         <span class="vertical-text">{{ interface }}</span>
       </div>
       <v-spacer />
-      <div class="d-flex flex-column stacked-text mr-2">
+      <div class="d-flex flex-column stacked-text mr-3">
         <div class="d-flex align-center text-caption bandwidth-row" style="margin-bottom: -8px">
           <div class="icon-label-group">
             <i class="arrow-icon-rx" v-html="arrowLeft" />
@@ -128,6 +128,7 @@ export default Vue.extend({
 
 .bandwidth-row {
   min-width: 110px;
+  margin-left: -10px;
 }
 
 .icon-label-group {


### PR DESCRIPTION
new:
<img width="312" height="428" alt="image" src="https://github.com/user-attachments/assets/fc8814be-516e-451b-bb81-688a20dc2684" />


old:
<img width="310" height="407" alt="image" src="https://github.com/user-attachments/assets/d3b38c5c-9f07-4752-b7ef-42eb50ea5ed6" />

## Summary by Sourcery

Enhancements:
- Increase right margin on the stacked-text container and add negative left margin to the bandwidth row for proper alignment