### PR TITLE
frontend: kraken: only show extension logs when it is enabled

### DIFF
--- a/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
@@ -186,6 +186,7 @@
         Uninstall
       </v-btn>
       <v-btn
+        v-if="extension.enabled"
         :style="{ backgroundColor: buttonBgColor }"
         @click="$emit('showlogs', extension)"
       >


### PR DESCRIPTION
the verification on the backend will be added with #3803

## Summary by Sourcery

Bug Fixes:
- Hide the extension log viewing button for disabled extensions to prevent showing logs when the extension is not enabled.