### PR TITLE
core: tools: disktest: Add binary

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -105,6 +105,7 @@ COPY --from=download-binaries \
     /usr/bin/blueos_startup_update.py \
     /usr/bin/blueos-recorder \
     /usr/bin/bridges \
+    /usr/bin/disktest \
     /usr/bin/linux2rest \
     /usr/bin/machineid-cli \
     /usr/bin/mavlink2rest \

--- a/core/tools/disktest/bootstrap.sh
+++ b/core/tools/disktest/bootstrap.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+PROJECT_NAME="disktest"
+REPOSITORY_ORG="patrickelectric"
+REPOSITORY_NAME="disktest"
+VERSION="1.16.0"
+
+echo "Installing project $PROJECT_NAME version $VERSION"
+
+# Step 1: Prepare the download URL
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64 | amd64)
+    BUILD_NAME="x86_64-unknown-linux-gnu"
+    ;;
+  armv7l | armhf)
+    BUILD_NAME="armv7-unknown-linux-gnueabihf"
+    ;;
+  aarch64 | arm64)
+    BUILD_NAME="aarch64-unknown-linux-gnu"
+    ;;
+  *)
+    echo "Architecture: $ARCH is unsupported, please create a new issue on https://github.com/${REPOSITORY_ORG}/${REPOSITORY_NAME}/issues"
+    exit 1
+    ;;
+esac
+ARTIFACT_NAME="${PROJECT_NAME}-${BUILD_NAME}"
+REMOTE_URL="https://github.com/${REPOSITORY_ORG}/${REPOSITORY_NAME}/releases/download/${VERSION}/${ARTIFACT_NAME}"
+echo "Remote URL is $REMOTE_URL"
+
+# Step 2: Prepare the installation and tools paths
+if [ -n "$VIRTUAL_ENV" ]; then
+    BIN_DIR="$VIRTUAL_ENV/bin"
+else
+    BIN_DIR="/usr/bin"
+fi
+mkdir -p "$BIN_DIR"
+
+BINARY_PATH="$BIN_DIR/$PROJECT_NAME"
+echo "Installing to $BINARY_PATH"
+
+# Step 3: Download and install
+wget -q "$REMOTE_URL" -O "$BINARY_PATH"
+chmod +x "$BINARY_PATH"
+echo "Installed binary type: $(file "$BINARY_PATH")"

--- a/core/tools/install-static-binaries.sh
+++ b/core/tools/install-static-binaries.sh
@@ -8,6 +8,7 @@ set -e
 TOOLS=(
     blueos_startup_update
     bridges
+    disktest
     linux2rest
     machineid
     mavlink2rest


### PR DESCRIPTION
## Summary by Sourcery

Add the disktest static binary to the core image and tooling.

New Features:
- Include the disktest utility in the core Docker image for runtime use.

Enhancements:
- Extend the static binary installation script with support for installing the disktest tool via an architecture-aware bootstrap script.

Build:
- Update Docker build context to copy the disktest binary into /usr/bin during image build.