### PR TITLE
AGENTS: Add comment about jq usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@ gh issue list --repo bluerobotics/BlueOS
 
 ### 3. Use yarn over npm
 
+### 4. Use `jq` to parse json
+
 ## Creating a New Service
 
 **Reference implementation:** [PR #3669](https://github.com/bluerobotics/BlueOS/pull/3669) (disk_usage service)


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a guideline in AGENTS documentation to use jq when parsing JSON.