### PR TITLE
core:frontend:views:MainView: Fix check internet instead of WiFi network

### DIFF
--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -6,7 +6,7 @@
       no-gutters
     >
       <v-alert
-        v-if="!current_network"
+        v-if="!has_internet"
         border="top"
         colored-border
         type="info"
@@ -92,9 +92,9 @@ import Vue from 'vue'
 
 import SelfHealthTest from '@/components/health/SelfHealthTest.vue'
 import GenericViewer from '@/components/vehiclesetup/viewers/GenericViewer.vue'
+import helper from '@/store/helper'
 import mavlink from '@/store/mavlink'
-import wifi from '@/store/wifi'
-import { Network } from '@/types/wifi'
+import { InternetConnectionState } from '@/types/helper'
 import mavlink_store_get from '@/utils/mavlink'
 import CPUUsage from '@/widgets/CpuPie.vue'
 import Networking from '@/widgets/Networking.vue'
@@ -183,8 +183,8 @@ export default Vue.extend({
         },
       ]
     },
-    current_network(): Network | null {
-      return wifi.current_network
+    has_internet(): boolean {
+      return helper.has_internet !== InternetConnectionState.OFFLINE
     },
     orientation(): string {
       const msg = mavlink_store_get(mavlink, 'ATTITUDE.messageData.message') as


### PR DESCRIPTION
Closes #1705

* Make sure the connect to internet banner only appears when no internet connection is available instead of WiFi network

## Summary by Sourcery

Use the app’s internet connectivity status instead of WiFi network presence to control the “connect to internet” alert in MainView.vue.

Bug Fixes:
- Show the connection banner only when there is no internet connection rather than when not connected to a WiFi network.

Enhancements:
- Replace the current_network computed property with has_internet using helper.has_internet and InternetConnectionState.
- Update imports to remove WiFi store and include helper module and its types.