### PR TITLE
frontend: autopilot: disable install firmware and change board buttons when vehicle is armed

### DIFF
--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -345,6 +345,9 @@ export default Vue.extend({
         .reverse()
     },
     allow_installing(): boolean {
+      if (!autopilot_data.is_safe) {
+        return false
+      }
       if (this.install_status === InstallStatus.Installing) {
         return false
       }

--- a/core/frontend/src/views/Autopilot.vue
+++ b/core/frontend/src/views/Autopilot.vue
@@ -82,7 +82,7 @@
           color="secondary"
           :block="$vuetify.breakpoint.xs"
           class="ma-1"
-          :disabled="restarting"
+          :disabled="restarting || !is_safe"
           @click="openBoardChangeDialog"
         >
           Change board
@@ -241,6 +241,9 @@ export default Vue.extend({
     },
     restarting(): boolean {
       return autopilot.restarting
+    },
+    is_safe(): boolean {
+      return autopilot_data.is_safe
     },
   },
   mounted() {


### PR DESCRIPTION
fix #2019

## Summary by Sourcery

Prevent users from initiating board changes or firmware installations when the vehicle is not in a safe state

Enhancements:
- Disable “Change board” button in Autopilot view if the vehicle is armed
- Block firmware installation actions in FirmwareManager when not safe