### PR TITLE
frontend: kraken: Improve custom installation extension

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -57,6 +57,7 @@
             v-model="new_extension.tag"
             label="Docker tag"
             :rules="[validate_tag]"
+            @paste="handleTagPaste"
           />
 
           <json-editor
@@ -302,6 +303,16 @@ export default Vue.extend({
         setTimeout(() => {
           this.copySuccess = false
         }, 2000) // Reset after 2 seconds
+      }
+    },
+    handleTagPaste(event: ClipboardEvent) {
+      const pastedText = event.clipboardData?.getData('text')?.trim()
+      if (!pastedText) return
+
+      const colonIdx = pastedText.lastIndexOf(':')
+      if (colonIdx >= 0 && colonIdx < pastedText.length - 1) {
+        event.preventDefault()
+        this.new_extension.tag = pastedText.slice(colonIdx + 1)
       }
     },
     handlePaste(event: ClipboardEvent) {


### PR DESCRIPTION
fix: #3127

## Summary by Sourcery

Improve the extension creation modal UX for setting Docker tags and saving custom extensions.

New Features:
- Allow saving a new extension from the creation modal using the Ctrl+Enter keyboard shortcut.
- Automatically extract and populate the Docker tag from pasted values that include a repository-style prefix (e.g., image:tag) in the tag field.