### PR TITLE
KrakenManager: bump extension installation timeout to 10 minutes

### DIFF
--- a/core/frontend/src/components/kraken/KrakenManager.ts
+++ b/core/frontend/src/components/kraken/KrakenManager.ts
@@ -207,7 +207,7 @@ export async function installExtension(
       permissions: extension?.permissions ?? '',
       user_permissions: extension?.user_permissions ?? '',
     },
-    timeout: 120000,
+    timeout: 600000,
     onDownloadProgress: progressHandler,
   })
 }


### PR DESCRIPTION
Dockerhub seems slower than usual today, which is causing me to be unable to install both Madrona and "Oak D Visual Odometry" extensions

## Summary by Sourcery

Enhancements:
- Relax the Kraken extension installation timeout from 2 minutes to 10 minutes to improve reliability under slow network or registry conditions.