### PR TITLE
frontend: remove unused ArduPilot parameter files from build

### DIFF
--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -77,9 +77,31 @@ export default defineConfig(({ command, mode }) => {
             next()
           })
         }
-      }
+      },
+      // Remove non-JSON files from ArduPilot parameter repository to reduce image size
+      {
+        name: 'cleanup-ardupilot-files',
+        apply: 'build',
+        closeBundle() {
+          const fs = require('fs')
+          const repoPath = path.resolve(__dirname, 'dist/assets/ArduPilot-Parameter-Repository')
+          if (!fs.existsSync(repoPath)) return
+
+          const removeNonJson = (dir) => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const fullPath = path.join(dir, entry.name)
+              if (entry.isDirectory()) {
+                removeNonJson(fullPath)
+              } else if (!entry.name.endsWith('.json') && !entry.name.endsWith('.json.gz')) {
+                fs.unlinkSync(fullPath)
+              }
+            }
+          }
+          removeNonJson(repoPath)
+        }
+      },
     ],
-    assetsInclude: ['**/*.gif', '**/*.glb', '**/*.png', '**/*.svg', '**/assets/ArduPilot-Parameter-Repository**.json', '**/*.msg', "**/three/examples/jsm/libs/draco/*"],
+    assetsInclude: ['**/*.gif', '**/*.glb', '**/*.png', '**/*.svg', '**/*.msg', "**/three/examples/jsm/libs/draco/*"],
     resolve: {
       extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
       alias: {


### PR DESCRIPTION
Only keep JSON files from the ArduPilot-Parameter-Repository, removing XML, RST, MD, and HTML documentation files that are not used by the frontend.

## Summary by Sourcery

Limit frontend build artifacts from the ArduPilot parameter repository to JSON-only assets to reduce bundle size.

Build:
- Add a Vite build hook that removes non-JSON ArduPilot parameter files from the built assets directory.
- Stop including ArduPilot-Parameter-Repository JSON files via the generic assetsInclude configuration, relying instead on the new cleanup step.