### PR TITLE
frontend: components: DHCPServerDialog: Add alert for Backup Server

### DIFF
--- a/core/frontend/src/components/ethernet/DHCPServerDialog.vue
+++ b/core/frontend/src/components/ethernet/DHCPServerDialog.vue
@@ -21,6 +21,15 @@
           v-model="is_backup_server"
           label="Backup Server"
         />
+        <v-alert
+          type="info"
+          dense
+          text
+          class="mt-0"
+        >
+          When Backup Server is enabled, the DHCP server will stay inactive and only
+          start serving IP addresses if no other DHCP server is detected on the network.
+        </v-alert>
         <v-btn
           :disabled="!allow_enabling"
           color="primary"


### PR DESCRIPTION
Fix #3547

<img width="475" height="342" alt="image" src="https://github.com/user-attachments/assets/91a1cb91-680c-4613-ae6d-da817475fd50" />

## Summary by Sourcery

New Features:
- Display an informational alert explaining how the DHCP backup server behaves when enabled.