### PR TITLE
backport: core: tools: mavlink-camera-manager: Update to t3.22.3

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.22.1"
+VERSION="t3.22.3"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
Changelogs [here](https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.22.3) and [here](https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.22.2)

## Summary by Sourcery

Build:
- Bump mavlink-camera-manager version in bootstrap script from t3.22.1 to t3.22.3.