### PR TITLE
frontend: video-manager: Add support for MCM Idle state

### DIFF
--- a/core/frontend/src/components/video-manager/VideoDevice.vue
+++ b/core/frontend/src/components/video-manager/VideoDevice.vue
@@ -8,7 +8,7 @@
               <v-icon
                 small
                 class="mr-2 mt-sm-2"
-                :color="!are_video_streams_available ? 'grey' : has_running_streams ? 'success' : 'error'"
+                :color="status_color"
                 v-bind="attrs"
                 v-on="on"
               >
@@ -18,11 +18,11 @@
             <span v-if="!are_video_streams_available">
               No streams added to this video source
             </span>
-            <span v-else-if="has_running_streams">
-              All streams running
+            <span v-else-if="has_healthy_streams">
+              Streams active
             </span>
             <span v-else>
-              Streams not running, see the errors for more information
+              Streams stopped, see the errors for more information
             </span>
           </v-tooltip>
           <p class="font-weigth-medium text-sm-h6 ma-0">
@@ -53,10 +53,10 @@
       </div>
       <div>
         <video-thumbnail
-          height="auto"
           width="280"
           :source="device.source"
-          :register="are_video_streams_available && has_running_streams"
+          :register="are_video_streams_available && has_healthy_streams && !thumbnails_disabled"
+          :disabled="thumbnails_disabled"
         />
       </div>
     </div>
@@ -89,7 +89,8 @@
     <video-controls-dialog
       v-model="show_controls_dialog"
       :device="device"
-      :thumbnail-register="are_video_streams_available && has_running_streams"
+      :thumbnail-register="are_video_streams_available && has_healthy_streams && !thumbnails_disabled"
+      :thumbnail-disabled="thumbnails_disabled"
     />
     <video-stream-creation-dialog
       v-model="show_stream_creation_dialog"
@@ -151,8 +152,22 @@ export default Vue.extend({
     has_configs(): boolean {
       return !this.device.controls.isEmpty()
     },
-    has_running_streams(): boolean {
-      return this.device_streams.some((stream) => stream.running)
+    has_healthy_streams(): boolean {
+      return this.device_streams.some((stream) => stream.state !== 'stopped')
+    },
+    thumbnails_disabled(): boolean {
+      return this.device_streams.some(
+        (stream) => stream.video_and_stream.stream_information?.extended_configuration?.disable_thumbnails === true,
+      )
+    },
+    status_color(): string {
+      if (!this.are_video_streams_available) {
+        return 'grey'
+      }
+      if (this.has_healthy_streams) {
+        return 'success'
+      }
+      return 'error'
     },
   },
   methods: {

--- a/core/frontend/src/components/video-manager/VideoStream.vue
+++ b/core/frontend/src/components/video-manager/VideoStream.vue
@@ -44,10 +44,10 @@
           Status:
         </div>
         <div class="info-value">
-          {{ stream.running ? 'Running' : 'Not running' }}
+          {{ stream_state_text }}
         </div>
 
-        <template v-if="(!stream.running) && stream.error">
+        <template v-if="stream.state === 'stopped' && stream.error">
           <div class="info-label error--text font-weight-bold">
             Errors:
           </div>
@@ -209,6 +209,14 @@ export default Vue.extend({
     }
   },
   computed: {
+    stream_state_text(): string {
+      const stateMap: Record<string, string> = {
+        running: 'Running',
+        idle: 'Idle',
+        stopped: 'Stopped',
+      }
+      return stateMap[this.stream.state] || 'Unknown'
+    },
     stream_prototype(): StreamPrototype {
       let dimensions
       if (this.stream.video_and_stream.stream_information.configuration.width
@@ -218,15 +226,18 @@ export default Vue.extend({
           height: this.stream.video_and_stream.stream_information.configuration.height,
         }
       }
+      const ext = this.stream.video_and_stream.stream_information?.extended_configuration
       return {
         name: this.stream.video_and_stream.name,
         encode: this.stream.video_and_stream.stream_information.configuration.encode,
         dimensions,
         interval: this.stream.video_and_stream.stream_information.configuration.frame_interval,
         endpoints: this.stream.video_and_stream.stream_information.endpoints,
-        thermal: this.stream.video_and_stream.stream_information?.extended_configuration?.thermal ?? false,
-        disable_mavlink:
-          this.stream.video_and_stream.stream_information?.extended_configuration?.disable_mavlink ?? false,
+        thermal: ext?.thermal ?? false,
+        disable_lazy: ext?.disable_lazy ?? false,
+        disable_mavlink: ext?.disable_mavlink ?? false,
+        disable_thumbnails: ext?.disable_thumbnails ?? false,
+        disable_zenoh: ext?.disable_zenoh ?? false,
       }
     },
     format(): string {

--- a/core/frontend/src/types/video.ts
+++ b/core/frontend/src/types/video.ts
@@ -115,7 +115,10 @@ export interface CaptureConfiguration {
 
 export interface ExtendedConfiguration {
   thermal: boolean
+  disable_lazy: boolean
   disable_mavlink: boolean
+  disable_thumbnails: boolean
+  disable_zenoh: boolean
 }
 
 export interface StreamInformation {
@@ -194,9 +197,12 @@ export interface VideoAndStreamInformation {
   video_source: VideoSourceLocal | VideoSourceGst | VideoSourceRedirect | VideoSourceOnvif
 }
 
+export type StreamStatusState = 'running' | 'idle' | 'stopped'
+
 export interface StreamStatus {
   id: string
   running: boolean
+  state: StreamStatusState
   error: string | null
   video_and_stream: VideoAndStreamInformation
 }
@@ -213,5 +219,8 @@ export interface StreamPrototype {
   interval?: FrameInterval
   endpoints: string[]
   thermal: boolean
+  disable_lazy: boolean
   disable_mavlink: boolean
+  disable_thumbnails: boolean
+  disable_zenoh: boolean
 }


### PR DESCRIPTION
To test it, one should use MCM next-13 from my fork.

Cherry-picks to 1.4:
- 6d909928 frontend: types: video: Add StreamStatusState and state field to StreamStatus
- 6ea3962a frontend: components: video-manager: VideoDevice: Update stream status handling for new state field
- 3eb791e2 frontend: components: video-manager: VideoStream: Update status display for new state field

## Summary by Sourcery

Update video manager frontend to support extended stream states and configuration flags, including idle state handling and thumbnail control.

New Features:
- Display human-readable stream state based on a new state field supporting running, idle, and stopped.
- Expose additional extended configuration flags (lazy mode, thumbnails, zenoh) on video streams and prototypes.

Enhancements:
- Adjust device-level status indicators and messaging to reflect overall stream health rather than simple running state.
- Control thumbnail registration and disabled state based on stream health and per-stream configuration flags.

## Summary by Sourcery

Update video manager frontend to use new stream state metadata and extended configuration flags for device status, stream display, and thumbnails.

New Features:
- Show human-readable stream status based on a new state field supporting running, idle, stopped, and unknown states.
- Expose additional extended stream configuration flags (lazy mode, thumbnails, zenoh) via the stream prototype model.

Enhancements:
- Base device-level health indicators and tooltip messaging on overall stream state instead of simple running flags.
- Control video thumbnail registration and disabled state using per-stream configuration and health, including support for disabling thumbnails globally on a device.