### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.22.3

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.22.2"
+VERSION="t3.22.3"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
Changelog [here](https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.22.3)

## Summary by Sourcery

Build:
- Update mavlink-camera-manager bootstrap script to fetch and use release t3.22.3 instead of t3.22.2.