### PR TITLE
core:services:cable-guy: Fix static IP not recovering after lost

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -894,8 +894,8 @@ class EthernetManager:
                     if not any(addr.mode == AddressMode.Client for addr in current_interface.addresses):
                         logger.info(f"Mismatch detected for {current_interface.name}: missing dhcp client address")
                         mismatches.add(saved_interface)
-                # Handle Server and Unmanaged modes
-                elif saved_address.mode in [AddressMode.Server, AddressMode.Unmanaged]:
+                # Handle Server/BackupServer and Unmanaged modes
+                elif saved_address.mode in [AddressMode.Server, AddressMode.BackupServer, AddressMode.Unmanaged]:
                     if saved_address not in current_interface.addresses:
                         logger.info(
                             f"Mismatch detected for {current_interface.name}: "


### PR DESCRIPTION
Fix edge case where user does NOT have a dynamic IP requisition and loses the backup-server static IP due to external factors, resulting in watchdog not recovering it.

## Summary by Sourcery

Bug Fixes:
- Treat BackupServer mode like Server and Unmanaged modes when detecting address mismatches to avoid dropping static IPs

## Summary by Sourcery

Bug Fixes:
- Include BackupServer mode in the static IP mismatch check to ensure watchdog recovers lost addresses