### PR TITLE
1.4: core: services: ping: ping360_ethernet_prober: Use REUSEADDR with 30303

### DIFF
--- a/core/services/ping/ping360_ethernet_prober.py
+++ b/core/services/ping/ping360_ethernet_prober.py
@@ -50,6 +50,7 @@ async def find_ping360_ethernet() -> List[PingDeviceDescriptor]:
     for ip in list_ips():
         server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         server.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         # Set a timeout so the socket does not block
         # indefinitely when trying to receive data.
         server.settimeout(0.2)


### PR DESCRIPTION
As requested

## Summary by Sourcery

Bug Fixes:
- Allow the Ping360 Ethernet prober to bind reliably to the broadcast port by enabling SO_REUSEADDR on its UDP socket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-socket option change limited to UDP discovery binding behavior; low likelihood of impacting other functionality beyond making binds more permissive.
> 
> **Overview**
> Improves Ping360 Ethernet discovery reliability by enabling `SO_REUSEADDR` on the UDP socket before binding to port `30303`, reducing failures when the port is already in use or recently closed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80a5c6484747d136b403c28b9d82b207aad6dea3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->