### PR TITLE
core: tools: install-system-tools: Remove apt cache after install

### DIFF
--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -18,3 +18,4 @@ parallel --halt now,fail=1 '/home/pi/tools/{}/bootstrap.sh' ::: "${TOOLS[@]}"
 # APT is terrible like pip and don't know how to handle parallel installation
 # These should periodically be moved onto the base image
 apt update && apt install -y --no-install-recommends dhcpcd5 iptables iproute2 isc-dhcp-client nmap systemd
+apt clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Removes around 110MB

## Summary by Sourcery

Enhancements:
- Clean APT cache and remove package list files after system tool installation to reduce disk usage.