### PR TITLE
(1.4 Backport)  disk saving changes

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -28,6 +28,7 @@ FROM bluerobotics/blueos-base:0.2.1 AS base
 # Download binaries
 FROM base AS download-binaries
 COPY tools /home/pi/tools
+RUN apt update && apt install -y --no-install-recommends binutils
 RUN /home/pi/tools/install-static-binaries.sh
 
 # BlueOS base image

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -83,6 +83,7 @@
     "typescript": "~4.9.5",
     "unplugin-vue-components": "^0.25.2",
     "vite": "3",
+    "vite-plugin-compression": "^0.5.1",
     "vite-plugin-pwa": "^0.16.5",
     "vue-cli-plugin-vuetify": "~2.4.1",
     "vue-template-babel-compiler": "^2.0.0",

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -4,6 +4,7 @@ import Components from 'unplugin-vue-components/vite'
 import { defineConfig, loadEnv } from 'vite'
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { VitePWA } from 'vite-plugin-pwa'
+import viteCompression from 'vite-plugin-compression'
 const { name } = require('./package.json')
 
 process.env.PROJECT_NAME = name
@@ -77,6 +78,14 @@ export default defineConfig(({ command, mode }) => {
           removeNonJson(repoPath)
         }
       },
+      // Pre-compress assets with gzip for nginx to serve via gzip_static always
+      viteCompression({
+        algorithm: 'gzip',
+        ext: '.gz',
+        threshold: 1024,
+        deleteOriginFile: true,
+        filter: /\.(js|css|json|svg|txt|xml|wasm|glb)$/i,
+      }),
     ],
     assetsInclude: ['**/*.gif', '**/*.glb', '**/*.png', '**/*.svg'],
     resolve: {

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -54,9 +54,31 @@ export default defineConfig(({ command, mode }) => {
         authToken: process.env.SENTRY_AUTH_TOKEN,
         org: "blue-robotics-c7",
         project: "blueos",
-      })
+      }),
+      // Remove non-JSON files from ArduPilot parameter repository to reduce image size
+      {
+        name: 'cleanup-ardupilot-files',
+        apply: 'build',
+        closeBundle() {
+          const fs = require('fs')
+          const repoPath = path.resolve(__dirname, 'dist/assets/ArduPilot-Parameter-Repository')
+          if (!fs.existsSync(repoPath)) return
+
+          const removeNonJson = (dir) => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const fullPath = path.join(dir, entry.name)
+              if (entry.isDirectory()) {
+                removeNonJson(fullPath)
+              } else if (!entry.name.endsWith('.json') && !entry.name.endsWith('.json.gz')) {
+                fs.unlinkSync(fullPath)
+              }
+            }
+          }
+          removeNonJson(repoPath)
+        }
+      },
     ],
-    assetsInclude: ['**/*.gif', '**/*.glb', '**/*.png', '**/*.svg', '**/assets/ArduPilot-Parameter-Repository**.json'],
+    assetsInclude: ['**/*.gif', '**/*.glb', '**/*.png', '**/*.svg'],
     resolve: {
       extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
       alias: {

--- a/core/tools/bridges/bootstrap.sh
+++ b/core/tools/bridges/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -4,6 +4,7 @@
 # Immediately exit on errors
 set -e
 
+apt update && apt install -y --no-install-recommends binutils
 TOOLS=(
     ardupilot_tools
     filebrowser
@@ -19,3 +20,4 @@ parallel --halt now,fail=1 '/home/pi/tools/{}/bootstrap.sh' ::: "${TOOLS[@]}"
 # APT is terrible like pip and don't know how to handle parallel installation
 # These should periodically be moved onto the base image
 apt update && apt install -y --no-install-recommends dhcpcd5 iptables iproute2 isc-dhcp-client nmap
+apt clean && rm -rf /var/lib/apt/lists/*

--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/machineid/bootstrap.sh
+++ b/core/tools/machineid/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavlink_router/bootstrap.sh
+++ b/core/tools/mavlink_router/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -51,6 +51,7 @@ echo "Installing to $BINARY_PATH"
 
 wget -q "$REMOTE_URL" -O "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/mavp2p/bootstrap.sh
+++ b/core/tools/mavp2p/bootstrap.sh
@@ -55,6 +55,7 @@ wget -q "$REMOTE_URL" -O - | tar -zxf - -C "$TMP_DIR"
 mv "$TMP_DIR/$PROJECT_NAME" "$BINARY_PATH"
 rm -rf "$TMP_DIR"
 chmod +x "$BINARY_PATH"
+strip "$BINARY_PATH"
 
 echo "Installed binary type: $(file "$(which "$BINARY_PATH")")"
 

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -24,6 +24,9 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Serve pre-compressed .gz files even without originals (requires client gzip support)
+    gzip_static always;
+
     # Cache
     proxy_cache_path /var/cache/nginx keys_zone=ourcache:10m levels=1:2 max_size=1g inactive=30d;
 
@@ -218,7 +221,6 @@ http {
 
         location /assets/ {
             root /home/pi/frontend;
-            try_files $uri $uri/;
             autoindex on;
             add_header Cache-Control "public, max-age=604800";
         }


### PR DESCRIPTION
<img width="445" height="163" alt="image" src="https://github.com/user-attachments/assets/09de5923-3d14-4670-8a88-56040d6b313b" />
<img width="441" height="166" alt="image" src="https://github.com/user-attachments/assets/b19e3cba-1b2f-434f-a857-1e549715fae9" />

## Summary by Sourcery

Reduce disk and image size while improving asset delivery and dev server behavior.

New Features:
- Serve pre-compressed frontend assets via nginx using gzip_static and a Vite compression plugin.
- Add a Vite dev-server plugin to correctly serve Draco .wasm and .js assets.

Bug Fixes:
- Fix serving of three.js Draco decoder assets in the Vite dev server by setting correct content types and paths.

Enhancements:
- Strip downloaded tool binaries after installation to shrink their size.
- Prune non-JSON files from the ArduPilot parameter repository in the built frontend bundle to reduce footprint.
- Install binutils in core images and tooling to enable binary stripping and related operations.

Build:
- Add vite-plugin-compression as a frontend dependency and configure gzip pre-compression for selected asset types.
- Adjust Vite assetsInclude configuration to stop bundling ArduPilot parameter repository JSON patterns explicitly.

Deployment:
- Configure nginx to always serve pre-compressed .gz files and simplify /assets/ location handling.

Chores:
- Tighten APT usage in tooling scripts by cleaning package lists after installation to reduce image size.