### PR TITLE
Backports/1.4/hide secondary radcam stream

### DIFF
--- a/core/frontend/src/components/video-manager/VideoManager.vue
+++ b/core/frontend/src/components/video-manager/VideoManager.vue
@@ -136,6 +136,11 @@ export default Vue.extend({
         if (device.name === 'Fake source') {
           return has_active_stream(device) || settings.is_pirate_mode
         }
+
+        // Do not show RadCam's secondary stream
+        if (device.name === 'UnderwaterCam - IPCamera (UnderwaterCam)' && device.source.endsWith('/stream_1')) {
+          return has_active_stream(device) || settings.is_pirate_mode
+        }
         return true
       }
 


### PR DESCRIPTION
This is a backport of https://github.com/bluerobotics/BlueOS/pull/3748 into 1.4

Following the same behavior as for Fake Sources: we only show when there's a configured stream or the user is in Pirate Mode.

Closes #3746

## Summary by Sourcery

Bug Fixes:
- Prevent the RadCam secondary stream entry from appearing when it has no active stream unless the user is in Pirate Mode.