### PR TITLE
core: tools: mcap-extractor: Update to 0.1.1

### DIFF
--- a/core/tools/mcap-extractor/bootstrap.sh
+++ b/core/tools/mcap-extractor/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 PROJECT_NAME="mcap-foxglove-video-extract"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="mcap-foxglove-video-extract"
-VERSION="0.1.0"
+VERSION="0.1.1"
 
 echo "Installing project $PROJECT_NAME version $VERSION"
 


### PR DESCRIPTION
## Summary by Sourcery

Bump the mcap-foxglove-video-extract tool bootstrap script to use version 0.1.1.