### PR TITLE
frontend: wizard: check if there is a board available before running wizard customization step

### DIFF
--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -83,6 +83,14 @@
             </v-row>
           </v-stepper-content>
           <v-stepper-content step="2">
+            <v-alert
+              v-if="board_not_detected"
+              type="warning"
+              class="ma-2"
+              dense
+            >
+              No flight controller detected.
+            </v-alert>
             <div class="d-flex justify-space-between">
               <model-viewer
                 v-if="model_viewer_supported && model_viewer_ready"
@@ -300,6 +308,7 @@ import Vue from 'vue'
 
 import {
   availableFirmwares,
+  fetchCurrentBoard,
   fetchFirmwareInfo,
   installFirmwareFromUrl,
 } from '@/components/autopilot/AutopilotManagerUpdater'
@@ -386,6 +395,7 @@ export default Vue.extend({
       configuration_page_index: 0,
       model_viewer_supported: MODEL_VIEWER_SUPPORTED,
       model_viewer_ready: false,
+      board_not_detected: false,
     }
   },
   computed: {
@@ -526,7 +536,13 @@ export default Vue.extend({
         ? ApplyStatus.Done : ApplyStatus.Failed
       this.retry_count += 1
     },
-    setupBoat() {
+    async setupBoat() {
+      await fetchCurrentBoard()
+      if (!autopilot.current_board) {
+        this.board_not_detected = true
+        return
+      }
+      this.board_not_detected = false
       this.vehicle_type = Vehicle.Rover
       this.vehicle_name = 'BlueBoat'
       this.vehicle_image = '/assets/vehicles/images/bb120.png'
@@ -586,7 +602,13 @@ export default Vue.extend({
         this.finalConfigurations()
       }
     },
-    setupROV() {
+    async setupROV() {
+      await fetchCurrentBoard()
+      if (!autopilot.current_board) {
+        this.board_not_detected = true
+        return
+      }
+      this.board_not_detected = false
       this.vehicle_type = Vehicle.Sub
       this.vehicle_name = 'BlueROV'
       this.vehicle_image = '/assets/vehicles/images/bluerov2.png'
@@ -661,6 +683,11 @@ export default Vue.extend({
         .catch((error) => `Failed to disable smart wifi hotspot: ${error.message ?? error.response?.data}.`)
     },
     async installLatestStableFirmware(vehicle: Vehicle): Promise<ConfigurationStatus> {
+      await fetchCurrentBoard()
+      if (!autopilot.current_board) {
+        return 'No flight controller board detected.'
+      }
+
       if (this.retry_count) {
         console.debug('Going to reboot flight controller on retry.')
         mavlink2rest.sendMessage(

--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -89,7 +89,7 @@
               class="ma-2"
               dense
             >
-              No flight controller detected.
+              {{ board_detection_message }}
             </v-alert>
             <div class="d-flex justify-space-between">
               <model-viewer
@@ -396,6 +396,7 @@ export default Vue.extend({
       model_viewer_supported: MODEL_VIEWER_SUPPORTED,
       model_viewer_ready: false,
       board_not_detected: false,
+      board_detection_message: 'No flight controller detected.',
     }
   },
   computed: {
@@ -537,12 +538,9 @@ export default Vue.extend({
       this.retry_count += 1
     },
     async setupBoat() {
-      await fetchCurrentBoard()
-      if (!autopilot.current_board) {
-        this.board_not_detected = true
+      if (!await this.isBoardDetected()) {
         return
       }
-      this.board_not_detected = false
       this.vehicle_type = Vehicle.Rover
       this.vehicle_name = 'BlueBoat'
       this.vehicle_image = '/assets/vehicles/images/bb120.png'
@@ -603,12 +601,9 @@ export default Vue.extend({
       }
     },
     async setupROV() {
-      await fetchCurrentBoard()
-      if (!autopilot.current_board) {
-        this.board_not_detected = true
+      if (!await this.isBoardDetected()) {
         return
       }
-      this.board_not_detected = false
       this.vehicle_type = Vehicle.Sub
       this.vehicle_name = 'BlueROV'
       this.vehicle_image = '/assets/vehicles/images/bluerov2.png'
@@ -683,8 +678,7 @@ export default Vue.extend({
         .catch((error) => `Failed to disable smart wifi hotspot: ${error.message ?? error.response?.data}.`)
     },
     async installLatestStableFirmware(vehicle: Vehicle): Promise<ConfigurationStatus> {
-      await fetchCurrentBoard()
-      if (!autopilot.current_board) {
+      if (!await this.isBoardDetected()) {
         return 'No flight controller board detected.'
       }
 
@@ -772,6 +766,22 @@ export default Vue.extend({
     },
     validateParams(): boolean {
       return this.$refs.param_loader?.validateParams()
+    },
+    async isBoardDetected(): Promise<boolean> {
+      try {
+        await fetchCurrentBoard()
+      } catch (error) {
+        this.board_not_detected = true
+        this.board_detection_message = `Failed to communicate with autopilot manager: ${error}`
+        return false
+      }
+      if (!autopilot.current_board) {
+        this.board_not_detected = true
+        this.board_detection_message = 'No flight controller detected.'
+        return false
+      }
+      this.board_not_detected = false
+      return true
     },
   },
 })


### PR DESCRIPTION
fix: #3426 

before:
<img width="797" height="95" alt="image" src="https://github.com/user-attachments/assets/5e62a44b-3ec6-474b-8bb2-5489af17615f" />

after:
<img width="804" height="382" alt="image" src="https://github.com/user-attachments/assets/529531b5-bbb1-4ee7-8f9c-b49bd10383bc" />

if the board is disconnected after the customization step the correct error is shown:
<img width="805" height="110" alt="image" src="https://github.com/user-attachments/assets/aba61cb7-35c0-4059-9e20-bc159db5a42a" />

## Summary by Sourcery

Ensure the wizard checks for a connected flight controller board before running customization and firmware installation steps, and surfaces clear feedback when none is detected.

Bug Fixes:
- Prevent wizard customization steps from running when no flight controller board is connected, avoiding failures later in the flow.
- Return a clear error message from firmware installation when no flight controller board is detected instead of proceeding silently.

Enhancements:
- Display a warning alert in the wizard UI when no flight controller board is detected during vehicle setup.