### PR TITLE
frontend: remove default blueboat model from Digital Twin

### DIFF
--- a/core/frontend/src/components/vehiclesetup/viewers/GenericViewer.vue
+++ b/core/frontend/src/components/vehiclesetup/viewers/GenericViewer.vue
@@ -47,22 +47,28 @@
         </v-icon>
       </v-btn>
     </model-viewer>
+    <div v-else-if="!show_model_not_found" class="d-flex flex-column align-center">
+      <SpinningLogo size="30%" />
+    </div>
     <div v-else class="d-flex flex-column align-center">
-      <SpinningLogo v-if="!computed_model_path" size="40%" />
-      <div v-else>
-        <v-icon
-          style="height: 400px"
-          size="256"
-          v-text="'mdi-sail-boat-sink'"
-        />
-        <div
-          class="text-h6"
-          :v-text="'Vehicle not found.'"
-        />
-        <p class="text-h6 text-center ma-4">
-          Vehicle not found
-        </p>
-      </div>
+      <v-icon
+        style="height: 170px"
+        size="200"
+        v-text="'mdi-sail-boat-sink'"
+      />
+      <p class="text-h6 ma-2">
+        Vehicle model not found
+      </p>
+      <p class="text-center text-body-2" style="max-width: 350px">
+        If you want to add a custom 3D model please follow the instructions in
+        <a
+          href="https://blueos.cloud/docs/latest/usage/advanced/#vehicle-model"
+          target="_blank"
+          class="text-decoration-none"
+        >
+          BlueOS Documentation
+        </a>
+      </p>
     </div>
   </div>
 </template>
@@ -141,6 +147,7 @@ export default Vue.extend({
       annotations: {} as Dictionary<HotspotConfiguration>,
       override_annotations: {} as Dictionary<HotspotConfiguration>,
       default_alphas: {} as Dictionary<number>,
+      show_model_not_found: false,
     }
   },
   computed: {
@@ -260,6 +267,13 @@ export default Vue.extend({
       this.redraw()
       this.hideIrrelevantParts()
     })
+
+    setTimeout(() => {
+      if (!this.computed_model_path) {
+        this.show_model_not_found = true
+      }
+    }, 5000)
+
     this.model_override_path = await checkModelOverrides()
     this.override_annotations = await this.loadAnnotationsOverride()
     this.reloadAnnotations()

--- a/core/frontend/src/store/autopilot.ts
+++ b/core/frontend/src/store/autopilot.ts
@@ -107,13 +107,13 @@ class AutopilotStore extends VuexModule {
   get vehicle_model() {
     const frame = this.frame_type
     if (!this.vehicle_type || frame === undefined) {
-      return `assets/vehicles/models/rover/unknown.glb`
+      return ''
     }
     const release_path = `assets/vehicles/models/${vehicle_folder()}/${this.frame_name}.glb`
     if (models[`/public/${release_path}`]) {
       return `/assets/vehicles/models/${vehicle_folder()}/${this.frame_name}.glb`
     }
-    return `assets/vehicles/models/rover/unknown.glb`
+    return ''
   }
 
   get is_safe() {


### PR DESCRIPTION
fix: #3508

Now when a vehicle model is not available it will not default to the BlueBoat anymore. Instead, it will wait 5 seconds to see if anything is identified and, if that is not the case, the user will be informed that no vehicle model was found.

<img width="444" height="347" alt="image" src="https://github.com/user-attachments/assets/5a58b8f5-62a6-409f-ad39-e4f9eb68fd6c" />

## Summary by Sourcery

Stop defaulting to the BlueBoat model for unidentified vehicles, show a spinner for 5 seconds, and then inform the user when no vehicle model is found by updating the UI and the vehicle_model getter.

Enhancements:
- Remove fallback to the BlueBoat model when no vehicle model is available, and defer showing an error for 5 seconds
- Display a loading spinner for 5 seconds before presenting a 'Vehicle model not found' message with a sink-boat icon
- Update the AutopilotStore vehicle_model getter to return an empty string instead of a default model path when no model is found