### PR TITLE
[backport] frontend: change default connection type to UDP Client when creating Mavlink endpoints

### DIFF
--- a/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
+++ b/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
@@ -107,7 +107,7 @@ import {
 const defaultEndpointValue: AutopilotEndpoint = {
   name: 'My endpoint',
   owner: 'User',
-  connection_type: EndpointType.udpin,
+  connection_type: EndpointType.udpout,
   place: '0.0.0.0',
   argument: 14550,
   protected: false,


### PR DESCRIPTION
This is a backport of #3560 into 1.4

## Summary by Sourcery

Enhancements:
- Set default connection type to UDP Client (udpout) when creating a Mavlink endpoint