### PR TITLE
frontend:model-viewer/Wizard: Gracefully handle missing WebGL support

### DIFF
--- a/core/frontend/src/utils/model_viewer_support.ts
+++ b/core/frontend/src/utils/model_viewer_support.ts
@@ -1,0 +1,38 @@
+let cachedSupport: boolean | undefined
+let loadPromise: Promise<boolean> | undefined
+
+function hasDOM(): boolean {
+  return globalThis.window !== undefined && globalThis.document !== undefined
+}
+
+function canCreateWebGLContext(): boolean {
+  if (!hasDOM()) {
+    return false
+  }
+  try {
+    const canvas = globalThis.document.createElement('canvas')
+    const context = canvas.getContext('webgl') ?? canvas.getContext('experimental-webgl')
+    return context !== null
+  } catch (error) {
+    console.warn('WebGL detection error:', error)
+    return false
+  }
+}
+
+export function canUseModelViewer(): boolean {
+  cachedSupport ??= canCreateWebGLContext()
+  return cachedSupport
+}
+
+export function ensureModelViewer(): Promise<boolean> {
+  if (!canUseModelViewer()) {
+    return Promise.resolve(false)
+  }
+  loadPromise ??= import('@google/model-viewer/dist/model-viewer')
+    .then(() => true)
+    .catch((error) => {
+      console.warn('Failed to load model-viewer, proceeding without 3D viewer.', error)
+      return false
+    })
+  return loadPromise
+}


### PR DESCRIPTION
This PR addresses the issue where the BlueOS frontend fails to load on browsers without WebGL support, resulting in a blank screen due to model-viewer failing to initialize.

## After Fix

### Initial Page:
<img width="1915" height="929" alt="image" src="https://github.com/user-attachments/assets/026dfe99-f26f-4112-9679-591f84da145b" />

### Vehicle Setup:
<img width="1632" height="659" alt="image" src="https://github.com/user-attachments/assets/b4e278b0-930c-4c25-91ef-959b7554e539" />


### Wizard:
<img width="801" height="319" alt="image" src="https://github.com/user-attachments/assets/fdcb13af-f95f-41b2-a28d-c68dc0eb846d" />

## Summary by Sourcery

Handle lack of WebGL/model-viewer support gracefully in the wizard and generic 3D viewer to avoid blank screens and hard failures.

New Features:
- Provide non-3D card-based vehicle selection in the setup wizard when model-viewer is unavailable.
- Show a clear fallback message when the 3D vehicle viewer cannot be used due to missing WebGL support.

Enhancements:
- Centralize model-viewer capability detection and lazy-loading in a shared utility with caching.
- Delay rendering of model-viewer components until support and library loading are confirmed to improve robustness.