### PR TITLE
Core: add /autopilot-manager/ location to nginx

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -75,6 +75,11 @@ http {
             proxy_pass http://127.0.0.1:8000/;
         }
 
+        location /autopilot-manager/ {
+            include cors.conf;
+            proxy_pass http://127.0.0.1:8000/;
+        }
+
         location /bag/ {
             include cors.conf;
             proxy_pass http://127.0.0.1:9101/;


### PR DESCRIPTION
~needs testing~ tested

## Summary by Sourcery

New Features:
- Expose /autopilot-manager/ path via nginx, forwarding requests to the core service with CORS enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small nginx config change that only adds an additional proxy location; main risk is misrouting or unintended exposure of the upstream service.
> 
> **Overview**
> Adds a new nginx route `location /autopilot-manager/` that mirrors the existing `/ardupilot-manager/` behavior by enabling CORS and proxying requests to the core service on `127.0.0.1:8000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60906559d4f93f391917c2f205dc3bdd962296e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

New Features:
- Expose a new /autopilot-manager/ HTTP endpoint through nginx, forwarding requests to the core backend with CORS support.