### PR TITLE
core: frontend: App.vue: remove Extensions beta tag

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -575,7 +575,6 @@ export default Vue.extend({
           route: '/tools/extensions-manager',
           advanced: false,
           text: 'Manage BlueOS extensions',
-          beta: true,
         },
         ...foundExtensions,
       ] as menuItem[]


### PR DESCRIPTION
The system is old (and publicly recommended) enough that plenty of people are relying on it - it isn't a beta anymore

## Summary by Sourcery

Remove the beta designation from the BlueOS extensions manager menu entry in the frontend navigation.