### PR TITLE
core:services:kraken:manifest: Fix fetch latest version

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -290,7 +290,7 @@ class ManifestManager:
 
         versions = await self.fetch_extension_versions(extension_id, stable, manifest_id)
 
-        return ext.versions.get(str(versions[0])) if versions else None
+        return (ext.versions.get(str(versions[0])) or ext.versions.get(f"v{versions[0]}")) if versions else None
 
     async def fetch_extension_version(self, extension_id: str, tag: str) -> Optional[ExtensionVersion]:
         ext = await self.fetch_extension(extension_id)


### PR DESCRIPTION
Closes #3694

## Summary by Sourcery

Bug Fixes:
- Handle extension manifest lookups where the stored version key may be either raw or prefixed with 'v' when fetching the latest version.