### PR TITLE
frontend: src: components: video-manager: VideoManager: Hide secondary stream from radcam

### DIFF
--- a/core/frontend/src/components/video-manager/VideoManager.vue
+++ b/core/frontend/src/components/video-manager/VideoManager.vue
@@ -136,6 +136,11 @@ export default Vue.extend({
         if (device.name === 'Fake source') {
           return has_active_stream(device) || settings.is_pirate_mode
         }
+
+        // Do not show RadCam's secondary stream
+        if (device.name === 'UnderwaterCam - IPCamera (UnderwaterCam)' && device.source.endsWith('/stream_1')) {
+          return has_active_stream(device) || settings.is_pirate_mode
+        }
         return true
       }
 


### PR DESCRIPTION
Following the same behavior as for Fake Sources: we only show when there's a configured stream or the user is in Pirate Mode.

Closes https://github.com/bluerobotics/BlueOS/issues/3746

## Summary by Sourcery

New Features:
- Conditionally hide RadCam’s secondary stream unless it has an active stream or the user is in Pirate Mode.