### PR TITLE
NetworkManager/Bookworm: Don't save wifi networks we failed to connect to

### DIFF
--- a/core/services/wifi/typedefs.py
+++ b/core/services/wifi/typedefs.py
@@ -43,6 +43,7 @@ class SavedWifiNetwork(BaseModel):
     bssid: Optional[str]
     flags: Optional[str]
     nm_id: Optional[str]
+    nm_uuid: Optional[str]
 
 
 class WifiCredentials(BaseModel):

--- a/core/services/wifi/wifi_handlers/networkmanager/networkmanager.py
+++ b/core/services/wifi/wifi_handlers/networkmanager/networkmanager.py
@@ -249,6 +249,7 @@ class NetworkManagerWifi(AbstractWifiManager):
         # If hotspot was running, restart it
         if not await wait_for_connection():
             logger.error(f"Connection timeout for {credentials.ssid}")
+            await self.remove_network(credentials.ssid)
             raise TimeoutError(f"Failed to connect to {credentials.ssid} within 30 seconds")
 
         if self._settings_manager.settings.hotspot_enabled:


### PR DESCRIPTION
Fix #2513

## Summary by Sourcery

Remove failed Wi-Fi profiles upon connection timeout, enrich saved network entries with UUIDs, and implement the remove_network method to delete NM connections by UUID.

Bug Fixes:
- Forget failed Wi-Fi networks after connection timeout

Enhancements:
- Add nm_uuid to SavedWifiNetwork and populate it when retrieving saved networks
- Implement remove_network to delete connections by UUID in NetworkManager

## Summary by Sourcery

Remove failed Wi-Fi profiles on connection timeout, enrich saved network entries with UUIDs, and enable network removal by UUID in NetworkManager

Bug Fixes:
- Forget failed Wi-Fi networks after connection timeout

Enhancements:
- Include nm_uuid in SavedWifiNetwork model and populate it when listing saved networks
- Implement remove_network to delete NetworkManager connections by UUID