### PR TITLE
[1.4 backport] core: start-blueos-core: Add runtime tuning for improved stream performance

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -220,6 +220,65 @@ prepare_cgroups() {
 
 prepare_cgroups
 
+# Runtime performance tuning (applied every container start via /sys/ bind mount)
+tune_performance() {
+  echo "Applying runtime performance tuning..."
+
+  # Network buffer tuning for high-bandwidth WebRTC streaming (55Mbps+)
+  # Maximum send buffer size per socket. The Pi's default was 180KB.
+  # WebRTC/SRTP sends ~55Mbps of UDP traffic. When the socket's send buffer is
+  # too small, the kernel drops outgoing packets during CPU load spikes. 16MB
+  # gives GStreamer/WebRTC headroom to queue bursts without drops. This is the
+  # single most impactful change for preventing video stutters.
+  echo $((16 * 1024 * 1024)) > /proc/sys/net/core/wmem_max 2>/dev/null || true
+  echo "wmem_max: $(cat /proc/sys/net/core/wmem_max 2>/dev/null || echo N/A)"
+
+  # Maximum receive buffer size per socket. Same logic but for incoming traffic
+  # (STUN/TURN negotiation, RTCP feedback, MAVLink). Less critical than wmem
+  # for outbound-heavy streaming, but prevents receive-side drops during
+  # inbound bursts.
+  echo $((16 * 1024 * 1024)) > /proc/sys/net/core/rmem_max 2>/dev/null || true
+  echo "rmem_max: $(cat /proc/sys/net/core/rmem_max 2>/dev/null || echo N/A)"
+
+  # Default buffer sizes for newly created sockets (when the application
+  # doesn't explicitly set SO_SNDBUF/SO_RCVBUF). The Pi default is ~180KB. If
+  # MCM or any BlueOS service opens a socket without tuning its buffers, it
+  # inherits this default. 1MB is a reasonable baseline that prevents casual
+  # sockets from starving under load.
+  echo $((1024 * 1024))  > /proc/sys/net/core/wmem_default 2>/dev/null || true
+  echo "wmem_default: $(cat /proc/sys/net/core/wmem_default 2>/dev/null || echo N/A)"
+  echo $((1024 * 1024))  > /proc/sys/net/core/rmem_default 2>/dev/null || true
+  echo "rmem_default: $(cat /proc/sys/net/core/rmem_default 2>/dev/null || echo N/A)"
+
+  # Per-CPU input queue length for incoming packets. When the network driver
+  # delivers packets faster than the kernel's softirq can process them, they
+  # queue here. Default is 1000. During dual-camera streaming, CPU0 was seeing
+  # time_squeeze events (softirq ran out of its time budget and packets backed
+  # up). A deeper queue reduces drops during those transient spikes. This pairs
+  # with the IRQ affinity changes that spread eth0 across CPU1/CPU2.
+  echo 5000     > /proc/sys/net/core/netdev_max_backlog 2>/dev/null || true
+  echo "netdev_max_backlog: $(cat /proc/sys/net/core/netdev_max_backlog 2>/dev/null || echo N/A)"
+
+  # How aggressively the kernel swaps anonymous pages to disk (the SD card). At
+  # the default of 60, under memory pressure, the kernel proactively swaps out
+  # process memory to free RAM for file cache. On an SD card, swap I/O is
+  # extremely slow (~10MB/s) and creates latency spikes for any swapped-out
+  # process. During our baseline measurements, kswapd was spiking to 8-12% CPU
+  # during streaming. At swappiness=10, the kernel strongly prefers reclaiming
+  # file cache over swapping, which eliminated kswapd activity and freed ~113MB
+  # of RAM.
+  echo 10       > /proc/sys/vm/swappiness 2>/dev/null || true
+  echo "swappiness: $(cat /proc/sys/vm/swappiness 2>/dev/null || echo N/A)"
+
+  # Prevent SCHED_RR/SCHED_FIFO threads from starving the rest of the system.
+  # Setting to -1 would disable the safety net entirely.
+  # 950000/1000000 = 95% RT, leaving 50ms/s per core for non-RT threads.
+  echo 950000 > /proc/sys/kernel/sched_rt_runtime_us 2>/dev/null || true
+  echo "RT throttle: $(cat /proc/sys/kernel/sched_rt_runtime_us 2>/dev/null || echo N/A)us per $(cat /proc/sys/kernel/sched_rt_period_us 2>/dev/null || echo N/A)us period"
+}
+
+tune_performance
+
 echo "Starting high priority services.."
 for TUPLE in "${PRIORITY_SERVICES[@]}"; do
     IFS=',' read -r NAME MEMORY_LIMIT_MB EXECUTABLE <<< "$TUPLE"


### PR DESCRIPTION
## Summary

Adds a `tune_performance()` function to `core/start-blueos-core` that applies runtime sysctl tuning on every container start. These changes were essential for improved WebRTC performance and stream stability.

## Changes

### UDP buffer sizes (`wmem_max`, `rmem_max`, `wmem_default`, `rmem_default`, `netdev_max_backlog`)

From testing, the minimum UDP buffer size for stable streaming was actually **2.5 MB**, but we set it to **16 MB** instead to be future-proof (4K 60fps, 100 Mbps, etc). We can lower this if reviewers think it is too much.

Note that this potentially increases the RAM used by **all services that use UDP**, not just the streaming pipeline, since these are system-wide sysctl settings.

### Swappiness (`vm.swappiness = 10`)

This did **not** come from test data. It was chosen as a better configuration than the current default (60), since the team had already mentioned during a meeting that it would be good to reduce swap use. On SD cards, swap I/O is extremely slow and creates latency spikes, so preferring file cache reclamation over swapping should improve overall responsiveness.

### Real-time scheduler limits (`sched_rt_runtime_us = 950000`)

This is a **safe rationale**, not derived from test data. MCM uses many real-time (SCHED_RR/SCHED_FIFO) threads for streaming, and we do not want to let them starve the rest of the system. The setting reserves 5% of each CPU core's time (50 ms per second) for non-RT threads, preventing a scenario where aggressive RT scheduling locks out essential system processes.

## Summary by Sourcery

Introduce runtime system tuning in start-blueos-core to improve streaming performance and system responsiveness by adjusting kernel networking and scheduling parameters on container startup.

Enhancements:
- Apply UDP-related sysctl tuning at container start to increase buffer sizes and backlog for more stable high-bitrate streaming.
- Lower system swappiness to reduce reliance on slow swap storage and improve interactivity on constrained media.
- Configure real-time scheduler runtime limits to prevent RT threads from starving other system processes during intensive streaming workloads.