### PR TITLE
core: frontend: components: Add global warning component

### DIFF
--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -158,36 +158,12 @@
         </v-card>
       </v-card>
     </v-dialog>
-    <v-dialog
+    <WarningDialog
       v-model="show_reset_warning"
-      width="fit-content"
-      @click:outside="show_reset_warning = false"
-      @keydown.esc="show_reset_warning = false"
-    >
-      <v-sheet
-        color="warning"
-        outlined
-      >
-        <v-card variant="outlined">
-          <v-card-title class="align-center">
-            WARNING
-          </v-card-title>
-          <v-card-text class="reset-warning-text">
-            Resetting will restore BlueOS services to their default configurations.
-            This action cannot be undone. Proceed?
-          </v-card-text>
-          <v-card-actions>
-            <v-btn color="primary" @click="show_reset_warning = false">
-              Cancel
-            </v-btn>
-            <v-spacer />
-            <v-btn color="warning" @click="reset_settings(); show_reset_warning = false">
-              Yes, reset settings
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-sheet>
-    </v-dialog>
+      :message="resetWarningMessage"
+      confirm-label="Yes, reset settings"
+      @confirm="onConfirmResetSettings"
+    />
     <v-dialog
       width="380"
       :value="show_reset_dialog"
@@ -206,6 +182,7 @@
 import Vue from 'vue'
 
 import SpinningLogo from '@/components/common/SpinningLogo.vue'
+import WarningDialog from '@/components/common/WarningDialog.vue'
 import filebrowser from '@/libs/filebrowser'
 import Notifier from '@/libs/notifier'
 import bag from '@/store/bag'
