### PR TITLE
core: start-blueos-core: Allow MAV_SYSTEM_ID configuration via env vars

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -10,7 +10,7 @@ SERVICES_PATH=$BLUEOS_PATH/services
 TOOLS_PATH=$BLUEOS_PATH/tools
 
 # MAVLink configuration
-MAV_SYSTEM_ID=1
+MAV_SYSTEM_ID=${MAV_SYSTEM_ID:-1}
 ## We use the last ID for the onboard computer component reserved address for our usage
 MAV_COMPONENT_ID_ONBOARD_COMPUTER4=194
 


### PR DESCRIPTION
This should allow us to set `MAV_SYSTEM_ID` via env var in `/root/.config/blueos/bootstrap/startup.json`.

Helps #3591

## How to test

To test it:
1. Change `SYSID_THISMAV` parameter to `2`
2. Add the following to your `/root/.config/blueos/bootstrap/startup.json`:

```json
"environment": [
  "MAV_SYSTEM_ID=2"
]
```

Then, open MAVLink-Server UI (http://blueos-avahi.local:8080) and check the SYS ID:

<img width="350" height="618" alt="image" src="https://github.com/user-attachments/assets/cbca8cc4-b794-4bab-ad47-dbf21e98bcfa" />

