### PR TITLE
core: tools: nginx: Workaround double allow hitting CORS on browser when developing

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -48,7 +48,8 @@ http {
         listen 80; # IPv4
         listen [::]:80; # IPv6
 
-        add_header Access-Control-Allow-Origin *;
+        proxy_hide_header Access-Control-Allow-Origin;
+        add_header Access-Control-Allow-Origin * always;
 
         # Custom 404 handler that serves Vue.js app with proper 404 status
         error_page 404 @fallback;


### PR DESCRIPTION
Sometimes, both nginx and the service (say, an extension like radcam, or mavlink-server) are adding CORS layers, making the browser requests hit CORS. This workaround makes sure we don't end up with the duplicate allowance header.

I've been using this when I needed to test a local instance of Cockpit with a remote instance of RadCam Manager.

## Summary by Sourcery

Work around duplicate CORS headers by hiding the upstream Access-Control-Allow-Origin header and always injecting it in nginx

Enhancements:
- Hide upstream Access-Control-Allow-Origin header using proxy_hide_header in nginx.conf
- Use add_header with the always flag to consistently set Access-Control-Allow-Origin in responses