### PR TITLE
helper: send mavlink message when BlueOS is in factory mode

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/mavlink_comm/MavlinkComm.py
+++ b/core/libs/commonwealth/src/commonwealth/mavlink_comm/MavlinkComm.py
@@ -144,3 +144,12 @@ class MavlinkMessenger:
                         raise MavlinkMessageSendFail(f"Received status code of {response.status}.")
             except asyncio.exceptions.TimeoutError as error:
                 raise MavlinkMessageSendFail(f"Request timed out after {request_timeout} second.") from error
+
+    def command_statustext_message(self, text: str) -> Dict[str, Any]:
+        return {
+            "type": "STATUSTEXT",
+            "severity": {"type": "MAV_SEVERITY_NOTICE"},
+            "text": list(text),
+            "id": 0,
+            "chunk_seq": 0,
+        }

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -19,7 +19,9 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 import psutil
+import requests
 from bs4 import BeautifulSoup
+from commonwealth.mavlink_comm.MavlinkComm import MavlinkMessenger
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.decorators import temporary_cache
 from commonwealth.utils.general import (
@@ -231,6 +233,8 @@ class Helper:
 
     MAX_ATTEMPTS_LEFT = 3
     attempts_left: Dict[int, int] = {}
+
+    mavlink2rest = MavlinkMessenger()
 
     @staticmethod
     # pylint: disable=too-many-arguments,too-many-branches,too-many-locals
@@ -536,6 +540,16 @@ class Helper:
             logging.info(f"file updated: {filename}")
         return True
 
+    @staticmethod
+    async def check_and_notify_factory_mode() -> None:
+        try:
+            response = requests.get("http://localhost/version-chooser/v1.0/version/current", timeout=10)
+            if response.status_code == 200 and response.json()["tag"] == "factory":
+                mav_message = Helper.mavlink2rest.command_statustext_message("BlueOS is in factory mode")
+                await Helper.mavlink2rest.send_mavlink_message(mav_message)
+        except Exception as e:
+            logger.info(f"Could not check factory mode: {e}.")
+
 
 fast_api_app = FastAPI(
     title="Helper API",
@@ -671,6 +685,8 @@ async def periodic() -> None:
     while True:
         await asyncio.sleep(60)
         Helper.check_internet_access()
+
+        await Helper.check_and_notify_factory_mode()
 
         # Clear the known ports cache and re-scan it
         if Helper.PERIODICALLY_RESCAN_ALL_SERVICES:

--- a/core/services/helper/pyproject.toml
+++ b/core/services/helper/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "psutil==5.7.2",
     "pydantic==1.10.12",
     "speedtest-cli==2.1.3",
+    "requests==2.26.0",
     "uvicorn==0.18.0",
 ]
 

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -665,6 +665,7 @@ dependencies = [
     { name = "loguru" },
     { name = "psutil" },
     { name = "pydantic" },
+    { name = "requests" },
     { name = "speedtest-cli" },
     { name = "uvicorn" },
 ]
@@ -678,6 +679,7 @@ requires-dist = [
     { name = "loguru", specifier = "==0.5.3" },
     { name = "psutil", specifier = "==5.7.2" },
     { name = "pydantic", specifier = "==1.10.12" },
+    { name = "requests", specifier = "==2.26.0" },
     { name = "speedtest-cli", specifier = "==2.1.3" },
     { name = "uvicorn", specifier = "==0.18.0" },
 ]


### PR DESCRIPTION
fix #2236.

side note: the issue suggested to put this functionality in the Helper service and I can see why. But at the same time it seems like a good option to put it in the VersionChooser service.

image: nicoschmdt/blueos-core:notify-factory-mode

## Summary by Sourcery

Notify external systems via MAVLink when BlueOS boots in factory mode by querying the VersionChooser service and sending a STATUSTEXT message from the Helper service

New Features:
- Send a MAVLink STATUSTEXT message if BlueOS is in factory mode at startup

Enhancements:
- Add Helper.statustext_message to format MAVLink STATUSTEXT messages
- Implement check_and_notify_factory_mode with retry logic querying the VersionChooser service