### PR TITLE
frontend: video-manager: Rework thumbnails

### DIFF
--- a/core/frontend/src/components/video-manager/VideoControlsDialog.vue
+++ b/core/frontend/src/components/video-manager/VideoControlsDialog.vue
@@ -15,9 +15,9 @@
       >
         <v-card-text>
           <video-thumbnail
-            height="auto"
             width="280"
             :register="thumbnailRegister"
+            :disabled="thumbnailDisabled"
             :source="device.source"
           />
           <v-container v-if="are_controllers_available">
@@ -125,6 +125,10 @@ export default Vue.extend({
     thumbnailRegister: {
       type: Boolean,
       default: true,
+    },
+    thumbnailDisabled: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {

--- a/core/frontend/src/components/video-manager/VideoStreamCreationDialog.vue
+++ b/core/frontend/src/components/video-manager/VideoStreamCreationDialog.vue
@@ -117,8 +117,20 @@
                   label="Thermal camera"
                 />
                 <v-checkbox
+                  v-model="is_disable_lazy"
+                  label="Disable Lazy"
+                />
+                <v-checkbox
                   v-model="is_disable_mavlink"
                   label="Disable Mavlink"
+                />
+                <v-checkbox
+                  v-model="is_disable_thumbnails"
+                  label="Disable Thumbnails"
+                />
+                <v-checkbox
+                  v-model="is_disable_zenoh"
+                  label="Disable Zenoh"
                 />
               </v-expansion-panel-content>
             </v-expansion-panel>
@@ -206,7 +218,10 @@ export default Vue.extend({
           interval: undefined,
           endpoints: [''],
           thermal: false,
+          disable_lazy: false,
           disable_mavlink: false,
+          disable_thumbnails: false,
+          disable_zenoh: false,
         }
       },
     },
@@ -224,7 +239,10 @@ export default Vue.extend({
       selected_interval: this.stream.interval,
       stream_endpoints: this.stream.endpoints,
       is_thermal: this.stream.thermal,
+      is_disable_lazy: this.stream.disable_lazy,
       is_disable_mavlink: this.stream.disable_mavlink,
+      is_disable_thumbnails: this.stream.disable_thumbnails,
+      is_disable_zenoh: this.stream.disable_zenoh,
       settings,
     }
   },
@@ -259,7 +277,10 @@ export default Vue.extend({
           },
           extended_configuration: {
             thermal: this.is_thermal,
+            disable_lazy: this.is_disable_lazy,
             disable_mavlink: this.is_disable_mavlink,
+            disable_thumbnails: this.is_disable_thumbnails,
+            disable_zenoh: this.is_disable_zenoh,
           },
         },
       }
@@ -311,10 +332,36 @@ export default Vue.extend({
       return this.stream_name.replace(/[^a-z0-9]/gi, '_').toLowerCase()
     },
   },
+  watch: {
+    show(newVal: boolean) {
+      if (newVal) {
+        this.resetFormFromStream()
+      }
+    },
+  },
   mounted() {
     this.set_default_configurations()
   },
   methods: {
+    resetFormFromStream(): void {
+      const format_match = this.device.formats
+        .find((format) => format.encode === this.stream.encode)
+      const size_match = format_match?.sizes
+        .find((size) => size.width === this.stream.dimensions?.width
+          && size.height === this.stream.dimensions?.height)
+
+      this.stream_name = this.stream.name
+      this.selected_encode = this.stream.encode
+      this.selected_size = size_match || null
+      this.selected_interval = this.stream.interval
+      this.stream_endpoints = this.stream.endpoints
+      this.is_thermal = this.stream.thermal
+      this.is_disable_lazy = this.stream.disable_lazy
+      this.is_disable_mavlink = this.stream.disable_mavlink
+      this.is_disable_thumbnails = this.stream.disable_thumbnails
+      this.is_disable_zenoh = this.stream.disable_zenoh
+      this.set_default_configurations()
+    },
     validate_required_field(input: string | null): (true | string) {
       if (!this.format_required) {
         return true

--- a/core/frontend/src/components/video-manager/VideoThumbnail.vue
+++ b/core/frontend/src/components/video-manager/VideoThumbnail.vue
@@ -63,6 +63,7 @@ export default Vue.extend({
     return {
       thumbnail: undefined as undefined | Thumbnail,
       update_task: new OneMoreTime({ delay: 1000, disposeWith: this, autostart: true }),
+      stopDebounceTimer: undefined as ReturnType<typeof setTimeout> | undefined,
     }
   },
   computed: {
@@ -76,8 +77,15 @@ export default Vue.extend({
   watch: {
     register(newValue, oldValue) {
       if (!newValue && oldValue) {
-        video.stopGetThumbnailForDevice(this.source)
+        clearTimeout(this.stopDebounceTimer)
+        this.stopDebounceTimer = setTimeout(() => {
+          if (!this.register) {
+            video.stopGetThumbnailForDevice(this.source)
+          }
+        }, 15000)
       } else if (newValue && !oldValue) {
+        clearTimeout(this.stopDebounceTimer)
+        this.stopDebounceTimer = undefined
         video.startGetThumbnailForDevice(this.source)
       }
     },
@@ -89,6 +97,11 @@ export default Vue.extend({
     this.update_task.setAction(this.updateThumbnail)
   },
   beforeDestroy() {
+    clearTimeout(this.stopDebounceTimer)
+    const blobUrl = video.thumbnails.get(this.source)?.source
+    if (blobUrl !== undefined) {
+      URL.revokeObjectURL(blobUrl)
+    }
     video.stopGetThumbnailForDevice(this.source)
   },
   methods: {

--- a/core/frontend/src/components/video-manager/VideoThumbnail.vue
+++ b/core/frontend/src/components/video-manager/VideoThumbnail.vue
@@ -1,38 +1,115 @@
 <template>
   <v-container class="d-flex flex-column align-center justify-space-between">
-    <v-avatar
-      :height="height"
-      :width="width"
-      tile
+    <div
+      class="thumbnail-frame d-flex align-center justify-center"
+      :style="{ width: width + 'px', aspectRatio: '16 / 9' }"
     >
       <span
-        v-if="not_available"
-        class="text-caption"
-        style="border: 2px dashed; opacity: 30%; padding: 20px;"
+        v-if="disabled"
+        class="text-caption text-center placeholder-box"
       >
-        Preview not<br>
-        available<br>
-        Add a stream<br>
-        to have one
+        Thumbnails disabled<br>
+        for this source.
+      </span>
+      <span
+        v-else-if="not_available"
+        class="text-caption text-center placeholder-box"
+      >
+        Preview not available,<br>
+        add a stream to have one.
       </span>
       <spinning-logo
         v-else-if="fetching"
         size="10%"
         subtitle="Fetching thumbnail..."
       />
+      <span
+        v-else-if="idle_placeholder"
+        class="text-caption text-center placeholder-box"
+      >
+        Preview not requested,<br>
+        use the controls to fetch one.
+      </span>
       <img
         v-else
         :src="thumbnail?.source"
+        style="width: 100%; height: 100%; object-fit: cover;"
       >
-    </v-avatar>
+      <div
+        v-if="is_pirate_mode && register"
+        class="thumbnail-overlay text-caption"
+      >
+        <template v-if="continuous_mode">
+          LIVE
+          <template v-if="last_fetch_ms !== null">
+            {{ last_fetch_ms }}ms
+          </template>
+        </template>
+        <template v-else-if="snapshot_in_progress">
+          fetching...
+        </template>
+        <template v-else-if="thumbnail">
+          <template v-if="last_fetch_ms !== null">
+            {{ last_fetch_ms }}ms
+          </template>
+        </template>
+        <template v-else>
+          idle
+        </template>
+      </div>
+      <div
+        v-if="register"
+        class="thumbnail-controls d-flex align-center"
+      >
+        <v-tooltip bottom>
+          <template #activator="{ on, attrs }">
+            <v-btn
+              text
+              dark
+              class="control-btn"
+              :disabled="snapshot_in_progress || snapshot_cooldown || continuous_mode"
+              v-bind="attrs"
+              v-on="on"
+              @click="fetchSingleThumbnail"
+            >
+              <v-icon small>
+                mdi-camera
+              </v-icon>
+            </v-btn>
+          </template>
+          <span>Fetch a single thumbnail</span>
+        </v-tooltip>
+        <span class="control-separator">|</span>
+        <v-tooltip bottom>
+          <template #activator="{ on, attrs }">
+            <v-btn
+              text
+              dark
+              class="control-btn"
+              v-bind="attrs"
+              v-on="on"
+              @click="toggleContinuous"
+            >
+              <v-icon small>
+                {{ continuous_mode ? 'mdi-pause' : 'mdi-play' }}
+              </v-icon>
+            </v-btn>
+          </template>
+          <span>
+            {{ continuous_mode ? 'Stop continuous thumbnails' : 'Start continuous thumbnails (1s)' }}
+          </span>
+        </v-tooltip>
+      </div>
+    </div>
   </v-container>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-import { VAvatar, VContainer } from 'vuetify/lib'
+import { VContainer } from 'vuetify/lib'
 
 import SpinningLogo from '@/components/common/SpinningLogo.vue'
+import settings from '@/libs/settings'
 import { OneMoreTime } from '@/one-more-time'
 import type { Thumbnail } from '@/store/video'
 import video from '@/store/video'
@@ -40,7 +117,6 @@ import video from '@/store/video'
 export default Vue.extend({
   name: 'VideoThumbnail',
   components: {
-    VAvatar,
     VContainer,
     SpinningLogo,
   },
@@ -49,21 +125,22 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    height: {
-      type: String,
-      default: 'auto',
-    },
     width: {
       type: String,
       default: '280',
     },
     register: Boolean,
+    disabled: Boolean,
   },
   data() {
     return {
       thumbnail: undefined as undefined | Thumbnail,
       update_task: new OneMoreTime({ delay: 1000, disposeWith: this, autostart: true }),
       stopDebounceTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+      continuous_mode: false,
+      snapshot_in_progress: false,
+      snapshot_cooldown: false,
+      last_fetch_ms: null as number | null,
     }
   },
   computed: {
@@ -72,6 +149,14 @@ export default Vue.extend({
     },
     fetching(): boolean {
       return this.register && this.thumbnail === undefined
+        && (this.continuous_mode || this.snapshot_in_progress)
+    },
+    idle_placeholder(): boolean {
+      return this.register && this.thumbnail === undefined
+        && !this.continuous_mode && !this.snapshot_in_progress
+    },
+    is_pirate_mode(): boolean {
+      return settings.is_pirate_mode
     },
   },
   watch: {
@@ -81,19 +166,19 @@ export default Vue.extend({
         this.stopDebounceTimer = setTimeout(() => {
           if (!this.register) {
             video.stopGetThumbnailForDevice(this.source)
+            this.continuous_mode = false
           }
         }, 15000)
       } else if (newValue && !oldValue) {
         clearTimeout(this.stopDebounceTimer)
         this.stopDebounceTimer = undefined
-        video.startGetThumbnailForDevice(this.source)
+        if (this.continuous_mode) {
+          video.startGetThumbnailForDevice(this.source)
+        }
       }
     },
   },
   mounted() {
-    if (this.register) {
-      video.startGetThumbnailForDevice(this.source)
-    }
     this.update_task.setAction(this.updateThumbnail)
   },
   beforeDestroy() {
@@ -107,15 +192,92 @@ export default Vue.extend({
   methods: {
     async updateThumbnail() {
       const result = video.thumbnails.get(this.source)
-      if (result?.status === 200 && result?.source !== undefined) {
-        // Only accepts if the source blob URL is still valid
+      if (result?.status === 200 && result?.source !== undefined && result.source !== this.thumbnail?.source) {
         const img = new Image()
         img.src = result.source
         img.onload = () => {
+          this.last_fetch_ms = result.roundtripMs ?? null
           this.thumbnail = result
+          if (this.snapshot_in_progress) {
+            this.snapshot_in_progress = false
+            this.snapshot_cooldown = true
+            setTimeout(() => { this.snapshot_cooldown = false }, 1000)
+            video.stopGetThumbnailForDevice(this.source)
+          }
         }
+      }
+    },
+    async fetchSingleThumbnail(): Promise<void> {
+      this.snapshot_in_progress = true
+      video.startGetThumbnailForDevice(this.source)
+    },
+    toggleContinuous(): void {
+      this.continuous_mode = !this.continuous_mode
+      if (this.continuous_mode) {
+        video.startGetThumbnailForDevice(this.source)
+      } else {
+        video.stopGetThumbnailForDevice(this.source)
       }
     },
   },
 })
 </script>
+
+<style scoped>
+.thumbnail-frame {
+  position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.thumbnail-overlay {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: monospace;
+  line-height: 1.2;
+  pointer-events: none;
+}
+
+.thumbnail-controls {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 4px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.control-btn {
+  min-width: 40px !important;
+  height: 32px !important;
+  padding: 0 14px !important;
+  border-radius: 0 !important;
+  margin: 0 !important;
+  letter-spacing: normal !important;
+}
+
+.control-separator {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 18px;
+  line-height: 32px;
+  user-select: none;
+}
+
+.placeholder-box {
+  border: 2px dashed;
+  opacity: 0.3;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/core/frontend/src/store/video.ts
+++ b/core/frontend/src/store/video.ts
@@ -16,9 +16,27 @@ import back_axios, { isBackendOffline } from '@/utils/api'
 export interface Thumbnail {
   source: string | undefined
   status: number | undefined
+  roundtripMs: number | undefined
 }
 
 const notifier = new Notifier(video_manager_service)
+
+interface ThumbnailFetchState {
+  task: OneMoreTime
+  sources: Set<string>
+  busy: Set<string>
+  inProgress: boolean
+}
+
+const THUMBNAIL_STATE_KEY = '__blueos_video_thumbnail_state__'
+const thumbnailState: ThumbnailFetchState = (window as any)[THUMBNAIL_STATE_KEY] ??= {
+  task: new OneMoreTime({ delay: 1000, autostart: false }),
+  sources: new Set<string>(),
+  busy: new Set<string>(),
+  inProgress: false,
+}
+;(window as any)[THUMBNAIL_STATE_KEY] = thumbnailState
+thumbnailState.task.setDelay(1000)
 
 @Module({
   dynamic: true,
@@ -42,14 +60,6 @@ class VideoStore extends VuexModule {
   fetch_devices_error: string | null = null
 
   thumbnails: Map<string, Thumbnail> = new Map()
-
-  private sources_to_request_thumbnail: Set<string> = new Set()
-
-  private busy_sources: Set<string> = new Set()
-
-  fetchThumbnailsTask = new OneMoreTime(
-    { delay: 1000, autostart: false },
-  )
 
   @Mutation
   setUpdatingStreams(updating: boolean): void {
@@ -174,17 +184,21 @@ class VideoStore extends VuexModule {
 
   @Action
   async fetchThumbnails(): Promise<void> {
+    if (thumbnailState.inProgress) return
+    thumbnailState.inProgress = true
+
     const target_height = 150
     const quality = 75
 
     const requests: Promise<void>[] = []
 
-    this.sources_to_request_thumbnail.forEach(async (source: string) => {
-      if (this.busy_sources.has(source)) {
+    thumbnailState.sources.forEach(async (source: string) => {
+      if (thumbnailState.busy.has(source)) {
         return
       }
-      this.busy_sources.add(source)
+      thumbnailState.busy.add(source)
 
+      const requestStart = Date.now()
       const request = back_axios({
         method: 'get',
         url: `${this.API_URL}/thumbnail?source=${source}&quality=${quality}&target_height=${target_height}`,
@@ -193,29 +207,42 @@ class VideoStore extends VuexModule {
       })
         .then((response) => {
           if (response.status === 200) {
+            const roundtripMs = Date.now() - requestStart
             const old_thumbnail_source = this.thumbnails.get(source)?.source
             if (old_thumbnail_source !== undefined) {
               URL.revokeObjectURL(old_thumbnail_source)
             }
 
-            this.thumbnails.set(source, { source: URL.createObjectURL(response.data), status: response.status })
+            this.thumbnails.set(source, {
+              source: URL.createObjectURL(response.data), status: response.status, roundtripMs,
+            })
           }
         })
         .catch((error) => {
+          const roundtripMs = Date.now() - requestStart
           if (error?.response?.status === StatusCodes.SERVICE_UNAVAILABLE) {
-            this.thumbnails.set(source, { source: undefined, status: error.response.status })
+            const existing = this.thumbnails.get(source)
+            if (existing?.source) {
+              this.thumbnails.set(source, { source: existing.source, status: error.response.status, roundtripMs })
+            } else {
+              this.thumbnails.set(source, { source: undefined, status: error.response.status, roundtripMs })
+            }
           } else {
             this.thumbnails.delete(source)
           }
         })
         .finally(() => {
-          this.busy_sources.delete(source)
+          thumbnailState.busy.delete(source)
         })
 
       requests.push(request)
     })
 
-    await Promise.allSettled(requests)
+    try {
+      await Promise.allSettled(requests)
+    } finally {
+      thumbnailState.inProgress = false
+    }
   }
 
   @Action
@@ -236,26 +263,25 @@ class VideoStore extends VuexModule {
       })
   }
 
+  // eslint-disable-next-line class-methods-use-this
   @Action
   startGetThumbnailForDevice(source: string): void {
-    if (this.sources_to_request_thumbnail.size > 0) {
-      this.fetchThumbnailsTask.resume()
-    } else {
-      this.fetchThumbnailsTask.start()
+    thumbnailState.sources.add(source)
+    const task = thumbnailState.task as any
+    if (task.isPaused) {
+      thumbnailState.task.resume()
+    } else if (!task.isRunning && !task.timeoutId) {
+      thumbnailState.task.start()
     }
-    this.sources_to_request_thumbnail.add(source)
   }
 
+  // eslint-disable-next-line class-methods-use-this
   @Action
   stopGetThumbnailForDevice(source: string): void {
-    const old_thumbnail_source = this.thumbnails.get(source)?.source
-    if (old_thumbnail_source !== undefined) {
-      URL.revokeObjectURL(old_thumbnail_source)
-    }
-    this.sources_to_request_thumbnail.delete(source)
+    thumbnailState.sources.delete(source)
 
-    if (this.sources_to_request_thumbnail.size === 0) {
-      this.fetchThumbnailsTask.stop()
+    if (thumbnailState.sources.size === 0) {
+      thumbnailState.task.stop()
     }
   }
 }
@@ -264,6 +290,6 @@ export { VideoStore }
 
 const video: VideoStore = getModule(VideoStore)
 
-video.fetchThumbnailsTask.setAction(video.fetchThumbnails)
+thumbnailState.task.setAction(video.fetchThumbnails)
 
 export default video


### PR DESCRIPTION
Cherry-picks to 1.4:
- b9b8fdd9 frontend: components: video-manager: VideoThumbnail: Debounce stop and fix blob URL cleanup
- 23fcf198 frontend: store: video: Use HMR-safe singleton for thumbnail polling state
- a5d29507 frontend: components: video-manager: VideoThumbnail: Add manual thumbnail controls
- 34fc40b6 frontend: components: video-manager: VideoStreamCreationDialog: Add extended config booleans and fix form state reset

## Summary by Sourcery

Rework video thumbnail fetching and controls, improve thumbnail polling state management, and extend video stream configuration options.

New Features:
- Add manual controls to fetch single or continuous thumbnails in the video thumbnail component.
- Show thumbnail fetching latency and state overlays in pirate mode for video thumbnails.
- Expose extended stream configuration toggles for lazy mode, thumbnails, and Zenoh in the video stream creation dialog.

Bug Fixes:
- Debounce stopping of thumbnail polling when unregistering a thumbnail to avoid premature backend stop calls.
- Ensure video stream creation dialog form state is reset from the current stream each time the dialog is opened.
- Avoid revoking active thumbnail blob URLs while they are still in use.

Enhancements:
- Refine thumbnail placeholders and layout, including a disabled state for sources with thumbnails turned off.
- Refactor thumbnail polling to use a hot-reload-safe singleton state shared across the app and guard concurrent fetch cycles.
- Track and store thumbnail round-trip time in the video store for use in UI overlays.