### PR TITLE
dockerfile: Fix GIT_DESCRIBE_TAGS validation

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -7,7 +7,7 @@ ENV GIT_DESCRIBE_TAGS=${GIT_DESCRIBE_TAGS:-0.0.0-0-g00000000}
 RUN <<-EOF
 set -e
 
-    if [[ ! $GIT_DESCRIBE_TAGS =~ -[0-9]+-g[a-f0-9]{8}$ ]]; then
+    if ! echo "$GIT_DESCRIBE_TAGS" | grep -Eq -- '-[0-9]+-g[a-f0-9]{8}$'; then
         echo "Invalid format: $GIT_DESCRIBE_TAGS (E.g: <TAG>-<COMMIT_NUMBER>-g<SHORT_HASH>)"
         exit 1
     fi

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -73,7 +73,7 @@ ENV GIT_DESCRIBE_TAGS=${GIT_DESCRIBE_TAGS:-0.0.0-0-g00000000}
 RUN <<-EOF
 set -e
 
-    if [[ ! $GIT_DESCRIBE_TAGS =~ -[0-9]+-g[a-f0-9]{8}$ ]]; then
+    if ! echo "$GIT_DESCRIBE_TAGS" | grep -Eq -- '-[0-9]+-g[a-f0-9]{8}$'; then
         echo "Invalid format: $GIT_DESCRIBE_TAGS (E.g: <TAG>-<COMMIT_NUMBER>-g<SHORT_HASH>)"
         exit 1
     fi


### PR DESCRIPTION
debian-based shell is dash, not bash, so the `[[` syntax fails silently when validating GIT_DESCRIBE_TAGS content.