### PR TITLE
frontend: kraken: make json-viewer follow JSON standard

### DIFF
--- a/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
@@ -149,6 +149,8 @@
           <json-viewer
             :value="JSON.parse(extension.permissions ?? '{}')"
             :expand-depth="5"
+            :show-array-index="false"
+            :show-double-quotes="true"
           />
         </v-expansion-panel-content>
       </v-expansion-panel>
@@ -166,6 +168,8 @@
           <json-viewer
             :value="JSON.parse(extension.user_permissions ?? '{}')"
             :expand-depth="5"
+            :show-array-index="false"
+            :show-double-quotes="true"
           />
         </v-expansion-panel-content>
       </v-expansion-panel>


### PR DESCRIPTION
fix #1732

## Summary by Sourcery

Enhancements:
- Adjust JSON viewer in installed extension cards to hide array indices and display string values with double quotes.