### PR TITLE
core:services:kraken: Fix container log stream timeout

### DIFF
--- a/core/services/kraken/harbor/container.py
+++ b/core/services/kraken/harbor/container.py
@@ -113,7 +113,7 @@ class ContainerManager:
 
     @classmethod
     async def get_container_log_by_name(cls, container_name: str) -> AsyncGenerator[str, None]:
-        async with DockerCtx() as client:
+        async with DockerCtx(timeout=0) as client:
             try:
                 container = await cls.get_raw_container_by_name(client, container_name)
             except ContainerNotFound as error:


### PR DESCRIPTION
Closes #3763

## Summary by Sourcery

Reduce the frequency of extension log synchronization by integrating it into the existing cleaner task loop instead of running a separate high-frequency background task.

Enhancements:
- Add a reusable helper method to perform extension log synchronization with error handling.
- Remove the dedicated extension log background task in favor of running log synchronization as part of the cleaner task cycle.

## Summary by Sourcery

Allow configuring Docker client timeouts for Kraken harbor operations and use a non-timing-out client for container log streaming to prevent premature log stream termination.

Bug Fixes:
- Prevent container log streaming from timing out by using a Docker client configured with no timeout for log retrieval.

Enhancements:
- Extend the Docker context manager to support an optional custom HTTP client timeout via a dedicated aiohttp session.