### PR TITLE
core: start-blueos-core: Add mkdir for /var/logs/blueos

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -93,6 +93,7 @@ else
 fi
 
 # Fix permissions for logging folders to allow other users to alter it
+mkdir -p /var/logs/blueos
 find /var/logs/blueos -type d -exec chmod a+rw {} \;
 mkdir -p /usr/blueos/userdata/settings
 find /usr/blueos/userdata -type d -exec chmod a+rw {} \;


### PR DESCRIPTION
If the folder does not exist or not create during the bind process BlueOS just fail

## Summary by Sourcery

Bug Fixes:
- Add mkdir command in start-blueos-core to create /var/logs/blueos before binding