### PR TITLE
EthernetUpdater/store:ethernet: Fix ethernet endpoint

### DIFF
--- a/core/frontend/src/components/ethernet/EthernetUpdater.vue
+++ b/core/frontend/src/components/ethernet/EthernetUpdater.vue
@@ -16,11 +16,11 @@ export default Vue.extend({
     }
   },
   mounted() {
-    this.fetch_available_interfaces_task.setAction(this.fetchAvailableInterfaces)
+    this.fetch_available_interfaces_task.setAction(this.fetchAvailableEthernetInterfaces)
   },
   methods: {
-    async fetchAvailableInterfaces(): Promise<void> {
-      await ethernet.getAvailableInterfaces()
+    async fetchAvailableEthernetInterfaces(): Promise<void> {
+      await ethernet.getAvailableEthernetInterfaces()
         .then((response) => {
           ethernet.setInterfaces(response.data)
         })

--- a/core/frontend/src/store/ethernet.ts
+++ b/core/frontend/src/store/ethernet.ts
@@ -169,6 +169,21 @@ class EthernetStore extends VuexModule {
     })
       .catch((error) => {
         this.context.commit('setInterfaces', [])
+        notifier.pushBackError('AVAILABLE_INTERFACES_FETCH_FAIL', error)
+        throw error
+      })
+  }
+
+  @Action
+  async getAvailableEthernetInterfaces() {
+    return await back_axios({
+      method: 'get',
+      url: `${this.API_URL}/ethernet`,
+      // Necessary since the system can hang with dhclient timeouts
+      timeout: 10000,
+    })
+      .catch((error) => {
+        this.context.commit('setInterfaces', [])
         notifier.pushBackError('ETHERNET_AVAILABLE_INTERFACES_FETCH_FAIL', error)
         throw error
       })


### PR DESCRIPTION
* Make sure EthernetUpdate is using `/ethernet` interfaces that filters wifi ones

## Summary by Sourcery

Route EthernetUpdater to use a dedicated ethernet-only interfaces endpoint and action in the store.

New Features:
- Add a Vuex action to fetch available ethernet interfaces from the `/ethernet` API endpoint.

Bug Fixes:
- Ensure EthernetUpdater fetches only ethernet interfaces instead of all network interfaces and handles failures via the new endpoint.