### PR TITLE
core: frontend: SettingsView: Prevent system log delete while downloading

### DIFF
--- a/core/frontend/src/views/SettingsView.vue
+++ b/core/frontend/src/views/SettingsView.vue
@@ -240,6 +240,7 @@
                     class="mr-2"
                     outlined
                     small
+                    :disabled="deletion_in_progress"
                     @click="download_service_log_files"
                   >
                     <v-icon left small>
@@ -251,7 +252,7 @@
                     v-tooltip="'Free up space by removing old logs'"
                     outlined
                     small
-                    :disabled="disable_remove || deletion_in_progress"
+                    :disabled="disable_remove || deletion_in_progress || downloading"
                     color="error"
                     @click="remove_service_log_files"
                   >
@@ -516,6 +517,7 @@ export default Vue.extend({
       operation_description: '',
       operation_error: undefined as undefined | string,
       deletion_in_progress: false,
+      downloading: false,
       deletion_log_abort_controller: null as null | AbortController,
       current_deletion_path: '',
       current_deletion_size: 0,
@@ -563,8 +565,13 @@ export default Vue.extend({
     },
 
     async download_service_log_files(): Promise<void> {
-      const folder = await filebrowser.fetchFolder('system_logs')
-      await filebrowser.downloadFolder(folder)
+      this.downloading = true
+      try {
+        const folder = await filebrowser.fetchFolder('system_logs')
+        await filebrowser.downloadFolder(folder)
+      } finally {
+        this.downloading = false
+      }
     },
 
     async download_mavlink_log_files(): Promise<void> {


### PR DESCRIPTION
Closes #3284

## Summary by Sourcery

Prevent system logs from being deleted while a log download is in progress by tracking download state and disabling relevant actions accordingly.

Bug Fixes:
- Disable the system log deletion action while a log download is in progress to avoid concurrent operations on the same logs.

Enhancements:
- Track the system log download state in the settings view and disable the download button during active downloads.