### PR TITLE
frontend: add timeout for snackbars

### DIFF
--- a/core/frontend/src/components/app/Alerter.vue
+++ b/core/frontend/src/components/app/Alerter.vue
@@ -1,7 +1,7 @@
 <template>
   <v-snackbar
     v-model="show"
-    timeout="-1"
+    :timeout="timeout"
   >
     {{ message }}
 
@@ -47,6 +47,17 @@ export default Vue.extend({
           return 'critical'
         default:
           return 'info'
+      }
+    },
+    timeout(): number {
+      switch (this.level) {
+        case MessageLevel.Success:
+        case MessageLevel.Info:
+          return 5000
+        case MessageLevel.Warning:
+          return 7000
+        default:
+          return -1
       }
     },
   },


### PR DESCRIPTION
fix #1884

## Summary by Sourcery

New Features:
- Introduce automatic dismissal timeouts for snackbar alerts varying by message level (success/info, warning, others).