### PR TITLE
core: tools: mavlink_server: Update to 0.7.0

### DIFF
--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.6.0"
+VERSION="0.7.0"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump mavlink_server version reference in the bootstrap script from 0.6.0 to 0.7.0.