### PR TITLE
core: compose: Add SSH_USER and SSH_PASSWORD for example

### DIFF
--- a/core/compose/compose.yml
+++ b/core/compose/compose.yml
@@ -26,6 +26,8 @@ services:
       - BLUEOS_DISABLE_SERVICES=cable_guy,wifi,commander
       - BLUEOS_DISABLE_MEMORY_LIMIT=true
       - BLUEOS_DISABLE_STARTUP_UPDATE=true
+  #    - SSH_USER=pi
+  #    - SSH_PASSWORD=raspberry
   #   ports:
   #     - "80:80"
   #     - "81:81"       # Helper


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add commented-out SSH_USER and SSH_PASSWORD environment variables to the compose.yml example to illustrate SSH setup