### PR TITLE
tools: strip binaries to save disk space

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -28,6 +28,7 @@ FROM bluerobotics/blueos-base:0.2.2 AS base
 # Download binaries
 FROM base AS download-binaries
 COPY tools /home/pi/tools
+RUN apt update && apt install -y --no-install-recommends binutils
 RUN /home/pi/tools/install-static-binaries.sh
 
 # Generation of python virtual environment for our libraries and services

--- a/core/tools/bridges/bootstrap.sh
+++ b/core/tools/bridges/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/machineid/bootstrap.sh
+++ b/core/tools/machineid/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mcap-extractor/bootstrap.sh
+++ b/core/tools/mcap-extractor/bootstrap.sh
@@ -47,6 +47,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$BINARY_PATH")"
 

--- a/core/tools/mcap/bootstrap.sh
+++ b/core/tools/mcap/bootstrap.sh
@@ -47,6 +47,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/recorder/bootstrap.sh
+++ b/core/tools/recorder/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 


### PR DESCRIPTION
saves ~40mb of ~346mb we currently have of rust binaries 🤔

## Summary by Sourcery

Reduce disk usage of downloaded Rust-based tools by stripping their binaries during installation.

Enhancements:
- Strip downloaded tool binaries in all bootstrap scripts to reduce their size on disk.

Build:
- Install binutils in the Docker image build stage so stripping binaries is available during tool installation.