### PR TITLE
[backport] frontend: extension editor UI improvement

### DIFF
--- a/core/frontend/src/components/common/JsonEditor.vue
+++ b/core/frontend/src/components/common/JsonEditor.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="d-flex flex-column">
+  <div
+    class="d-flex flex-column"
+    :style="{ height: height }"
+  >
     <div
       v-if="!is_read_only"
       class="editor d-flex"
@@ -51,6 +54,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    height: {
+      type: String,
+      default: '300px',
+    },
   },
   data() {
     return {
@@ -92,6 +99,9 @@ export default {
         this.edited_code = json
         this.editor.set(json)
       }
+    },
+    edited_code(json) {
+      this.$emit('input', json)
     },
     readOnly() {
       this.editor.setMode(this.read ? 'view' : this.editor_code_mode)

--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -96,9 +96,9 @@
 import Vue, { PropType } from 'vue'
 
 import JsonEditor from '@/components/common/JsonEditor.vue'
+import { copyToClipboard } from '@/cosmos'
 import { InstalledExtensionData } from '@/types/kraken'
 import { VForm } from '@/types/vuetify'
-import { copyToClipboard } from '@/utils/clipboard'
 
 export default Vue.extend({
   name: 'ExtensionCreationModal',

--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -1,4 +1,4 @@
-  <template>
+<template>
   <v-dialog
     v-if="extension"
     width="700"
@@ -8,11 +8,26 @@
     @click:outside="closeDialog"
   >
     <v-card>
-      <v-card-title>
-        {{ is_editing ? 'Edit' : 'Create' }} Extension
+      <v-card-title class="d-flex align-center justify-space-between">
+        <span>{{ is_editing ? 'Edit' : 'Create' }} Extension</span>
+        <v-btn
+          icon
+          x-small
+          class="ml-2"
+          :color="copySuccess ? 'success' : undefined"
+          title="Copy configuration"
+          @click="copyConfig"
+        >
+          <v-icon small>
+            {{ copySuccess ? 'mdi-check' : 'mdi-content-copy' }}
+          </v-icon>
+        </v-btn>
       </v-card-title>
 
-      <v-card-text class="d-flex flex-column">
+      <v-card-text
+        class="d-flex flex-column"
+        @paste="handlePaste"
+      >
         <v-form
           ref="form"
           lazy-validation
@@ -45,28 +60,28 @@
 
           <json-editor
             v-model="new_permissions"
-              style="width:100%; height:100%"
-              @save="onEditingPermissionsSave"
+            style="width:100%; min-height:400px"
+          >
+            <template
+              v-if="is_reset_editing_permissions_visible"
+              #controls
             >
-              <template
-                v-if="is_reset_editing_permissions_visible"
-                #controls
+              <v-btn
+                v-tooltip="'Reset to default permissions'"
+                class="editor-control"
+                icon
+                color="white"
+                @click="resetToDefaultPermissions"
               >
-                <v-btn
-                  v-tooltip="'Reset to default permissions'"
-                  class="editor-control"
-                  icon
-                  color="white"
-                  @click="resetToDefaultPermissions"
-                >
-                  <v-icon>mdi-restore</v-icon>
-                </v-btn>
-              </template>
-            </json-editor>
-
+                <v-icon>mdi-restore</v-icon>
+              </v-btn>
+            </template>
+          </json-editor>
+          <v-spacer />
           <v-btn
             color="primary"
             class="mr-4"
+            :disabled="!valid_permissions"
             @click="saveExtension"
           >
             {{ is_editing ? 'Save' : 'Create' }}
@@ -80,11 +95,16 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 
+import JsonEditor from '@/components/common/JsonEditor.vue'
 import { InstalledExtensionData } from '@/types/kraken'
 import { VForm } from '@/types/vuetify'
+import { copyToClipboard } from '@/utils/clipboard'
 
 export default Vue.extend({
   name: 'ExtensionCreationModal',
+  components: {
+    JsonEditor,
+  },
   model: {
     prop: 'extension',
     event: 'change',
@@ -98,55 +118,82 @@ export default Vue.extend({
 
   data() {
     return {
-      new_extension: this.extension,
-      new_permissions: this.extension?.permissions ?? '{}',
+      new_extension: this.extension ?? {
+        identifier: '',
+        name: '',
+        docker: '',
+        tag: '',
+        permissions: '{}',
+        editing: false,
+      } as InstalledExtensionData & { editing: boolean },
+      new_permissions: JSON.parse(this.extension?.permissions ?? '{}'),
+      copySuccess: false,
     }
   },
   computed: {
     form(): VForm {
       return this.$refs.form as VForm
     },
-    formatted_permissions() {
-      return JSON.stringify(JSON.parse(this.new_extension?.permissions ?? '{}'), null, 2)
-    },
     is_editing() {
       return this.extension?.editing ?? false
     },
     is_reset_editing_permissions_visible() {
       return this.new_permissions !== this.extension?.permissions
+    },
     valid_permissions() {
       return this.new_permissions
-    },
     },
   },
   watch: {
     new_extension() {
       this.$emit('input', this.new_extension)
     },
+    new_permissions(new_permissions: string) {
+      this.new_extension.user_permissions = JSON.stringify(new_permissions)
+    },
     extension() {
-      this.new_extension = this.extension
-      this.new_permissions = JSON.parse(this.extension?.permissions ?? '{}')
-    this.populatePermissions()
-        this.new_extension.user_permissions = this.new_extension.permissions
+      if (this.extension) {
+        this.new_extension = { ...this.extension }
+      } else {
+        this.new_extension = {
+          identifier: '',
+          name: '',
+          docker: '',
+          tag: '',
+          permissions: '{}',
+          editing: false,
+        } as InstalledExtensionData & { editing: boolean }
       }
+      this.populatePermissions()
     },
   },
   mounted() {
-    this.new_permissions = JSON.parse(this.extension?.permissions ?? '{}')
+    this.populatePermissions()
   },
   methods: {
-    onEditingPermissionsSave(permissions: string) {
-      if (this.new_extension) {
-        this.new_extension.permissions = permissions
+    populatePermissions() {
+      const user_permissions = JSON.parse(this.extension?.user_permissions ?? '{}')
+      const original_permissions = JSON.parse(this.extension?.permissions ?? '{}')
+      if (user_permissions) {
+        this.new_permissions = user_permissions
+      } else {
+        this.new_permissions = original_permissions
       }
     },
     closeDialog() {
-      this.new_extension = null
+      this.new_extension = {
+        identifier: '',
+        name: '',
+        docker: '',
+        tag: '',
+        permissions: '{}',
+        editing: false,
+      } as InstalledExtensionData & { editing: boolean }
       this.$emit('closed')
     },
     resetToDefaultPermissions() {
       if (this.new_extension) {
-        this.new_extension.permissions = this.extension?.permissions ?? '{}'
+        this.new_permissions = JSON.parse(this.extension?.permissions ?? '{}')
       }
     },
     validate_identifier(input: string): (true | string) {
@@ -192,26 +239,6 @@ export default Vue.extend({
       }
       return true
     },
-    validate_permissions(input: string): (true | string) {
-      try {
-        JSON.parse(input)
-        return true
-      } catch {
-        return 'This entry must be in valid JSON format.'
-      }
-    },
-    validate_user_permissions(input: string): (true | string) {
-      if (input === '') {
-        return true
-      }
-
-      try {
-        JSON.parse(input)
-        return true
-      } catch {
-        return 'This entry must be in valid JSON format.'
-      }
-    },
     validate_tag(input: string) {
       if (input.includes(' ')) {
         return 'Tag name must not include spaces.'
@@ -229,6 +256,9 @@ export default Vue.extend({
       return true
     },
     async saveExtension(): Promise<void> {
+      if (this.new_permissions) {
+        this.new_extension.user_permissions = JSON.stringify(this.new_permissions)
+      }
       if (this.form.validate() === true) {
         this.$emit('extensionChange', this.new_extension)
       }
@@ -236,6 +266,66 @@ export default Vue.extend({
     showDialog(state: boolean) {
       if (this.form.validate() === true) {
         this.$emit('change', state)
+      }
+    },
+    async copyConfig() {
+      if (!this.new_extension) {
+        return
+      }
+
+      const config = {
+        identifier: this.new_extension.identifier,
+        name: this.new_extension.name,
+        docker: this.new_extension.docker,
+        tag: this.new_extension.tag,
+        permissions: this.new_extension.permissions,
+      }
+
+      const jsonString = JSON.stringify(config, null, 2)
+      const success = await copyToClipboard(jsonString)
+
+      if (success) {
+        this.copySuccess = true
+        setTimeout(() => {
+          this.copySuccess = false
+        }, 2000) // Reset after 2 seconds
+      }
+    },
+    handlePaste(event: ClipboardEvent) {
+      try {
+        // Get the pasted text
+        const pastedText = event.clipboardData?.getData('text')
+        if (!pastedText) return
+
+        // Try to parse it as JSON
+        const config = JSON.parse(pastedText)
+
+        // Validate that it has the expected structure
+        if (config.identifier && config.name && config.docker && config.tag) {
+          // Prevent the default paste
+          event.preventDefault()
+
+          // Update the form data
+          if (!this.new_extension) {
+            this.new_extension = {} as InstalledExtensionData & { editing: boolean }
+          }
+
+          this.new_extension.identifier = config.identifier
+          this.new_extension.name = config.name
+          this.new_extension.docker = config.docker
+          this.new_extension.tag = config.tag
+
+          // Handle permissions if present
+          if (config.permissions) {
+            this.new_extension.permissions = typeof config.permissions === 'string'
+              ? config.permissions
+              : JSON.stringify(config.permissions)
+            this.new_permissions = JSON.parse(this.new_extension.permissions)
+          }
+        }
+      } catch (error) {
+        // Not valid JSON or doesn't match our format - ignore
+        console.debug('Pasted content was not valid extension configuration')
       }
     },
   },

--- a/core/frontend/src/components/video-manager/VideoStream.vue
+++ b/core/frontend/src/components/video-manager/VideoStream.vue
@@ -177,6 +177,7 @@
 import { saveAs } from 'file-saver'
 import Vue, { PropType } from 'vue'
 
+import { copyToClipboard } from '@/cosmos'
 import video from '@/store/video'
 import {
   CreatedStream, Device, StreamPrototype, StreamStatus,
@@ -312,60 +313,10 @@ export default Vue.extend({
         })
     },
     async copySDPFileURL(): Promise<void> {
-      return this.copyToClipboard(this.sDPFileURL)
-    },
-    async copyToClipboard(content: string): Promise<void> {
-      // eslint-disable-next-line func-style
-      const try_fallback_clipboard_copy_method = (): void => {
-        // If we don't have the permission, fallback to the old hacky way of creating an input,
-        // copying the text from it, and destroy it even before it renders.
-        const temporaryInputElement = document.createElement('input')
-        temporaryInputElement.value = content
-        document.body.appendChild(temporaryInputElement)
-
-        try {
-          temporaryInputElement.select()
-          document.execCommand('copy')
-        } catch (error) {
-          console.error(`Failed to copy URL to clipboard. Reason: ${error}`)
-        } finally {
-          document.body.removeChild(temporaryInputElement)
-        }
-      }
-
-      // eslint-disable-next-line func-style
-      const clipboard_copy_api = (): void => {
-        navigator.clipboard.writeText(content).catch((error) => {
-          console.error(`Failed to copy URL to clipboard using Clipboard API. Reason: ${error}`)
-          try_fallback_clipboard_copy_method()
-        })
-      }
-
-      navigator.permissions
-        .query({ name: 'clipboard-write' as PermissionName })
-        .then((permissionStatus) => {
-          if (permissionStatus.state === 'granted') {
-            clipboard_copy_api()
-          } else if (permissionStatus.state === 'prompt') {
-            // The user will be prompted to grant the permission.
-            permissionStatus.onchange = () => {
-              if (permissionStatus.state === 'granted') {
-                clipboard_copy_api()
-              } else {
-                try_fallback_clipboard_copy_method()
-              }
-            }
-          } else {
-            try_fallback_clipboard_copy_method()
-          }
-        })
-        .catch((error) => {
-          console.error('Error while requesting clipboard-write permission:', error)
-          try_fallback_clipboard_copy_method()
-        })
+      await copyToClipboard(this.sDPFileURL)
     },
     async copyVideoStreamToClipboard(): Promise<void> {
-      return this.copyToClipboard(JSON.stringify(this.$props, null, 2))
+      await copyToClipboard(JSON.stringify(this.$props, null, 2))
     },
     toggleExpandStreamError() {
       this.isExpanded = !this.isExpanded

--- a/core/frontend/src/cosmos.ts
+++ b/core/frontend/src/cosmos.ts
@@ -55,3 +55,81 @@ String.prototype.toTitle = function (this: string): string {
   }
   return this[0].toUpperCase() + this.substring(1)
 }
+
+
+/**
+ * Utility functions for clipboard operations
+ */
+
+/**
+ * Fallback method to copy text to clipboard using a temporary input element
+ * @param text - The text to copy to clipboard
+ * @returns boolean indicating if the copy operation succeeded
+ */
+const copyWithFallbackMethod = (text: string): boolean => {
+  const temporaryInputElement = document.createElement('input')
+  temporaryInputElement.value = text
+  document.body.appendChild(temporaryInputElement)
+
+  try {
+      temporaryInputElement.select()
+      document.execCommand('copy')
+      return true
+  } catch (error) {
+      console.error(`Failed to copy text to clipboard. Reason: ${error}`)
+      return false
+  } finally {
+      document.body.removeChild(temporaryInputElement)
+  }
+}
+
+/**
+* Copy text using the Clipboard API
+* @param text - The text to copy to clipboard
+* @param fallback - Optional callback to handle fallback behavior
+* @returns Promise<boolean> indicating if the copy operation succeeded
+*/
+const copyWithClipboardAPI = async (text: string, fallback?: () => boolean): Promise<boolean> => {
+  try {
+      await navigator.clipboard.writeText(text)
+      return true
+  } catch (error) {
+      console.error(`Failed to copy text to clipboard using Clipboard API. Reason: ${error}`)
+      if (fallback) {
+          return fallback()
+      }
+      return copyWithFallbackMethod(text)
+  }
+}
+
+/**
+* Main function to copy text to clipboard with permission handling
+* @param text - The text to copy to clipboard
+* @returns Promise<boolean> indicating if the copy operation succeeded
+*/
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  try {
+      const permissionStatus = await navigator.permissions.query({ name: 'clipboard-write' as PermissionName })
+
+      if (permissionStatus.state === 'granted') {
+          return await copyWithClipboardAPI(text)
+      } else if (permissionStatus.state === 'prompt') {
+          // The user will be prompted to grant the permission
+          return new Promise((resolve) => {
+              permissionStatus.onchange = async () => {
+                  if (permissionStatus.state === 'granted') {
+                      resolve(await copyWithClipboardAPI(text))
+                  } else {
+                      resolve(copyWithFallbackMethod(text))
+                  }
+              }
+          })
+      } else {
+          return copyWithFallbackMethod(text)
+      }
+  } catch (error) {
+      console.error('Error while requesting clipboard-write permission:', error)
+      return copyWithFallbackMethod(text)
+  }
+}
+

--- a/core/frontend/src/cosmos.ts
+++ b/core/frontend/src/cosmos.ts
@@ -68,6 +68,7 @@ String.prototype.toTitle = function (this: string): string {
  */
 const copyWithFallbackMethod = (text: string): boolean => {
   const temporaryInputElement = document.createElement('input')
+  temporaryInputElement.addEventListener('focusin', e => e.stopPropagation())
   temporaryInputElement.value = text
   document.body.appendChild(temporaryInputElement)
 


### PR DESCRIPTION
backport of PR #3150

## Summary by Sourcery

Improve the extension editor UI by introducing a richer JSON editing experience, adding copy/paste configuration capabilities, consolidating clipboard logic into a shared utility, and making minor layout and validation enhancements.

New Features:
- Add a configuration copy button in ExtensionCreationModal to copy extension settings to clipboard
- Support pasting JSON extension configuration into ExtensionCreationModal to auto-populate form fields

Enhancements:
- Replace permission textareas in ExtensionCreationModal with a JsonEditor component featuring reset-to-default controls
- Increase ExtensionCreationModal width and disable the save button until permissions JSON is valid
- Extract clipboard copy logic into a reusable copyToClipboard utility in cosmos.ts with Clipboard API and fallback support
- Refactor VideoStream component to use the shared copyToClipboard utility instead of a custom implementation
- Enhance JsonEditor to accept a height prop and emit input events on code edits