### PR TITLE
ci: test-and-deploy: Replace pip aws install with unfor19/install-aws-cli-action

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -259,14 +259,17 @@ jobs:
         include:
           - runner: blueos-ci
             platform: "linux/arm/v7"
+            aws_arch: "arm"
             os: "bookworm"
             image: "raspios_lite_armhf/images/raspios_lite_armhf-2024-07-04/2024-07-04-raspios-bookworm-armhf-lite.img.xz"
           - runner: pi4-builder2
             platform: "linux/arm/v7"
+            aws_arch: "arm"
             os: "bullseye"
             image: "raspios_lite_armhf/images/raspios_lite_armhf-2022-01-28/2022-01-28-raspios-bullseye-armhf-lite.zip"
           - runner: pi5-builder
             platform: "linux/arm64/v8"
+            aws_arch: "arm64"
             os: "bookworm"
             image: "raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/2024-07-04-raspios-bookworm-arm64-lite.img.xz"
 
@@ -285,6 +288,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - id: install-aws-cli
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          arch: matrix.aws_arch
 
       # We use our own pimod as upstream doesn't provide armv7 images
       - name: Pimod Build
@@ -341,13 +350,6 @@ jobs:
           elif [[ ${{ matrix.os }} == 'bullseye' ]]; then
             echo "ASSET_NAME_SUFFIX=-pi4" >> $GITHUB_ENV
           fi
-
-      - name: Install pip and AWS CLI via pip
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          sudo apt update
-          sudo apt install -y python3-pip
-          pip3 install awscli
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace manual pip-based AWS CLI installation with the unfor19/install-aws-cli-action, parameterized by matrix AWS architecture.