### PR TITLE
Fontend: fix display size of images on extension readmes

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
@@ -341,6 +341,10 @@ div.readme ul {
   margin-left: 20px;
 }
 
+div.readme img {
+  max-width: 100%;
+}
+
 .editor-control {
   margin: 0;
   opacity: 0.7;


### PR DESCRIPTION
<img width="986" height="1063" alt="Screenshot 2026-03-19 at 12 41 02" src="https://github.com/user-attachments/assets/9fd04214-58e0-429b-aa39-c331cdc58f05" />

fix #3832

## Summary by Sourcery

Bug Fixes:
- Prevent extension README images from exceeding the modal width by limiting their maximum displayed width.