### PR TITLE
frontend: vehiclesetup: fix dashboard vehicle viewer clipping

### DIFF
--- a/core/frontend/src/components/vehiclesetup/viewers/GenericViewer.vue
+++ b/core/frontend/src/components/vehiclesetup/viewers/GenericViewer.vue
@@ -11,6 +11,7 @@
       shadow-intensity="0.3"
       interaction-prompt="none"
       :camera-orbit="cameraOrbit"
+      camera-target="auto 0m auto"
     >
       <button
         v-for="annotation in filtered_annotations"


### PR DESCRIPTION
fix: #3372

The submarine viewer was not being clipped since around `1.5.0-beta.12`. To avoid the clipping in the BB the Y position of the model was set to 0.

<img width="442" height="350" alt="image" src="https://github.com/user-attachments/assets/5c5219bd-8618-4485-8153-3b0b6464b505" />
<img width="434" height="342" alt="image" src="https://github.com/user-attachments/assets/0f0de1f4-fa62-4f5c-8231-3829d6387180" />
<img width="436" height="342" alt="image" src="https://github.com/user-attachments/assets/48231089-7841-4cd0-ab19-dfd295e5cf8a" />

## Summary by Sourcery

Bug Fixes:
- Restore proper clipping for the submarine and other vehicle viewers by setting the camera-target Y position to zero