### PR TITLE
[1.4] cable_guy: check if interface is valid BEFORE changing it

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -105,13 +105,12 @@ class EthernetManager:
             watchdog_call: Whether this is a watchdog call
         """
         async with self.config_mutex:
-            if not watchdog_call:
-                await self.network_handler.cleanup_interface_connections(interface.name)
             interfaces = self.get_interfaces()
             valid_names = [interface.name for interface in interfaces]
             if interface.name not in valid_names:
                 raise ValueError(f"Invalid interface name ('{interface.name}'). Valid names are: {valid_names}")
-
+            if not watchdog_call:
+                await self.network_handler.cleanup_interface_connections(interface.name)
             logger.info(f"Setting configuration for interface '{interface.name}'.")
             if interface.addresses:
                 # bring interface up

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -180,7 +180,7 @@ class EthernetManager:
         Returns:
             bool: True if valid, False if not
         """
-        blacklist = ["lo", "ham.*", "docker.*", "veth.*"]
+        blacklist = ["lo", "ham.*", "docker.*", "veth.*", "zt.*"]
         if filter_wifi:
             wifi_interfaces = self._get_wifi_interfaces()
             blacklist += wifi_interfaces


### PR DESCRIPTION
Cherry-pick from #3612

## Summary by Sourcery

Validate interface names before cleanup in set_configuration and extend the interface blacklist to include 'zt.*'.

Bug Fixes:
- Reorder non-watchdog cleanup to occur after interface name validation in set_configuration
- Add 'zt.*' pattern to the blacklist in is_valid_interface_name