### PR TITLE
[backport] core: tools: linux2rest: Update to 0.9.4

### DIFF
--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="v0.6.2"
+VERSION="v0.9.4"
 REPOSITORY_ORG="patrickelectric"
 REPOSITORY_NAME="linux2rest"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
Backport of https://github.com/bluerobotics/BlueOS/pull/3794 into 1.4

@patrickelectric I'm assuming `1.4` is still the branch I should backport to, let me know if it's not the case anymore.

## Summary by Sourcery

Enhancements:
- Bump linux2rest bootstrap script version from v0.6.2 to v0.9.4.