### PR TITLE
[backport] core: tools: mavlink-camera-manager: Update to t3.22.1

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.19.2"
+VERSION="t3.22.1"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
This is a backport of #3575 into 1.4

## Summary by Sourcery

Chores:
- Bump VERSION in bootstrap.sh from t3.19.2 to t3.22.1