### PR TITLE
Frontend: compress most files to .gz

### DIFF
--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -94,6 +94,7 @@
     "typescript": "~4.9.5",
     "unplugin-vue-components": "^0.25.2",
     "vite": "3",
+    "vite-plugin-compression": "^0.5.1",
     "vite-plugin-pwa": "^0.16.5",
     "vite-plugin-wasm": "^3.4.1",
     "vue-cli-plugin-vuetify": "~2.4.1",

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -4,6 +4,7 @@ import Components from 'unplugin-vue-components/vite'
 import { defineConfig, loadEnv } from 'vite'
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { VitePWA } from 'vite-plugin-pwa'
+import viteCompression from 'vite-plugin-compression'
 import wasm from "vite-plugin-wasm"
 const { name } = require('./package.json')
 
@@ -100,6 +101,14 @@ export default defineConfig(({ command, mode }) => {
           removeNonJson(repoPath)
         }
       },
+      // Pre-compress assets with gzip for nginx to serve via gzip_static always
+      viteCompression({
+        algorithm: 'gzip',
+        ext: '.gz',
+        threshold: 1024,
+        deleteOriginFile: true,
+        filter: /\.(js|css|json|svg|txt|xml|wasm|glb)$/i,
+      }),
     ],
     assetsInclude: ['**/*.gif', '**/*.glb', '**/*.png', '**/*.svg', '**/*.msg', "**/three/examples/jsm/libs/draco/*"],
     resolve: {

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -24,6 +24,9 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Serve pre-compressed .gz files even without originals (requires client gzip support)
+    gzip_static always;
+
     # Cache
     proxy_cache_path /var/cache/nginx keys_zone=ourcache:10m levels=1:2 max_size=1g inactive=30d;
 
@@ -265,7 +268,6 @@ http {
 
         location /assets/ {
             root /home/pi/frontend;
-            try_files $uri $uri/;
             autoindex on;
             add_header Cache-Control "public, max-age=604800";
         }


### PR DESCRIPTION
This saves about 75mb of image size

## Summary by Sourcery

Enable pre-compressed gzip asset delivery in the frontend build and nginx configuration.

New Features:
- Add Vite compression plugin to generate gzip-compressed frontend assets during build.

Enhancements:
- Configure nginx to always serve pre-compressed .gz files via gzip_static and simplify asset location handling.

Build:
- Add vite-plugin-compression dependency and integrate it into the Vite config to gzip selected asset types.

Deployment:
- Update nginx configuration to serve pre-compressed static assets from the frontend build output.