### PR TITLE
[1.4 backport] core: Dockerfile: Allow base image override using docker ARG

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,3 +1,6 @@
+# Override with --build-arg BASE_IMAGE=blueos-base:dev for local builds
+ARG BASE_IMAGE=bluerobotics/blueos-base:0.2.1
+
 # Build frontend
 FROM --platform=$BUILDPLATFORM oven/bun:1.0.3-slim AS frontend-builder
 
@@ -23,7 +26,7 @@ set -e
 
 EOF
 
-FROM bluerobotics/blueos-base:0.2.1 AS base
+FROM ${BASE_IMAGE} AS base
 
 # Download binaries
 FROM base AS download-binaries


### PR DESCRIPTION
## Summary

This adds a `BASE_IMAGE` build argument to `core/Dockerfile`, allowing the base image to be overridden at build time via `--build-arg BASE_IMAGE=blueos-base:dev`.

By default it still uses `bluerobotics/blueos-base:0.2.1`, so nothing changes for CI or production builds.

## Motivation

This change is meant to ease offline and quick iteration between modifying `blueos-base` and `blueos-core`, and testing the results — without needing to push intermediate images to a registry. Previously, any change to the base image required publishing it before `blueos-core` could consume it, which made the feedback loop slow and required internet connectivity.

This was essential to reach the modifications done for WebRTC performance improvements, where many iterative changes to the base image needed to be validated against the core build rapidly.

## Usage

```sh
# Build blueos-base locally
docker build -t blueos-base:dev ./base

# Build blueos-core using the local base image
docker build --build-arg BASE_IMAGE=blueos-base:dev -t blueos-core:dev ./core
```