### PR TITLE
Add commonwealth files to docker compose

### DIFF
--- a/core/compose/compose.yml
+++ b/core/compose/compose.yml
@@ -23,6 +23,7 @@ services:
       - ../start-blueos-core:/usr/bin/start-blueos-core
       - ../tools/blueos_startup_update/blueos_startup_update.py:/usr/bin/blueos_startup_update.py
       - ../services:/home/pi/services
+      - ../libs:/home/pi/libs/
     pid: "host"
     environment:
       - BLUEOS_DISABLE_SERVICES=cable_guy,wifi,commander


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add libs directory bind-mount to the core container filesystem for access at /home/pi/libs.