### PR TITLE
frontend: fix and update tour

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -376,7 +376,7 @@
     <ethernet-updater />
     <mavlink-updater />
     <new-version-notificator />
-    <Wizard />
+    <Wizard @start-tour="setStartTour" />
     <alerter />
     <VTour
       name="welcomeTour"
@@ -475,6 +475,7 @@ export default Vue.extend({
     selected_widgets: settings.user_top_widgets,
     bootstrap_version: undefined as string|undefined,
     build_clicks: 0,
+    start_tour: false,
   }),
   computed: {
     widgets(): TopBarWidget[] {
@@ -778,6 +779,9 @@ export default Vue.extend({
     settings_selected_widgets() {
       this.selected_widgets = this.settings_selected_widgets
     },
+    start_tour() {
+      this.checkTour()
+    },
   },
 
   async mounted() {
@@ -849,9 +853,13 @@ export default Vue.extend({
     },
     checkTour(): void {
       // Check the current page and tour version to be sure that we are in the correct place before starting
-      if (this.$route.name === this.$router.options.routes!.first()!.name) {
+      if (this.$route.name === this.$router.options.routes!.first()!.name
+        && this.start_tour) {
         settings.run_tour_version(2)
-          .then(() => this.$tours.welcomeTour.start())
+          .then(() => {
+            this.start_tour = false
+            this.$tours.welcomeTour.start()
+          })
           .catch((message) => console.log(message))
       }
     },
@@ -878,6 +886,9 @@ export default Vue.extend({
     bluePillClick(): void {
       this.build_clicks = 0
       settings.is_dev_mode = false
+    },
+    setStartTour(value: boolean): void {
+      this.start_tour = value
     },
   },
 })

--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -416,6 +416,8 @@ export default Vue.extend({
 
     if (wizard?.version !== WIZARD_VERSION) {
       this.should_open = true
+    } else {
+      this.$emit('start-tour', true)
     }
   },
   methods: {
@@ -424,6 +426,7 @@ export default Vue.extend({
     },
     close() {
       this.should_open = false
+      this.$emit('start-tour')
       setTimeout(() => { window.location.reload() }, 500)
     },
     cancel() {


### PR DESCRIPTION
fix #3413 

Tour messages were outdated and did not correspond to the content of our current menu so I tried to update them.

The variable `start-tour` ensures that tour will only show up if wizard does not

## Summary by Sourcery

Align the welcome tour with the updated frontend navigation by adding proper element IDs, refreshing step messages and targets, and controlling tour activation through the wizard component.

Enhancements:
- Add id attributes to the navigation drawer and menu items (replacing spaces with hyphens) for precise tour targeting
- Update all guided tour steps’ targets, content, and placement to match the current UI menu structure
- Introduce a start_tour state flag and emit a start-tour event from the Wizard component to trigger the tour
- Modify checkTour logic to only launch the tour when start_tour is true and reset the flag after starting