### PR TITLE
[backport] core: start-blueos-core: Allow MAV_SYSTEM_ID configuration via env vars

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -10,7 +10,7 @@ SERVICES_PATH=$BLUEOS_PATH/services
 TOOLS_PATH=$BLUEOS_PATH/tools
 
 # MAVLink configuration
-MAV_SYSTEM_ID=1
+MAV_SYSTEM_ID=${MAV_SYSTEM_ID:-1}
 ## We use the last ID for the onboard computer component reserved address for our usage
 MAV_COMPONENT_ID_ONBOARD_COMPUTER4=194
 


### PR DESCRIPTION
This is a backport of #3600 into 1.4

## Summary by Sourcery

Enhancements:
- Allow configuring MAV_SYSTEM_ID via the MAV_SYSTEM_ID environment variable in start-blueos-core