### PR TITLE
Frontend: add Homepage to extensions modal

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
@@ -15,6 +15,18 @@
           <strong>{{ compatible_version_archs.join(', ') }}</strong>
         </div>
       </div>
+      <v-btn
+        v-if="extension.website"
+        v-tooltip="'Homepage'"
+        icon
+        :href="extension.website"
+        target="_blank"
+        rel="noopener"
+      >
+        <v-icon small>
+          mdi-web
+        </v-icon>
+      </v-btn>
     </v-card-subtitle>
     <div class="px-4 pt-4 d-flex justify-space-between align-start">
       <v-select

--- a/core/frontend/src/types/kraken.ts
+++ b/core/frontend/src/types/kraken.ts
@@ -56,6 +56,7 @@ export interface ExtensionData {
     extension_logo?: string
     company_logo: string
     is_compatible?: boolean
+    website?: string
     repo_info?: {
         downloads: number,
         last_updated?: string,


### PR DESCRIPTION
I don't think I like the way this looks. feedback is appreciated

<img width="827" height="582" alt="image" src="https://github.com/user-attachments/assets/8a855eaa-ee9d-4ad3-b998-e8e25aa6e9f6" />

fix #3834

## Summary by Sourcery

Add extension homepage and improved author contact display to the extensions details modal.

New Features:
- Display an extension homepage link in the details modal when a website URL is available.

Enhancements:
- Show authors in the extension details modal with icons and mailto links instead of a plain text list.
- Extend the extension data type to include an optional website field used by the UI.

## Summary by Sourcery

Add support for displaying an extension homepage link in the extension details modal.

New Features:
- Show a homepage button in the extension details modal when an extension provides a website URL.

Enhancements:
- Extend the extension metadata type to include an optional website field used by the UI.