### PR TITLE
core: frontend: wizard: rover/BOAT exists but no boat/UNDEFINED

### DIFF
--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -361,7 +361,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      boat_model: get_model('boat', 'UNDEFINED'),
+      boat_model: get_model('rover', 'BOAT'),
       scripts: [] as string[],
       configuration_failed: false,
       error_message: 'The operation failed!',


### PR DESCRIPTION
Fix #3678

```
src/assets/3d/generic_sensor.glb
src/assets/3d/navigator.glb
public/assets/vehicles/models/sub/SIMPLEROV_4.glb
public/assets/vehicles/models/sub/bluerov.glb
public/assets/vehicles/models/sub/CUSTOM.glb
public/assets/vehicles/models/sub/SIMPLEROV_3.glb
public/assets/vehicles/models/sub/SIMPLEROV_5.glb
public/assets/vehicles/models/sub/VECTORED.glb
public/assets/vehicles/models/sub/VECTORED_6DOF.glb
public/assets/vehicles/models/sub/BLUEROV1.glb
public/assets/vehicles/models/rover/BOAT.glb
public/assets/vehicles/models/rover/unknown.glb
```

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect default model configuration in the wizard by referencing rover BOAT instead of an undefined boat model.