### PR TITLE
cable_guy: blacklist zerotier interfaces

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -180,7 +180,7 @@ class EthernetManager:
         Returns:
             bool: True if valid, False if not
         """
-        blacklist = ["lo", "ham.*", "docker.*", "veth.*"]
+        blacklist = ["lo", "ham.*", "docker.*", "veth.*", "zt.*"]
         if filter_wifi:
             wifi_interfaces = self._get_wifi_interfaces()
             blacklist += wifi_interfaces


### PR DESCRIPTION
(shitty) fix for #3611

## Summary by Sourcery

Blacklist ZeroTier interfaces from network configuration and ensure interface cleanup is only performed for valid non-watchdog calls

Bug Fixes:
- Defer cleanup of interface connections until after interface name validation for non-watchdog calls

Enhancements:
- Add "zt.*" pattern to the default interface blacklist