### PR TITLE
frontend: ExtensionCreationCard: fix logic bug

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -176,8 +176,8 @@ export default Vue.extend({
   },
   methods: {
     populatePermissions() {
-      const user_permissions = JSON.parse(this.extension?.user_permissions ?? '{}')
-      const original_permissions = JSON.parse(this.extension?.permissions ?? '{}')
+      const user_permissions = JSON.parse(this.extension?.user_permissions || '{}')
+      const original_permissions = JSON.parse(this.extension?.permissions || '{}')
       if (user_permissions) {
         this.new_permissions = user_permissions
       } else {


### PR DESCRIPTION
this may be fixing a bug where the editor is not populated with the correct permissions. I haven't really noticed the issue other than the console errors.

<img width="163" height="104" alt="image" src="https://github.com/user-attachments/assets/21cdc5ea-b724-4aee-b75a-72009d03eb90" />
