### PR TITLE
frontend: change default connection type to UDP Client when creating Mavlink endpoints

### DIFF
--- a/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
+++ b/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
@@ -107,7 +107,7 @@ import {
 const defaultEndpointValue: AutopilotEndpoint = {
   name: 'My endpoint',
   owner: 'User',
-  connection_type: EndpointType.udpin,
+  connection_type: EndpointType.udpout,
   place: '0.0.0.0',
   argument: 14550,
   protected: false,


### PR DESCRIPTION
fix: #3399 

When creating new Mavlink endpoints the default selected type will be UDP Client.

## Summary by Sourcery

Bug Fixes:
- Set default Mavlink endpoint connection type to UDP Client when creating new endpoints in the frontend