### PR TITLE
bootstrap: Add BLUEOS_FACTORY_IMAGE

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -261,7 +261,7 @@ class Bootstrapper:
             bool: True if version chooser is online, False otherwise.
         """
         try:
-            response = requests.get("http://localhost/version-chooser/v1.0/version/current", timeout=10)
+            response = requests.get("http://127.0.0.1/version-chooser/v1.0/version/current", timeout=10)
             if Bootstrapper.SETTINGS_NAME_CORE in response.json()["repository"]:
                 if not self.version_chooser_is_online:
                     self.version_chooser_is_online = True


### PR DESCRIPTION
## Summary by Sourcery

Add an optional BLUEOS_FACTORY_IMAGE setting to bootstrapper to allow customizing the core container image and tag via environment variable with validation and logging.

New Features:
- Add support for BLUEOS_FACTORY_IMAGE environment variable to override the core factory image and tag

Enhancements:
- Validate the format of BLUEOS_FACTORY_IMAGE and log a warning if it's invalid
- Log the selected image and tag when BLUEOS_FACTORY_IMAGE is applied