### PR TITLE
frontend: version-chooser: update bootstrap button only appears if there are no updates for the current BlueOS image

### DIFF
--- a/core/frontend/src/components/version-chooser/VersionCard.vue
+++ b/core/frontend/src/components/version-chooser/VersionCard.vue
@@ -77,12 +77,12 @@
         </div>
       </v-btn>
       <v-dialog
+        v-if="showBootstrapUpdate"
         v-model="bootstrapDialog"
         width="500"
       >
         <template #activator="{ on, attrs }">
           <v-btn
-            v-if="showBootstrapUpdate"
             color="warning"
             class="mx-2 my-1"
             :disabled="working"
@@ -234,6 +234,10 @@ export default Vue.extend({
       type: Boolean,
       default: false,
     },
+    allImagesLoaded: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -253,7 +257,8 @@ export default Vue.extend({
         || helper.has_internet === InternetConnectionState.UNKNOWN) {
         return false
       }
-      return this.settings.is_pirate_mode && this.current && !this.updateAvailable && this.isFromBR
+      return this.settings.is_pirate_mode && this.current
+        && !this.updateAvailable && this.isFromBR && this.allImagesLoaded
         && this.bootstrapVersion !== `${this.image.repository.split('/')[0]}/blueos-bootstrap:${this.image.tag}`
     },
   },

--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -67,6 +67,7 @@
           :current="image.tag === current_version?.tag && image.repository === current_version?.repository"
           :bootstrap-version="bootstrap_version"
           :update-available="updateIsAvailable(image)"
+          :all-images-loaded="all_images_loaded"
           :deleting="isBeingDeleted(image)"
           :enable-delete="local_versions.result.local.length > 2"
           @delete="deleteVersion"
@@ -277,6 +278,7 @@ export default Vue.extend({
       deleting: '', // image currently being deleted, if any
       file_input_error: '',
       show_docker_login_dialog: false,
+      all_images_loaded: false,
     }
   },
   computed: {
@@ -434,6 +436,7 @@ export default Vue.extend({
       await VCU.loadAvailableVersions(this.selected_image)
         .then((versions_query) => {
           this.available_versions = versions_query
+          this.all_images_loaded = true
         })
         .finally(() => {
           this.loading_images = false
@@ -442,6 +445,7 @@ export default Vue.extend({
           this.latest_stable = VCU.getLatestStable(this.available_versions)?.tag
         })
         .catch((error) => {
+          this.all_images_loaded = false
           this.available_versions = {
             local: [],
             remote: [],


### PR DESCRIPTION
fix: #2199

test image: `nicoschmdt/blueos-core:fix-update-button`

Test steps:
- configure an old bootstrap version;
- run `BLUEOS_ADDRESS=<BLUEOS_IP> bun run dev` locally from the frontend folder;
- change BlueOS image to a local one which is not up to date;
- if it is not a blue robotics image comment the following part ` && this.isFromBR`  in the `VersionCard.vue` file;
- the bootstrap update button will not appear.

## Summary by Sourcery

Delay rendering of the bootstrap update button until all BlueOS images are loaded and no update is available for the current image.

Bug Fixes:
- Prevent the bootstrap update button from appearing prematurely when images are still loading

Enhancements:
- Add an all_images_loaded state in VersionChooser to track completion of image fetching
- Pass all_images_loaded to VersionCard and include it in showBootstrapUpdate condition
- Move the v-if check from the update button to the dialog element to avoid flashing the button