### PR TITLE
kraken: remove update endpoint

### DIFF
--- a/core/frontend/src/components/kraken/KrakenManager.ts
+++ b/core/frontend/src/components/kraken/KrakenManager.ts
@@ -186,32 +186,6 @@ export async function setManifestSourceOrder(identifier: string, order: number):
 }
 
 /**
- * Update an extension to the latest version available
- * @param {InstalledExtensionData} extension The extension to be updated
- * @param {function} progressHandler The progress handler for the download
- */
-export async function updateExtension(
-  extension: InstalledExtensionData,
-  progressHandler: (event: any) => void,
-): Promise<void> {
-  await back_axios({
-    url: `${KRAKEN_API_V2_URL}/extension/update`,
-    method: 'POST',
-    data: {
-      identifier: extension.identifier,
-      name: extension.name,
-      docker: extension.docker,
-      tag: extension.tag,
-      enabled: true,
-      permissions: extension?.permissions ?? '',
-      user_permissions: extension?.user_permissions ?? '',
-    },
-    timeout: 120000,
-    onDownloadProgress: progressHandler,
-  })
-}
-
-/**
  * Install an extension to the latest version available
  * @param {InstalledExtensionData} extension The extension to be installed
  * @param {function} progressHandler The progress handler for the download
@@ -374,7 +348,6 @@ export default {
   disabledManifestSource,
   setManifestSourcesOrders,
   setManifestSourceOrder,
-  updateExtension,
   updateExtensionToVersion,
   installExtension,
   getInstalledExtensions,

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -342,11 +342,8 @@ export default Vue.extend({
         return
       }
 
-      if (this.edited_extension.editing) {
-        await this.update_local(this.edited_extension)
-      } else {
-        await this.install(this.edited_extension)
-      }
+      await this.install(this.edited_extension)
+
       this.show_dialog = false
       this.edited_extension = null
     },
@@ -458,27 +455,6 @@ export default Vue.extend({
       const tracker = this.getTracker()
 
       kraken.installExtension(
-        extension,
-        (progressEvent) => this.handleDownloadProgress(progressEvent, tracker),
-      )
-        .then(() => {
-          this.fetchInstalledExtensions()
-        })
-        .catch((error) => {
-          this.alerter = true
-          this.alerter_error = String(error)
-          notifier.pushBackError('EXTENSIONS_INSTALL_FAIL', error)
-        })
-        .finally(() => {
-          this.resetPullOutput()
-        })
-    },
-    async update_local(extension: InstalledExtensionData) {
-      this.show_dialog = false
-      this.show_pull_output = true
-      const tracker = this.getTracker()
-
-      kraken.updateExtension(
         extension,
         (progressEvent) => this.handleDownloadProgress(progressEvent, tracker),
       )

--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -155,16 +155,6 @@ async def update_to_tag(identifier: str, tag: str, purge: bool = True) -> Respon
     return StreamingResponse(streamer(extension.update(purge)))
 
 
-@extension_router_v2.post("/update", status_code=status.HTTP_200_OK)
-@extension_to_http_exception
-async def update_extension(body: ExtensionSource) -> StreamingResponse:
-    """
-    Update a given extension defined by an ExtensionSource object. Used to update manually added extensions.
-    """
-    extension = Extension(body)
-    return StreamingResponse(streamer(extension.update(True)))
-
-
 @extension_router_v2.delete("/{identifier}", status_code=status.HTTP_202_ACCEPTED)
 @extension_to_http_exception
 async def uninstall(identifier: str) -> None:


### PR DESCRIPTION
@joaomariolago explained that the way Kraken API works is not compatible with having an `update` endpoint. To avoid the problem described in this [issue](https://github.com/bluerobotics/BlueOS/issues/3260) we should merge this PR after https://github.com/bluerobotics/BlueOS/pull/3568.

## Summary by Sourcery

Remove Kraken update endpoint and clean up corresponding frontend and backend logic to simplify extension updates.

Bug Fixes:
- Eliminate incompatible Kraken update endpoint to prevent API conflicts.

Enhancements:
- Unify extension update workflow to always use the install endpoint.

Chores:
- Remove update_local method from ExtensionManagerView.vue.
- Remove updateExtension function from KrakenManager.ts.
- Delete /update route from Kraken API router.