### PR TITLE
core: libs: commonwealth: settings: managers: Deal with invalid settings file

### DIFF
--- a/core/libs/commonwealth/commonwealth/settings/managers/pydantic_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/managers/pydantic_manager.py
@@ -6,7 +6,6 @@ import appdirs
 from loguru import logger
 
 from commonwealth.settings.bases.pydantic_base import PydanticSettings
-from commonwealth.settings.exceptions import SettingsFromTheFuture
 
 
 class PydanticManager:
@@ -128,10 +127,12 @@ class PydanticManager:
                 self._settings = PydanticManager.load_from_file(self.settings_type, valid_file)
                 logger.debug(f"Using {valid_file} as settings source")
                 return
-            except SettingsFromTheFuture as exception:
+            except Exception as exception:
                 logger.debug("Invalid settings, going to try another file:", exception)
 
-        self._settings = PydanticManager.load_from_file(self.settings_type, self.settings_file_path())
+        logger.debug("No valid settings found, using default settings")
+        self._settings = self.settings_type()
+        self.save()
 
     def _clear_temp_files(self) -> None:
         """Clear temporary files"""

--- a/core/libs/commonwealth/commonwealth/settings/managers/pydantic_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/managers/pydantic_manager.py
@@ -29,7 +29,7 @@ class PydanticManager:
         )
         self.config_folder.mkdir(parents=True, exist_ok=True)
         self.settings_type = settings_type
-        self._settings = None
+        self._settings: Optional[PydanticSettings] = None
         logger.debug(
             f"Starting {project_name} settings with {settings_type.__name__}, configuration path: {config_folder}"
         )

--- a/core/libs/commonwealth/commonwealth/settings/managers/pykson_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/managers/pykson_manager.py
@@ -29,7 +29,7 @@ class PyksonManager:
         )
         self.config_folder.mkdir(parents=True, exist_ok=True)
         self.settings_type = settings_type
-        self._settings = None
+        self._settings: Optional[PyksonSettings] = None
         logger.debug(
             f"Starting {project_name} settings with {settings_type.__name__}, configuration path: {config_folder}"
         )

--- a/core/libs/commonwealth/commonwealth/settings/managers/pykson_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/managers/pykson_manager.py
@@ -6,7 +6,6 @@ import appdirs
 from loguru import logger
 
 from commonwealth.settings.bases.pykson_base import PyksonSettings
-from commonwealth.settings.exceptions import SettingsFromTheFuture
 
 
 class PyksonManager:
@@ -124,10 +123,12 @@ class PyksonManager:
                 self._settings = PyksonManager.load_from_file(self.settings_type, valid_file)
                 logger.debug(f"Using {valid_file} as settings source")
                 return
-            except SettingsFromTheFuture as exception:
+            except Exception as exception:
                 logger.debug("Invalid settings, going to try another file:", exception)
 
-        self._settings = PyksonManager.load_from_file(self.settings_type, self.settings_file_path())
+        logger.debug("No valid settings found, using default settings")
+        self._settings = self.settings_type()
+        self.save()
 
     def _clear_temp_files(self) -> None:
         """Clear temporary files"""

--- a/core/libs/commonwealth/commonwealth/settings/tests/test_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/tests/test_manager.py
@@ -198,3 +198,77 @@ def test_fallback_settings_save_load() -> None:
     assert settings_manager.settings.version_2_variable == 2
     assert settings_manager.settings.version_3_variable == 3
     assert settings_manager.settings.version_12_variable == 12
+
+
+def test_invalid_json_fallback_to_defaults_v1() -> None:
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+
+    # Create a settings file with invalid JSON
+    settings_folder = config_path / "managertest"
+    settings_folder.mkdir(parents=True, exist_ok=True)
+    invalid_settings_file = settings_folder / "settings-1.json"
+    with open(invalid_settings_file, "w", encoding="utf-8") as f:
+        f.write('{"VERSION": 1, "version_1_variable": 999, "invalid_json": }')
+
+    settings_manager = manager.Manager("ManagerTest", SettingsV1, config_path)
+
+    # Verify that the manager falls back to default values
+    assert settings_manager.settings.VERSION == 1
+    assert settings_manager.settings.version_1_variable == 42
+
+    # Verify that a v1 settings will be replaced
+    settings_manager.save()
+    assert len(os.listdir(settings_folder)) == 1
+
+
+def test_invalid_json_fallback_to_defaults_v1_from_invalid_v2() -> None:
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+    settings_folder = config_path / "managertest"
+    settings_folder.mkdir(parents=True, exist_ok=True)
+
+    # Create a valid JSON from settings V1
+    default_settings = SettingsV1()
+    default_settings.version_1_variable = 369
+    default_settings.save(settings_folder / "settings-1.json")
+
+    # Create a invalid JSON from settings V2
+    invalid_settings_file = settings_folder / "settings-2.json"
+    with open(invalid_settings_file, "w", encoding="utf-8") as f:
+        f.write('{"VERSION": 2, "version_2_variable": 999, "invalid_json": }')
+
+    settings_manager = manager.Manager("ManagerTest", SettingsV2, config_path)
+
+    # Verify that the manager falls back to default values
+    assert settings_manager.settings.VERSION == 2
+    assert settings_manager.settings.version_1_variable == 369
+    assert settings_manager.settings.version_2_variable == 66
+
+    # Verify that a v2 settings will be replaced
+    settings_manager.save()
+    assert len(os.listdir(settings_folder)) == 2
+
+
+def test_invalid_json_fallback_to_defaults_v2_from_invalid_v2_and_v1() -> None:
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+    settings_folder = config_path / "managertest"
+    settings_folder.mkdir(parents=True, exist_ok=True)
+
+    # Create a invalid JSON from settings V1
+    invalid_settings_file = settings_folder / "settings-2.json"
+    with open(invalid_settings_file, "w", encoding="utf-8") as f:
+        f.write('{"VERSION": 1, "version_1_variable": 999, "invalid_json": }')
+
+    # Create a invalid JSON from settings V2
+    invalid_settings_file = settings_folder / "settings-2.json"
+    with open(invalid_settings_file, "w", encoding="utf-8") as f:
+        f.write('{"VERSION": 2, "version_2_variable": 999, "invalid_json": }')
+
+    settings_manager = manager.Manager("ManagerTest", SettingsV2, config_path)
+
+    # Verify that the manager falls back to default values
+    assert settings_manager.settings.VERSION == 2
+    assert settings_manager.settings.version_1_variable == 42
+    assert settings_manager.settings.version_2_variable == 66


### PR DESCRIPTION
Cherry-pick from: #3529

## Summary by Sourcery

Handle corrupted settings files by falling back to default settings and replacing invalid files, updating both Pykson and Pydantic managers and their tests

New Features:
- Fallback to default settings when encountering invalid JSON configurations
- Automatic replacement of corrupted settings files upon save

Enhancements:
- Broaden exception handling in PyksonManager and PydanticManager to catch all errors during load
- Remove unused SettingsFromTheFuture exception imports and improve debug logging

Tests:
- Add tests for invalid JSON fallback scenarios across multiple settings versions for both Pykson and Pydantic managers