### PR TITLE
Version Chooser: display response text contents on tag fetching error

### DIFF
--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -103,7 +103,7 @@ class TagFetcher:
             ) as resp:
                 if resp.status != 200:
                     warn(f"Error status {resp.status}")
-                    raise RuntimeError("Failed getting tags from DockerHub!")
+                    raise RuntimeError(f"Failed getting tags from DockerHub! {resp.status} {await resp.text()}")
                 data = await resp.json(content_type=None)
                 tags = data["results"]
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Expose the HTTP status and response body in the error thrown when DockerHub tag fetching fails to aid debugging and diagnosis.