### PR TITLE
core: move internet speed test to pardal

### DIFF
--- a/core/frontend/src/components/speedtest/InternetSpeedTest.vue
+++ b/core/frontend/src/components/speedtest/InternetSpeedTest.vue
@@ -127,7 +127,9 @@
 import Vue from 'vue'
 
 import helper from '@/store/helper'
-import { InternetConnectionState, SpeedTestResult } from '@/types/helper'
+import pardal from '@/store/pardal'
+import { InternetConnectionState } from '@/types/helper'
+import { SpeedTestResult } from '@/types/pardal'
 
 export default Vue.extend({
   name: 'InternetSpeedTest',
@@ -175,7 +177,7 @@ export default Vue.extend({
     },
   },
   async mounted() {
-    this.result = await helper.checkPreviousInternetTestResult() ?? undefined
+    this.result = await pardal.checkPreviousInternetTestResult() ?? undefined
   },
   methods: {
     getRateIcon(index: number, rate: number): string {
@@ -193,11 +195,11 @@ export default Vue.extend({
       this.result = undefined
       this.started = true
       this.message = 'Starting.. Looking for best server..'
-      this.result = await helper.checkInternetBestServer() ?? this.result
+      this.result = await pardal.checkInternetBestServer() ?? this.result
       this.message = 'Checking download speed..'
-      this.result = await helper.checkInternetDownloadSpeed() ?? this.result
+      this.result = await pardal.checkInternetDownloadSpeed() ?? this.result
       this.message = 'Checking upload speed..'
-      this.result = await helper.checkInternetUploadSpeed() ?? this.result
+      this.result = await pardal.checkInternetUploadSpeed() ?? this.result
       this.message = 'Done!'
       this.started = false
     },

--- a/core/frontend/src/store/helper.ts
+++ b/core/frontend/src/store/helper.ts
@@ -7,7 +7,7 @@ import Notifier from '@/libs/notifier'
 import { OneMoreTime } from '@/one-more-time'
 import store from '@/store'
 import { helper_service } from '@/types/frontend_services'
-import { InternetConnectionState, Service, SpeedTestResult } from '@/types/helper'
+import { InternetConnectionState, Service } from '@/types/helper'
 import back_axios, { isBackendOffline } from '@/utils/api'
 
 const notifier = new Notifier(helper_service)
@@ -96,58 +96,6 @@ class PingStore extends VuexModule {
         this.setHasInternet(InternetConnectionState.UNKNOWN)
         this.setReachableHosts([])
         notifier.pushBackError('INTERNET_CHECK_FAIL', error)
-      })
-  }
-
-  @Action
-  async checkInternetBestServer(): Promise<SpeedTestResult | void> {
-    return back_axios({
-      method: 'get',
-      url: `${this.API_URL}/internet_best_server`,
-      timeout: 15000,
-    })
-      .then((response) => response.data as SpeedTestResult)
-      .catch((error) => {
-        notifier.pushBackError('INTERNET_BEST_SERVER_FAIL', error)
-      })
-  }
-
-  @Action
-  async checkInternetDownloadSpeed(): Promise<SpeedTestResult | void> {
-    return back_axios({
-      method: 'get',
-      url: `${this.API_URL}/internet_download_speed`,
-      timeout: 15000,
-    })
-      .then((response) => response.data as SpeedTestResult)
-      .catch((error) => {
-        notifier.pushBackError('INTERNET_DOWNLOAD_SPEED_FAIL', error)
-      })
-  }
-
-  @Action
-  async checkInternetUploadSpeed(): Promise<SpeedTestResult | void> {
-    return back_axios({
-      method: 'get',
-      url: `${this.API_URL}/internet_upload_speed`,
-      timeout: 15000,
-    })
-      .then((response) => response.data as SpeedTestResult)
-      .catch((error) => {
-        notifier.pushBackError('INTERNET_UPLOAD_SPEED_FAIL', error)
-      })
-  }
-
-  @Action
-  async checkPreviousInternetTestResult(): Promise<SpeedTestResult | void> {
-    return back_axios({
-      method: 'get',
-      url: `${this.API_URL}/internet_test_previous_result`,
-      timeout: 15000,
-    })
-      .then((response) => response.data as SpeedTestResult)
-      .catch((error) => {
-        notifier.pushBackError('INTERNET_RESULT_SPEED_FAIL', error)
       })
   }
 

--- a/core/frontend/src/store/pardal.ts
+++ b/core/frontend/src/store/pardal.ts
@@ -1,0 +1,82 @@
+import { 
+    Action,
+    getModule,
+    Module,
+    VuexModule,
+} from "vuex-module-decorators"
+
+import Notifier from "@/libs/notifier"
+import store from "@/store"
+import { pardal_service } from "@/types/frontend_services"
+import { SpeedTestResult } from "@/types/pardal"
+import back_axios from "@/utils/api"
+
+const notifier = new Notifier(pardal_service)
+
+@Module({
+    dynamic: true,
+    store,
+    name: 'pardal',
+  })
+
+class PardalStore extends VuexModule {
+  API_URL = '/network-test'
+
+  @Action
+  async checkInternetBestServer(): Promise<SpeedTestResult | void> {
+    return back_axios({
+      method: 'get',
+      url: `${this.API_URL}/internet_best_server`,
+      timeout: 15000,
+    })
+      .then((response) => response.data as SpeedTestResult)
+      .catch((error) => {
+        notifier.pushBackError('INTERNET_BEST_SERVER_FAIL', error)
+      })
+  }
+
+  @Action
+  async checkInternetDownloadSpeed(): Promise<SpeedTestResult | void> {
+    return back_axios({
+      method: 'get',
+      url: `${this.API_URL}/internet_download_speed`,
+      timeout: 15000,
+    })
+      .then((response) => response.data as SpeedTestResult)
+      .catch((error) => {
+        notifier.pushBackError('INTERNET_DOWNLOAD_SPEED_FAIL', error)
+      })
+  }
+
+  @Action
+  async checkInternetUploadSpeed(): Promise<SpeedTestResult | void> {
+    return back_axios({
+      method: 'get',
+      url: `${this.API_URL}/internet_upload_speed`,
+      timeout: 15000,
+    })
+      .then((response) => response.data as SpeedTestResult)
+      .catch((error) => {
+        notifier.pushBackError('INTERNET_UPLOAD_SPEED_FAIL', error)
+      })
+  }
+
+  @Action
+  async checkPreviousInternetTestResult(): Promise<SpeedTestResult | void> {
+    return back_axios({
+      method: 'get',
+      url: `${this.API_URL}/internet_test_previous_result`,
+      timeout: 15000,
+    })
+      .then((response) => response.data as SpeedTestResult)
+      .catch((error) => {
+        notifier.pushBackError('INTERNET_RESULT_SPEED_FAIL', error)
+      })
+  }
+}
+
+export { PardalStore }
+
+const pardal: PardalStore = getModule(PardalStore)
+
+export default pardal

--- a/core/frontend/src/types/frontend_services.ts
+++ b/core/frontend/src/types/frontend_services.ts
@@ -146,3 +146,10 @@ export const version_chooser_service: Service = {
   company: 'Blue Robotics',
   version: '0.1.0',
 }
+
+export const pardal_service: Service = {
+  name: 'Pardal service',
+  description: 'Service to manage Pardal',
+  company: 'Blue Robotics',
+  version: '0.1.0',
+}

--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -24,45 +24,6 @@ export interface Service {
     metadata?: ServiceMetadata
 }
 
-export interface SpeedtestServer {
-    url: string
-    lat: string
-    lon: string
-    name: string
-    country: string
-    cc: string
-    sponsor: string
-    id: string
-    host: string
-    d: number
-    latency: number
-}
-
-export interface SpeedtestClient {
-    ip: string
-    lat: string
-    lon: string
-    isp: string
-    isprating: string
-    rating: string
-    ispdlavg: string
-    ispulavg: string
-    loggedin: string
-    country: string
-}
-
-export interface SpeedTestResult {
-    download: number
-    upload: number
-    ping: number
-    server: SpeedtestServer
-    timestamp: Date
-    bytes_sent: number
-    bytes_received: number
-    share: string | null
-    client: SpeedtestClient
-}
-
 export enum InternetConnectionState {
   OFFLINE = 0,
   UNKNOWN = 1,

--- a/core/frontend/src/types/pardal.ts
+++ b/core/frontend/src/types/pardal.ts
@@ -1,0 +1,38 @@
+export interface SpeedTestServer {
+    url: string
+    lat: string
+    lon: string
+    name: string
+    country: string
+    cc: string
+    sponsor: string
+    id: string
+    host: string
+    d: number
+    latency: number
+}
+
+export interface SpeedTestClient {
+    ip: string
+    lat: string
+    lon: string
+    isp: string
+    isprating: string
+    rating: string
+    ispdlavg: string
+    ispulavg: string
+    loggedin: string
+    country: string
+}
+
+export interface SpeedTestResult {
+    download: number
+    upload: number
+    ping: number
+    server: SpeedTestServer
+    timestamp: Date
+    bytes_sent: number
+    bytes_received: number
+    share: string | null
+    client: SpeedTestClient
+}

--- a/core/services/pardal/main.py
+++ b/core/services/pardal/main.py
@@ -4,15 +4,17 @@ import asyncio
 import argparse
 import logging
 import os
-from typing import Generator
+from typing import Generator, Optional
 
 import aiohttp
 from aiohttp import web
 from commonwealth.utils.logs import InterceptHandler, init_logger
 from commonwealth.utils.sentry_config import init_sentry_async
 from loguru import logger
+from speedtest import Speedtest
 
 SERVICE_NAME = "pardal"
+SPEED_TEST: Optional[Speedtest] = None
 
 parser = argparse.ArgumentParser(description="Pardal, web service to help with speed and latency tests")
 parser.add_argument("-p", "--port", help="Port to run web server", action="store_true", default=9120)
@@ -23,6 +25,14 @@ logging.basicConfig(handlers=[InterceptHandler()], level=0)
 init_logger(SERVICE_NAME)
 
 logger.info("Starting Pardal")
+
+routes = web.RouteTableDef()
+
+try:
+    SPEED_TEST = Speedtest(secure=True)
+except Exception:
+    # When starting, the system may not be connected to the internet
+    pass
 
 
 def generate_random_data(size: int, chunk_size: int = 1024 * 1024) -> Generator[bytes, None, None]:
@@ -65,6 +75,57 @@ async def post_file(request: web.Request) -> web.Response:
     return web.Response(status=200)
 
 
+@routes.get("/internet_best_server")
+async def internet_best_server(request: web.Request) -> web.Response:
+    """
+    Check internet best server for test from BlueOS.
+    """
+    # Since we are finding a new server, clear previous results
+    # pylint: disable=global-statement
+
+    interface_addr = request.query.get("interface_addr") or None
+
+    global SPEED_TEST
+    SPEED_TEST = Speedtest(secure=True, source_address=interface_addr)
+    SPEED_TEST.get_best_server()
+    return web.json_response(SPEED_TEST.results.dict())
+
+
+# pylint: disable=unused-argument
+@routes.get("/internet_download_speed")
+async def internet_download_speed(request: web.Request) -> web.Response:
+    """
+    Check internet download speed test from BlueOS.
+    """
+    if not SPEED_TEST:
+        raise RuntimeError("SPEED_TEST not initialized, initialize server search.")
+    SPEED_TEST.download()
+    return web.json_response(SPEED_TEST.results.dict())
+
+
+# pylint: disable=unused-argument
+@routes.get("/internet_upload_speed")
+async def internet_upload_speed(request: web.Request) -> web.Response:
+    """
+    Check internet upload speed test from BlueOS.
+    """
+    if not SPEED_TEST:
+        raise RuntimeError("SPEED_TEST not initialized, initialize server search.")
+    SPEED_TEST.upload(pre_allocate=False)
+    return web.json_response(SPEED_TEST.results.dict())
+
+
+# pylint: disable=unused-argument
+@routes.get("/internet_test_previous_result")
+async def internet_test_previous_result(request: web.Request) -> web.Response:
+    """
+    Return previous result of internet speed test.
+    """
+    if not SPEED_TEST:
+        raise RuntimeError("SPEED_TEST not initialized, initialize server search.")
+    return web.json_response(SPEED_TEST.results.dict())
+
+
 # pylint: disable=unused-argument
 async def root(request: web.Request) -> web.Response:
     html_content = """
@@ -83,7 +144,7 @@ async def main() -> None:
     app = web.Application()
     app.client_max_size = 2 * (2**30)  # 2 GBs
 
-    app.add_routes([web.get("/ws", websocket_echo)])
+    app.add_routes([web.get("/ws", websocket_echo), *routes])
     app.router.add_get("/", root, name="root")
     app.router.add_get("/get_file", get_file, name="get_file")
     app.router.add_post("/post_file", post_file, name="post_file")


### PR DESCRIPTION
fix: #2146

## Summary by Sourcery

Extract the internet speed test functionality from the helper service into the pardal microservice and update frontend components and stores to point to the new pardal endpoints

New Features:
- Add speed test endpoints (best server, download, upload, previous result) to the pardal service

Enhancements:
- Remove speed test models and routes from the helper service
- Create a dedicated Vuex module for pardal and update InternetSpeedTest.vue to use pardal for speed tests
- Introduce new TypeScript types and service definition for pardal in the frontend