### PR TITLE
core: services: ping: ping360_ethernet_prober: Use REUSEADDR with 30303

### DIFF
--- a/core/services/ping/ping360_ethernet_prober.py
+++ b/core/services/ping/ping360_ethernet_prober.py
@@ -49,6 +49,7 @@ async def find_ping360_ethernet() -> List[PingDeviceDescriptor]:
     for ip in list_ips():
         server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         server.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         # Set a timeout so the socket does not block
         # indefinitely when trying to receive data.
         server.settimeout(0.2)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Allow multiple or repeated Ping360 Ethernet probe runs to bind to the same UDP port without failing due to address-in-use errors.