### PR TITLE
core: frontend: system-information: Fix negative bandwidth display

### DIFF
--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -182,8 +182,8 @@ class SystemInformationStore extends VuexModule {
         const dt = (now - (previousNetwork?.last_update ?? 5)) / 1000
         network.last_update = now
         if (previousNetwork) {
-          network.download_speed = (network.total_received_B - previousNetwork.total_received_B) / dt
-          network.upload_speed = (network.total_transmitted_B - previousNetwork.total_transmitted_B) / dt
+          network.download_speed = Math.max(0, (network.total_received_B - previousNetwork.total_received_B) / dt)
+          network.upload_speed = Math.max(0, (network.total_transmitted_B - previousNetwork.total_transmitted_B) / dt)
         }
       }
       this.system.network = networks

--- a/core/frontend/src/utils/networking.ts
+++ b/core/frontend/src/utils/networking.ts
@@ -1,5 +1,5 @@
 export function formatBandwidth(bytesPerSecond: number): string {
-  const mbps = (8 * bytesPerSecond / 1024 / 1024)
+  const mbps = (8 * Math.max(0, bytesPerSecond) / 1024 / 1024)
   const decimal_places = mbps < 10 ? 2 : mbps < 100 ? 1 : 0
   return `${mbps.toFixed(decimal_places)}Mbps`
 }


### PR DESCRIPTION
Closes #3587

## Summary by Sourcery

Prevent negative bandwidth values from being calculated or displayed in the system information frontend.

Bug Fixes:
- Clamp calculated download and upload speeds to zero or higher when deriving them from network counters.
- Ensure formatted bandwidth values never show as negative Mbps by clamping the input rate to zero.