### PR TITLE
core: tools: mavlink-server: Update to 0.7.2

### DIFF
--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.7.0"
+VERSION="0.7.2"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
* wrong initial stats got fixed
* binary size reduced from ~80 to ~26MB (-67%)

Change logs: [0.7.1](https://github.com/bluerobotics/mavlink-server/releases/tag/0.7.1), [0.7.2](https://github.com/bluerobotics/mavlink-server/releases/tag/0.7.2)

## Summary by Sourcery

New Features:
- Adopt mavlink-server 0.7.2, inheriting its upstream fixes and binary size improvements.