### PR TITLE
[1.4] core: lib: commonwealth: general: Skip check for open log file if is already compressed

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -54,7 +54,7 @@ def get_host_os() -> HostOs:
 
 
 def delete_everything(path: Path) -> None:
-    if path.is_file() and not file_is_open(path):
+    if path.is_file() and (path.suffix == ".gz" or not file_is_open(path)):
         path.unlink()
         return
 


### PR DESCRIPTION
From #3607

## Summary by Sourcery

Enhancements:
- Skip the open-file check for files with a .gz suffix when deleting items