### PR TITLE
frontend: fix full_page extensions not showing up

### DIFF
--- a/core/frontend/src/components/utils/BrIframe.vue
+++ b/core/frontend/src/components/utils/BrIframe.vue
@@ -2,7 +2,7 @@
   <v-sheet
     width="100%"
     height="100%"
-    style="overflow: hidden; position: relative;"
+    style="overflow: hidden; position: absolute;"
   >
     <spinning-logo
       v-if="!gl_compatible && !iframe_loaded"


### PR DESCRIPTION
The issue can be seen by trying to open sonarview

I'm not sure if this breaks anything from https://github.com/bluerobotics/BlueOS/pull/3714
It doesn't look like it, for me.

## Summary by Sourcery

Bug Fixes:
- Fix full-page iframe-based extensions not rendering due to incorrect container positioning.