### PR TITLE
deploy: pimod: blueos.Pifile: Update to 3.5GB

### DIFF
--- a/deploy/pimod/blueos.Pifile
+++ b/deploy/pimod/blueos.Pifile
@@ -1,6 +1,6 @@
 FROM https://downloads.raspberrypi.org/${BASE_IMAGE}
 
-PUMP 3000M
+PUMP 3500M
 
 # expand_fs
 INSTALL deploy/expand_fs.sh /usr/bin/expand_fs.sh


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust BlueOS pimod Pifile deployment configuration to target a 3.5GB image.