### PR TITLE
[1.4] core: frontend: widgets: Networking: Fix svg height

### DIFF
--- a/core/frontend/src/widgets/Networking.vue
+++ b/core/frontend/src/widgets/Networking.vue
@@ -118,6 +118,7 @@ export default Vue.extend({
 
 .pi-icon :deep(svg) {
   width: 35px;
+  height: 40px;
   margin-bottom: -10px;
 }
 


### PR DESCRIPTION
This is a backport of #3273 into 1.4

## Summary by Sourcery

Bug Fixes:
- Fix SVG icon height in Networking widget