### PR TITLE
agents: Add important note about yarn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ yarn --cwd core/frontend lint --fix  # Lint and fix frontend code
 
 This enforces: Black formatting, isort imports, pylint, ruff, mypy strict mode, pytest with coverage.
 
+> **Important:** Always use `yarn` for frontend commands, never `npx`, `npm` or others.
+
 ## Common Pitfalls
 
 1. **Adding new dependencies without checking pyproject.toml** - Use what exists


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add an explicit note in AGENTS documentation to always use yarn for frontend commands and avoid npx/npm or other alternatives.