### PR TITLE
frontend: kraken: fix duplicated entries in settings and user custom settings

### DIFF
--- a/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
@@ -147,7 +147,7 @@
         </v-expansion-panel-header>
         <v-expansion-panel-content>
           <json-viewer
-            :value="JSON.parse(extension.permissions ?? '{}')"
+            :value="parsed_permissions"
             :expand-depth="5"
             :show-array-index="false"
             :show-double-quotes="true"
@@ -166,7 +166,7 @@
         </v-expansion-panel-header>
         <v-expansion-panel-content>
           <json-viewer
-            :value="JSON.parse(extension.user_permissions ?? '{}')"
+            :value="parsed_user_permissions"
             :expand-depth="5"
             :show-array-index="false"
             :show-double-quotes="true"
@@ -233,6 +233,7 @@ import Vue, { PropType } from 'vue'
 import SpinningLogo from '@/components/common/SpinningLogo.vue'
 import settings from '@/libs/settings'
 import system_information from '@/store/system-information'
+import { JSONValue } from '@/types/common'
 import { ExtensionData, InstalledExtensionData } from '@/types/kraken'
 import { Disk } from '@/types/system-information/system'
 import { prettifySize } from '@/utils/helper_functions'
@@ -316,6 +317,12 @@ export default Vue.extend({
       }
 
       return this.extension.tag === latest ? false : latest
+    },
+    parsed_user_permissions(): JSONValue {
+      return JSON.parse(this.extension.user_permissions ?? '{}')
+    },
+    parsed_permissions(): JSONValue {
+      return JSON.parse(this.extension.permissions ?? '{}')
     },
   },
   methods: {


### PR DESCRIPTION
fix #3453 

Tested by applying the change in `User Custom Settings` and leaving `Settings` with the `JSON.parse()`. The modification displayed the configurations correctly while the old version was showing duplicates.

## Summary by Sourcery

Bug Fixes:
- Resolve duplicated entries shown for extension permissions and user custom permissions in the settings view by using consistently parsed JSON values.