### PR TITLE
ci: test-and-deploy: Use zip -9 to compress BlueOS

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -331,7 +331,7 @@ jobs:
         timeout-minutes: 120
         with:
           name: BlueOS-raspberry-${{ env.GITHUB_REF_NAME }}${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}
-          path: deploy/pimod/blueos.img
+          path: BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}.zip
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
Helps #3683 

## Summary by Sourcery

Update the CI test-and-deploy workflow to compress the BlueOS Raspberry Pi image as a high-compression ZIP and upload the resulting archive instead of the raw image file.

CI:
- Use maximum compression (zip -9) when packaging the BlueOS Raspberry Pi image in the test-and-deploy workflow.
- Upload the generated ZIP archive as the artifact instead of the uncompressed image, and print its details for verification.