@@ -222,6 +199,7 @@ export default Vue.extend({
   name: 'SettingsMenu',
   components: {
     SpinningLogo,
+    WarningDialog,
   },
   data() {
     return {
@@ -246,6 +224,12 @@ export default Vue.extend({
   computed: {
     has_operation_error(): boolean {
       return this.operation_error !== undefined
+    },
+    resetWarningMessage(): string {
+      return (
+        'Resetting will restore BlueOS services to their default configurations.\n'
+        + 'This action cannot be undone. Proceed?'
+      )
     },
   },
   watch: {
@@ -319,6 +303,10 @@ export default Vue.extend({
     },
     confirm_reset_settings(): void {
       this.show_reset_warning = true
+    },
+    onConfirmResetSettings(): void {
+      this.show_reset_warning = false
+      this.reset_settings()
     },
     async reset_settings(): Promise<void> {
       this.prepare_operation('Resetting settings...')
@@ -443,8 +431,5 @@ export default Vue.extend({
   height: 100%;
   backdrop-filter: blur(2px);
   z-index: 9999 !important;
-}
-.reset-warning-text {
-  max-width: 30rem;
 }
 </style>

--- a/core/frontend/src/components/common/WarningDialog.vue
+++ b/core/frontend/src/components/common/WarningDialog.vue
@@ -1,0 +1,142 @@
+<template>
+  <v-dialog
+    :value="value"
+    :width="width"
+    :persistent="persistent"
+    @input="emitInput"
+    @click:outside="handleOutsideClick"
+    @keydown.esc="handleEsc"
+  >
+    <v-sheet
+      color="warning"
+      outlined
+    >
+      <v-card variant="outlined">
+        <v-card-title class="align-center">
+          <span class="warning-title">
+            <span
+              class="warning-emoji"
+              aria-label="warning"
+              role="img"
+            >⚠️</span>
+            {{ title }}
+          </span>
+        </v-card-title>
+        <v-card-text :class="['warning-text', textClass]">
+          {{ message }}
+        </v-card-text>
+        <v-card-actions>
+          <v-btn :color="cancelColor" @click="close">
+            {{ cancelLabel }}
+          </v-btn>
+          <v-spacer />
+          <v-btn :color="confirmColor" @click="confirmAndMaybeClose">
+            {{ confirmLabel }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-sheet>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+
+export default Vue.extend({
+  name: 'WarningDialog',
+  props: {
+    value: {
+      type: Boolean,
+      required: true,
+    },
+    title: {
+      type: String,
+      default: 'WARNING',
+    },
+    message: {
+      type: String,
+      required: true,
+    },
+    confirmLabel: {
+      type: String,
+      required: true,
+    },
+    cancelLabel: {
+      type: String,
+      default: 'Cancel',
+    },
+    confirmColor: {
+      type: String as PropType<string>,
+      default: 'warning',
+    },
+    cancelColor: {
+      type: String as PropType<string>,
+      default: 'primary',
+    },
+    width: {
+      type: [String, Number] as PropType<string | number>,
+      default: 'fit-content',
+    },
+    persistent: {
+      type: Boolean,
+      default: false,
+    },
+    closeOnOutside: {
+      type: Boolean,
+      default: true,
+    },
+    closeOnEsc: {
+      type: Boolean,
+      default: true,
+    },
+    closeOnConfirm: {
+      type: Boolean,
+      default: true,
+    },
+    textClass: {
+      type: String,
+      default: '',
+    },
+  },
+  methods: {
+    emitInput(state: boolean) {
+      this.$emit('input', state)
+    },
+    close() {
+      this.emitInput(false)
+    },
+    handleOutsideClick() {
+      if (this.closeOnOutside && !this.persistent) {
+        this.close()
+      }
+    },
+    handleEsc() {
+      if (this.closeOnEsc && !this.persistent) {
+        this.close()
+      }
+    },
+    confirmAndMaybeClose() {
+      this.$emit('confirm')
+      if (this.closeOnConfirm) {
+        this.close()
+      }
+    },
+  },
+})
+</script>
+
+<style scoped>
+.warning-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.warning-emoji {
+  font-size: 1.2rem;
+}
+
+.warning-text {
+  max-width: 30rem;
+}
+</style>

--- a/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
@@ -69,39 +69,12 @@
       </v-card-actions>
     </v-card>
 
-    <v-dialog
+    <WarningDialog
       v-model="show_warning"
-      width="fit-content"
-      persistent
-    >
-      <v-sheet
-        color="warning"
-        outlined
-      >
-        <v-card
-          variant="outlined"
-        >
-          <v-card-title class="align-center">
-            WARNING
-          </v-card-title>
-          <v-card-text
-            style="max-width: 30rem;"
-          >
-            You will lose ALL your parameters, vehicle setup, and calibrations.
-            Are you sure you want to reset?
-          </v-card-text>
-          <v-card-actions>
-            <v-btn align="end" color="primary" @click="show_warning = false">
-              Cancel
-            </v-btn>
-            <v-spacer />
-            <v-btn color="warning" @click="wipe()">
-              Yes, reset them
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-sheet>
-    </v-dialog>
+      :message="warningMessage"
+      confirm-label="Yes, reset them"
+      @confirm="wipe"
+    />
   </v-row>
 </template>
 
@@ -111,6 +84,7 @@ import Vue from 'vue'
 
 import * as AutopilotManager from '@/components/autopilot/AutopilotManagerUpdater'
 import { fetchCurrentBoard } from '@/components/autopilot/AutopilotManagerUpdater'
+import WarningDialog from '@/components/common/WarningDialog.vue'
 import ParameterLoader from '@/components/parameter-editor/ParameterLoader.vue'
 import mavlink2rest from '@/libs/MAVLink2Rest'
 import {
@@ -130,6 +104,7 @@ export default Vue.extend({
   name: 'ParamSets',
   components: {
     ParameterLoader,
+    WarningDialog,
   },
   data: () => ({
     all_param_sets: {} as Dictionary<Dictionary<number>>,
@@ -176,6 +151,9 @@ export default Vue.extend({
       return {
         ...fw_params,
       }
+    },
+    warningMessage(): string {
+      return 'You will lose ALL your parameters, vehicle setup, and calibrations. Are you sure you want to reset?'
     },
   },
   mounted() {


### PR DESCRIPTION
<img width="775" height="303" alt="image" src="https://github.com/user-attachments/assets/4e2369fd-eec7-4dc2-8b6e-d8a8ea585ce2" />

## Summary by Sourcery

Introduce a reusable warning dialog component and adopt it in existing settings and parameter reset flows to standardize critical confirmation prompts.

New Features:
- Add a generic WarningDialog component for displaying confirmation warnings with configurable text, labels, and behavior.

Enhancements:
- Refactor settings reset and parameter reset views to use the shared WarningDialog component instead of inline dialog markup, improving consistency and reuse.