### PR TITLE
Upload releases to S3

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -343,6 +343,19 @@ jobs:
             echo "ASSET_NAME_SUFFIX=-pi4" >> $GITHUB_ENV
           fi
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Upload to S3
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          aws s3 sync BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}.zip s3://blueos-downlaods/releases/ --delete
+
       - name: Upload raspberry image for release
         uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary by Sourcery

Upload release artifacts to S3 during tagged builds.

CI:
- Configure AWS credentials in the GitHub Actions workflow for tagged releases.
- Sync built Raspberry Pi release ZIPs to the blueos-downloads S3 bucket on tag builds.