### PR TITLE
core: tools: mcap: bootstrap: Update to 0.0.58

### DIFF
--- a/core/tools/mcap/bootstrap.sh
+++ b/core/tools/mcap/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 PROJECT_NAME="mcap"
 REPOSITORY_ORG="foxglove"
 REPOSITORY_NAME="mcap"
-VERSION="releases/mcap-cli/v0.0.56"
+VERSION="releases/mcap-cli/v0.0.58"
 
 echo "Installing project $PROJECT_NAME version $VERSION"
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the mcap bootstrap script to download the mcap CLI from the releases/mcap-cli/v0.0.58 tag.