### PR TITLE
Frontend: limit calls to /status to 0.5hz

### DIFF
--- a/core/frontend/src/store/frontend.ts
+++ b/core/frontend/src/store/frontend.ts
@@ -17,6 +17,8 @@ class FrontendStore extends VuexModule {
 
   backend_status_request = null as Promise<AxiosResponse> | null
 
+  last_backend_online_time: Date = new Date()
+
   backend_offline = false
 
   frontend_id = (() => {
@@ -32,6 +34,9 @@ class FrontendStore extends VuexModule {
 
   @Mutation
   setBackendOffline(offline: boolean): void {
+    if (!offline) {
+      this.last_backend_online_time = new Date()
+    }
     this.backend_offline = offline
   }
 }

--- a/core/frontend/src/utils/api.ts
+++ b/core/frontend/src/utils/api.ts
@@ -12,8 +12,14 @@ export const isBackendOffline = (error: any): boolean => {
   return false;
 }
 
+const minimum_backend_status_check_interval = 2000
+
 const axios_backend_instance: AxiosInstance = axios.create()
 axios_backend_instance.interceptors.request.use(async (config) => {
+  const online_recently = frontend.last_backend_online_time.getTime() + minimum_backend_status_check_interval > new Date().getTime()
+  if (online_recently) {
+    return config
+  }
   // Check if there's already a backend status request running. If yes, use it. If not, start one.
   if (frontend.backend_status_request === null) {
     frontend.setBackendStatusRequest(axios.get(frontend.backend_status_url, { timeout: 5000 }))


### PR DESCRIPTION
I was seeing requests to /status at ~3hz.
I don't expect huge improvements of performance or bandwidth, but this will at the very least making look at the network tab of developer tools more... sane.

## Summary by Sourcery

Limit frontend backend status checks to avoid excessive /status requests.

Enhancements:
- Throttle backend status polling by skipping status checks if the backend was recently online.
- Track the last time the backend was confirmed online in the frontend store to support rate limiting of status checks.