### PR TITLE
frontend: version-chooser: update bootstrap when changing BlueOS to a stable

### DIFF
--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -611,7 +611,7 @@ export default Vue.extend({
         })
       this.updating_bootstrap = false
     },
-    async setBootstrapVersion(version: string) {
+    async setBootstrapVersion(version: string, reload = true) {
       await back_axios({
         method: 'post',
         url: '/version-chooser/v1.0/bootstrap/current',
@@ -633,12 +633,19 @@ export default Vue.extend({
           `Successfully updated bootstrap version to ${version}`,
           true,
         )
-        window.location.reload()
+        if (reload) {
+          window.location.reload()
+        }
       })
     },
     async setVersion(args: string | string[]) {
       const fullname: string = Array.isArray(args) ? args[0] : args
       const [repository, tag] = fullname.split(':')
+
+      if (this.isStable(tag)) {
+        await this.setBootstrapVersion(tag, false)
+      }
+
       await back_axios({
         method: 'post',
         url: '/version-chooser/v1.0/version/current',
@@ -707,6 +714,9 @@ export default Vue.extend({
     },
     isBeingDeleted(image: Version) {
       return this.deleting === `${image.repository}:${image.tag}`
+    },
+    isStable(tag: string) {
+      return VCU.isSemVer(tag) && !tag.includes('beta')
     },
   },
 })


### PR DESCRIPTION
fix: #2896

## Summary by Sourcery

Automatically update the bootstrap version to match semver-stable BlueOS tags without forcing a page reload and make bootstrap reload behavior configurable.

Bug Fixes:
- Ensure the bootstrap version is updated when switching to a stable BlueOS tag
- Prevent unconditional page reload after setting the bootstrap version

Enhancements:
- Add an optional reload parameter to setBootstrapVersion to control window reload
- Introduce isStable helper to detect semver-compliant stable tags