### PR TITLE
core:services:bridget:Migrate settings to pydantic

### DIFF
--- a/core/services/bridget/bridget.py
+++ b/core/services/bridget/bridget.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 from typing import Dict, List
 
 import requests
@@ -8,10 +7,9 @@ from bridges.serialhelper import Baudrate
 from commonwealth.settings.manager import Manager
 from pydantic import BaseModel, conint
 from serial.tools.list_ports_linux import SysFS
+from config import SERVICE_NAME
 
 from settings import BridgeSettingsSpecV2, SettingsV2
-
-USERDATA = Path("/usr/blueos/userdata/")
 
 
 class BridgeFrontendSpec(BaseModel):
@@ -47,9 +45,8 @@ class Bridget:
 
     def __init__(self) -> None:
         self._bridges: Dict[BridgeFrontendSpec, Bridge] = {}
-        # We use userdata because our regular settings folder is under /root, which regular users
-        # don't have access to.
-        self._settings_manager = Manager("bridget", SettingsV2, USERDATA / "settings" / "bridget")
+        # Following the standard BlueOS pattern: /root/.config/blueos/<service-name>/
+        self._settings_manager = Manager(SERVICE_NAME, SettingsV2)
         self._settings_manager.load()
         for bridge_settings_spec in self._settings_manager.settings.specsv2:
             try:

--- a/core/services/bridget/config.py
+++ b/core/services/bridget/config.py
@@ -1,0 +1,3 @@
+# This file is used to define general configurations for the app
+
+SERVICE_NAME = "bridget"

--- a/core/services/bridget/main.py
+++ b/core/services/bridget/main.py
@@ -13,8 +13,7 @@ from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
 
 from bridget import BridgeFrontendSpec, Bridget
-
-SERVICE_NAME = "bridget"
+from config import SERVICE_NAME
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)


### PR DESCRIPTION
Fix #3523

* Move from pykson with custom directory to new settings implementation using pydantic

## Summary by Sourcery

Migrate the bridget service settings from a custom pykson-based implementation to Pydantic models and the PydanticSettings framework, consolidate legacy migration logic, and standardize settings storage to the standard user config path using a service name constant.

Enhancements:
- Replace pykson.JsonObject specs and custom BaseSettings with Pydantic BaseModel and PydanticSettings subclasses for SettingsV1 and SettingsV2
- Introduce migrate_from_old_settings and on_settings_created hooks to automatically migrate legacy v1 and v2 JSON settings files
- Standardize settings directory by using a SERVICE_NAME constant and remove the hardcoded USERDATA path in Manager initialization
- Add a new config module to define SERVICE_NAME for consistent configuration across the service