### PR TITLE
frontend: autopilot: parameter: Limit size of exponential

### DIFF
--- a/core/frontend/src/types/autopilot/parameter.ts
+++ b/core/frontend/src/types/autopilot/parameter.ts
@@ -90,10 +90,10 @@ export function printParam(param?: Parameter): string {
 
   try {
     if (Math.abs(param.value) > 1e4) {
-      return param.value.toExponential()
+      return param.value.toExponential(2)
     }
     if (Math.abs(param.value) < 0.01 && param.value !== 0) {
-      return param.value.toExponential()
+      return param.value.toExponential(2)
     }
     return param.value.toFixed(param.paramType.type.includes('INT') ? 0 : 2)
   } catch {


### PR DESCRIPTION
Fix #2948 

<img width="193" height="67" alt="image" src="https://github.com/user-attachments/assets/fb63297f-2e23-4799-ab23-76ca3e731b90" />

## Summary by Sourcery

Bug Fixes:
- Limit exponential formatting of very large or very small autopilot parameter values to two decimal places to avoid excessively long strings.