### PR TITLE
core: frontend: zenoh-inspector: Add check for TEXT_PLAIN

### DIFF
--- a/core/frontend/src/components/zenoh-inspector/ZenohInspector.vue
+++ b/core/frontend/src/components/zenoh-inspector/ZenohInspector.vue
@@ -212,7 +212,9 @@ export default Vue.extend({
         payload: message.payload.toString(),
       }
 
-      if (message.encoding === Encoding.APPLICATION_JSON.toString()) {
+      if (message.encoding === Encoding.TEXT_PLAIN.toString()) {
+        formattedMessage.payload = message.payload.to_string()
+      } else if (message.encoding === Encoding.APPLICATION_JSON.toString()) {
         formattedMessage.payload = JSON.parse(message.payload.to_string())
       } else if (message.encoding === Encoding.ZENOH_BYTES.toString()) {
         try {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce a check for Encoding.TEXT_PLAIN in message formatting and use payload.to_string() for plain text messages