### PR TITLE
core: lib: commonwealth: general: Skip check for open log file if is already compressed

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/general.py
@@ -127,7 +127,7 @@ async def delete_everything_stream(path: Path) -> AsyncGenerator[dict[str, Any],
 
     for item in items:
         try:
-            if item.is_file() and not file_is_open(item):
+            if item.is_file() and (item.suffix == ".gz" or not file_is_open(item)):
                 size = item.stat().st_size
                 await asyncio.to_thread(item.unlink)
                 # fmt: off


### PR DESCRIPTION
This speed up the process
Helps #3588

## Summary by Sourcery

Improve deletion speed by skipping the file_is_open check for .gz files in the delete_everything_stream utility.

Bug Fixes:
- Fix performance issue #3588 by avoiding unnecessary file_is_open calls on compressed logs

Enhancements:
- Skip open-file check for already compressed (.gz) files in delete_everything_stream to speed up deletion