### PR TITLE
core: frontend: components: SettingsMenu: Increase timeout to 30s

### DIFF
--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -329,7 +329,7 @@ export default Vue.extend({
         params: {
           i_know_what_i_am_doing: true,
         },
-        timeout: 10000,
+        timeout: 30000,
       })
         .then(() => {
           this.show_reset_dialog = true


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Raise the SettingsMenu reset API call timeout from 10s to 30s to better tolerate slower backend responses.