### PR TITLE
[1.4 backport] CI: split zip files into 2gb~ish chunks

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -317,21 +317,6 @@ jobs:
       - name: Sanitize platform name
         run: echo "SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | tr '/' '-')" >> $GITHUB_ENV
 
-      - name: Zip image
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          sudo apt install zip
-          zip BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}.zip deploy/pimod/blueos.img
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 120
-        with:
-          name: BlueOS-raspberry-${{ env.GITHUB_REF_NAME }}${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}
-          path: deploy/pimod/blueos.img
-          if-no-files-found: error
-          retention-days: 7
-
       - name: Set asset name
         run: |
           if [[ ${{ matrix.runner }} == 'pi5-builder' ]]; then
@@ -340,13 +325,29 @@ jobs:
             echo "ASSET_NAME_SUFFIX=-pi4" >> $GITHUB_ENV
           fi
 
+      - name: Zip image
+        run: |
+          sudo apt install zip
+          zip -9 -s 2000m BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}.zip deploy/pimod/blueos.img
+          ls -lah BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}*
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 120
+        with:
+          name: BlueOS-raspberry-${{ env.GITHUB_REF_NAME }}${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}
+          path: BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}.z*
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Upload raspberry image for release
         uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}.zip
-          asset_name: BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}.zip
+          # Matches single .zip or multi-volume .z01, .z02, ..., .zip
+          file: BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}.z*
+          file_glob: true
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true


### PR DESCRIPTION
tested here
https://github.com/Williangalvani/BlueOS/releases/tag/1.4.4-beta.15

## Summary by Sourcery

Build:
- Update CI packaging to produce size-limited, multi-volume zip archives for Raspberry Pi images and include platform-specific suffixes in asset names.