### PR TITLE
frontend: move cable-guy API calls to ethernet store

### DIFF
--- a/core/frontend/src/components/ethernet/AddressCreationDialog.vue
+++ b/core/frontend/src/components/ethernet/AddressCreationDialog.vue
@@ -35,15 +35,9 @@
 <script lang="ts">
 import Vue from 'vue'
 
-import Notifier from '@/libs/notifier'
 import ethernet from '@/store/ethernet'
-import { AddressMode } from '@/types/ethernet'
-import { ethernet_service } from '@/types/frontend_services'
 import { VForm } from '@/types/vuetify'
-import back_axios from '@/utils/api'
 import { isIpAddress } from '@/utils/pattern_validators'
-
-const notifier = new Notifier(ethernet_service)
 
 export default Vue.extend({
   name: 'AddressCreationDialog',
@@ -88,24 +82,11 @@ export default Vue.extend({
       if (!this.form.validate()) {
         return false
       }
-      ethernet.setUpdatingInterfaces(true)
       this.showDialog(false)
 
-      await back_axios({
-        method: 'post',
-        url: `${ethernet.API_URL}/address`,
-        timeout: 10000,
-        params: {
-          interface_name: this.interfaceName,
-          mode: AddressMode.unmanaged,
-          ip_address: this.ip_address,
-        },
-      })
+      await ethernet.addAddress({ interface_name: this.interfaceName, ip_address: this.ip_address })
         .then(() => {
           this.form.reset()
-        })
-        .catch((error) => {
-          notifier.pushBackError('ETHERNET_ADDRESS_CREATION_FAIL', error)
         })
       return true
     },

--- a/core/frontend/src/components/ethernet/EthernetUpdater.vue
+++ b/core/frontend/src/components/ethernet/EthernetUpdater.vue
@@ -5,13 +5,8 @@
 <script lang="ts">
 import Vue from 'vue'
 
-import Notifier from '@/libs/notifier'
 import { OneMoreTime } from '@/one-more-time'
 import ethernet from '@/store/ethernet'
-import { ethernet_service } from '@/types/frontend_services'
-import back_axios from '@/utils/api'
-
-const notifier = new Notifier(ethernet_service)
 
 export default Vue.extend({
   name: 'EthernetUpdater',
@@ -25,18 +20,9 @@ export default Vue.extend({
   },
   methods: {
     async fetchAvailableInterfaces(): Promise<void> {
-      await back_axios({
-        method: 'get',
-        url: `${ethernet.API_URL}/ethernet`,
-        // Necessary since the system can hang with dhclient timeouts
-        timeout: 10000,
-      })
+      await ethernet.getAvailableInterfaces()
         .then((response) => {
           ethernet.setInterfaces(response.data)
-        })
-        .catch((error) => {
-          ethernet.setInterfaces([])
-          notifier.pushBackError('ETHERNET_AVAILABLE_FETCH_FAIL', error)
         })
     },
   },

--- a/core/frontend/src/store/ethernet.ts
+++ b/core/frontend/src/store/ethernet.ts
@@ -1,9 +1,15 @@
 import {
+  Action,
   getModule, Module, Mutation, VuexModule,
 } from 'vuex-module-decorators'
 
 import store from '@/store'
-import { EthernetInterface } from '@/types/ethernet'
+import { DHCPServerDetails, EthernetInterface } from '@/types/ethernet'
+import { ethernet_service } from '@/types/frontend_services'
+import back_axios from '@/utils/api'
+import Notifier from '@/libs/notifier'
+
+const notifier = new Notifier(ethernet_service)
 
 @Module({
   dynamic: true,
@@ -27,6 +33,183 @@ class EthernetStore extends VuexModule {
   setInterfaces(ethernet_interfaces: EthernetInterface[]): void {
     this.available_interfaces = ethernet_interfaces
     this.updating_interfaces = false
+  }
+
+  @Action
+  async addAddress(payload: { interface_name: string, ip_address: string }): Promise<void> {
+    this.context.commit('setUpdatingInterfaces', true)
+
+    await back_axios({
+      method: 'post',
+      url: `${this.API_URL}/address`,
+      timeout: 10000,
+      params: {
+        interface_name: payload.interface_name,
+        ip_address: payload.ip_address,
+      },
+    })
+      .catch((error) => {
+        notifier.pushBackError('ETHERNET_ADDRESS_CREATION_FAIL', error)
+        throw error
+      })
+  }
+
+  @Action
+  async deleteAddress(payload: { interface_name: string, ip_address: string }): Promise<void> {
+    this.context.commit('setUpdatingInterfaces', true)
+
+    await back_axios({
+      method: 'delete',
+      url: `${this.API_URL}/address`,
+      timeout: 10000,
+      params: {
+        interface_name: payload.interface_name,
+        ip_address: payload.ip_address,
+      },
+    })
+      .catch((error) => {
+        notifier.pushError('ETHERNET_ADDRESS_DELETE_FAIL', error)
+        throw error
+      })
+  }
+
+  @Action
+  async addDHCPServer(payload: { interface_name: string, ipv4_gateway: string, is_backup_server: boolean }): Promise<void> {
+    this.context.commit('setUpdatingInterfaces', true)
+
+    await back_axios({
+      method: 'post',
+      url: `${this.API_URL}/dhcp`,
+      timeout: 10000,
+      params: {
+        interface_name: payload.interface_name,
+        ipv4_gateway: payload.ipv4_gateway,
+        is_backup_server: payload.is_backup_server,
+      },
+    })
+      .catch((error) => {
+        notifier.pushBackError('DHCP_SERVER_ADD_FAIL', error)
+        throw error
+      })
+      .finally(() => {
+        this.context.commit('setUpdatingInterfaces', false)
+      })
+  }
+
+  @Action
+  async RemoveDHCPServer(interface_name: string): Promise<void> {
+    await back_axios({
+      method: 'delete',
+      url: `${this.API_URL}/dhcp`,
+      timeout: 10000,
+      params: {
+        interface_name: interface_name,
+      },
+    })
+      .catch((error) => {
+        const message = `Could not remove DHCP server from interface '${interface_name}': ${error.message}.`
+        notifier.pushError('DHCP_SERVER_REMOVE_FAIL', message)
+      })
+  }
+
+  @Action
+  async getDHCPServerDetails(interface_name: string): Promise<DHCPServerDetails> {
+    return await back_axios({
+      method: 'get',
+      url: `${this.API_URL}/dhcp/details/${interface_name}`,
+      timeout: 15000,
+    })
+  }
+
+  @Action
+  async getHostDNS() {
+    return await back_axios({
+      method: 'get',
+      url: `${this.API_URL}/host_dns`,
+      timeout: 10000,
+    })
+      .catch((error) => {
+        this.context.commit('setInterfaces', [])
+        notifier.pushBackError('HOST_DNS_FETCH_FAIL', error)
+        throw error
+      })
+  }
+
+  @Action
+  async updateHostDNS(payload: { host_nameservers: string[], is_locked: boolean }): Promise<void> {
+    await back_axios({
+      method: 'post',
+      url: `${this.API_URL}/host_dns`,
+      timeout: 15000,
+      data: {
+        nameservers: payload.host_nameservers,
+        lock: payload.is_locked,
+      },
+    })
+      .then(() => {
+        notifier.pushSuccess(
+          'APPLY_HOST_DNS_SUCCESS',
+          'Host DNS nameservers updated successfully!',
+          true,
+        )
+      })
+      .catch((error) => {
+        notifier.pushError('APPLY_HOST_DNS_FAIL', error)
+        throw error
+      })
+  }
+
+  @Action
+  async getAvailableInterfaces() {
+    return await back_axios({
+      method: 'get',
+      url: `${this.API_URL}/interfaces`,
+      // Necessary since the system can hang with dhclient timeouts
+      timeout: 10000,
+    })
+      .catch((error) => {
+        this.context.commit('setInterfaces', [])
+        notifier.pushBackError('ETHERNET_AVAILABLE_INTERFACES_FETCH_FAIL', error)
+        throw error
+      })
+  }
+
+  @Action
+  async setInterfacesPriority(interfaces: { name: string, priority: number }[]): Promise<void> {
+    await back_axios({
+      method: 'post',
+      url: `${this.API_URL}/set_interfaces_priority`,
+      timeout: 10000,
+      data: interfaces,
+    })
+      .catch((error) => {
+        const message = `Could not set network interface priorities: ${interfaces}, error: ${error}`
+        notifier.pushError('INCREASE_NETWORK_INTERFACE_METRIC_FAIL', message)
+        throw error
+      })
+      .then(() => {
+        notifier.pushSuccess(
+          'INCREASE_NETWORK_INTERFACE_METRIC_SUCCESS',
+          'Network interface priorities successfully updated!',
+          true,
+        )
+      })
+  }
+
+  @Action
+  async triggerDynamicIP(interface_name: string): Promise<void> {
+    await back_axios({
+      method: 'post',
+      url: `${this.API_URL}/dynamic_ip`,
+      timeout: 10000,
+      params: {
+        interface_name: interface_name,
+      },
+    })
+      .catch((error) => {
+        const message = `Could not trigger for dynamic IP address on '${interface_name}': ${error.message}.`
+        notifier.pushError('DYNAMIC_IP_TRIGGER_FAIL', message)
+      })
   }
 }
 


### PR DESCRIPTION
fix: #1841 

tested all endpoints affected

## Summary by Sourcery

Centralize Ethernet-related API calls into the Vuex ethernet store and remove direct axios usage from components

Enhancements:
- Migrate all cable-guy axios requests (address, DHCP, DNS, interfaces, priorities, dynamic IP) into Vuex actions
- Eliminate redundant Notifier and back_axios imports in components and replace with store action calls