### PR TITLE
frontend: kraken: add dedicated displays for installing/updating

### DIFF
--- a/core/frontend/src/components/kraken/BackAlleyTab.vue
+++ b/core/frontend/src/components/kraken/BackAlleyTab.vue
@@ -255,6 +255,8 @@
             :key="extension.identifier + extension.name"
             :extension="extension"
             :installed="installed_extensions"
+            :active-operation-identifier="activeOperationIdentifier"
+            :active-operation-type="activeOperationType"
             :imgs-processed="imgs_processed"
             @selected="$emit('clicked', extension)"
             @update="update"
@@ -308,6 +310,14 @@ export default Vue.extend({
       type: Object as PropType<undefined | Record<string, InstalledExtensionData>>,
       required: false,
       default: undefined,
+    },
+    activeOperationIdentifier: {
+      type: String as PropType<string | null>,
+      default: null,
+    },
+    activeOperationType: {
+      type: String as PropType<string | null>,
+      default: null,
     },
   },
   data() {

--- a/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/StoreExtensionCard.vue
@@ -97,6 +97,7 @@
             small
             class="ml-1"
             :color="is_installed ? 'success' : 'primary'"
+            :disabled="is_installing"
             v-bind="attrs"
             v-on="on"
             @click="performActionClick"
@@ -135,6 +136,14 @@ export default Vue.extend({
       type: Array as PropType<InstalledExtensionData[]>,
       required: true,
     },
+    activeOperationIdentifier: {
+      type: String as PropType<string | null>,
+      default: null,
+    },
+    activeOperationType: {
+      type: String as PropType<string | null>,
+      default: null,
+    },
     imgsProcessed: {
       type: Object as PropType<Record<string, ImgProcessedResult>>,
       required: true,
@@ -156,6 +165,9 @@ export default Vue.extend({
     },
     is_installed(): boolean {
       return this.installed_extension !== undefined
+    },
+    is_installing(): boolean {
+      return this.extension.identifier === this.activeOperationIdentifier
     },
     update_available_tag(): undefined | string {
       if (this.is_installed && this.installed_extension?.tag) {
@@ -183,6 +195,9 @@ export default Vue.extend({
       return archs.join(', ')
     },
     action_button_text(): string {
+      if (this.is_installing) {
+        return this.activeOperationType === 'update' ? 'UPDATING...' : 'INSTALLING...'
+      }
       if (!this.is_installed) {
         return 'GET'
       }

--- a/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
@@ -32,6 +32,7 @@
       <v-select
         v-model="selected_version"
         :items="available_tags"
+        :disabled="isInstalling"
         label="Version"
         outlined
         dense
@@ -61,16 +62,16 @@
       <v-tooltip :disabled="extension.is_compatible" bottom>
         <template #activator="{ on, attrs }">
           <v-btn
-            :disabled="!extension.is_compatible || !is_version_compatible"
+            :disabled="!extension.is_compatible || !is_version_compatible || isInstalling"
+            :loading="isInstalling"
             width="120px"
             height="40px"
             :color="is_installed ? 'error' : 'primary'"
-
             v-bind="attrs"
             v-on="on"
             @click="performAction"
           >
-            {{ is_installed ? 'Uninstall' : 'Install' }}
+            {{ is_installed ? 'Uninstall' : (isInstalling ? 'Installing...' : 'Install') }}
           </v-btn>
         </template>
         <span>No versions available for this architecture</span>
@@ -206,6 +207,10 @@ export default Vue.extend({
       type: Object as PropType<InstalledExtensionData>,
       default: null,
       required: false,
+    },
+    isInstalling: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -1049,9 +1049,10 @@ export default Vue.extend({
       kraken.uninstallExtension(extension.identifier)
         .then(() => {
           this.fetchInstalledExtensions()
+          notifier.pushSuccess('EXTENSION_UNINSTALL_SUCCESS', `${extension.name} uninstalled successfully.`, true)
         })
         .catch((error) => {
-          notifier.pushBackError('EXTENSIONS_UNINSTALL_FAIL', error)
+          notifier.pushBackError('EXTENSION_UNINSTALL_FAIL', error)
         })
         .finally(() => {
           this.setLoading(extension, false)

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -16,6 +16,7 @@
         :extension="selected_extension"
         :installed="installedVersion()"
         :installed-extension="installedExtension()"
+        :is-installing="active_operation_identifier !== null"
         @clicked="performActionFromModal"
       />
     </v-dialog>
@@ -290,6 +291,8 @@
       v-show="is_back_alley_tab"
       :manifest="manifest"
       :installed-extensions="installed_extensions"
+      :active-operation-identifier="active_operation_identifier"
+      :active-operation-type="active_operation_type"
       @clicked="showModal"
       @update="update"
       @refresh="fetchManifest"
@@ -471,6 +474,8 @@ function currentStepForPhase(phase: TarInstallPhase): TarStepKey {
 
 const notifier = new Notifier(kraken_service)
 const ansi = new AnsiUp()
+const ACTIVE_OPERATION_KEY = 'blueos-extension-operation'
+const ACTIVE_OPERATION_TYPE_KEY = 'blueos-extension-operation-type'
 
 export default Vue.extend({
   name: 'ExtensionManagerView',
@@ -531,6 +536,8 @@ export default Vue.extend({
       install_from_file_error: null as null | string,
       install_from_file_failed_step: null as null | TarStepKey,
       install_from_file_last_level: -1,
+      active_operation_identifier: localStorage.getItem(ACTIVE_OPERATION_KEY) as null | string,
+      active_operation_type: (localStorage.getItem(ACTIVE_OPERATION_TYPE_KEY) ?? null) as null | 'install' | 'update',
     }
   },
   computed: {
@@ -818,6 +825,7 @@ export default Vue.extend({
       }
     },
     async update(extension: InstalledExtensionData, version: string) {
+      this.setInstallingState(extension.identifier, 'update')
       this.show_pull_output = true
       const tracker = this.getTracker()
       kraken.updateExtensionToVersion(
@@ -827,13 +835,15 @@ export default Vue.extend({
       )
         .then(() => {
           this.fetchInstalledExtensions()
+          notifier.pushSuccess('EXTENSION_UPDATE_SUCCESS', `${extension.name} updated successfully.`, true)
         })
         .catch((error) => {
           this.alerter = true
           this.alerter_error = String(error)
-          notifier.pushBackError('EXTENSIONS_INSTALL_FAIL', error)
+          notifier.pushBackError('EXTENSION_UPDATE_FAIL', error)
         })
         .finally(() => {
+          this.clearInstallingState()
           this.resetPullOutput()
         })
     },
@@ -886,8 +896,22 @@ export default Vue.extend({
     async fetchRunningContainers(): Promise<void> {
       try {
         this.running_containers = await kraken.listContainers()
+        this.clearStaleInstallingState()
       } catch (error) {
         notifier.pushBackError('RUNNING_CONTAINERS_FETCH_FAIL', error)
+      }
+    },
+    clearStaleInstallingState(): void {
+      if (!this.active_operation_identifier || this.show_pull_output) return
+      const ext = this.installed_extensions[this.active_operation_identifier]
+      if (!ext) return
+      const is_running = this.running_containers.some(
+        (container) => container.image === `${ext.docker}:${ext.tag}`,
+      )
+      if (is_running) {
+        const action = this.active_operation_type === 'update' ? 'updated' : 'installed'
+        notifier.pushSuccess('EXTENSION_OPERATION_SUCCESS', `${ext.name} ${action} successfully.`, true)
+        this.clearInstallingState()
       }
     },
     async fetchContainersStats(): Promise<void> {
@@ -966,6 +990,7 @@ export default Vue.extend({
       this.selected_extension = extension
     },
     async install(extension: InstalledExtensionData) {
+      this.setInstallingState(extension.identifier, 'install')
       this.show_dialog = false
       this.show_pull_output = true
       const tracker = this.getTracker()
@@ -976,6 +1001,7 @@ export default Vue.extend({
       )
         .then(() => {
           this.fetchInstalledExtensions()
+          notifier.pushSuccess('EXTENSION_INSTALL_SUCCESS', `${extension.name} installed successfully.`, true)
         })
         .catch((error) => {
           this.alerter = true
@@ -983,6 +1009,7 @@ export default Vue.extend({
           notifier.pushBackError('EXTENSIONS_INSTALL_FAIL', error)
         })
         .finally(() => {
+          this.clearInstallingState()
           this.resetPullOutput()
         })
     },
@@ -1203,6 +1230,18 @@ export default Vue.extend({
       } finally {
         this.resetPullOutput()
       }
+    },
+    setInstallingState(identifier: string, action: 'install' | 'update'): void {
+      this.active_operation_identifier = identifier
+      this.active_operation_type = action
+      localStorage.setItem(ACTIVE_OPERATION_KEY, identifier)
+      localStorage.setItem(ACTIVE_OPERATION_TYPE_KEY, action)
+    },
+    clearInstallingState(): void {
+      this.active_operation_identifier = null
+      this.active_operation_type = null
+      localStorage.removeItem(ACTIVE_OPERATION_KEY)
+      localStorage.removeItem(ACTIVE_OPERATION_TYPE_KEY)
     },
   },
 })


### PR DESCRIPTION
also added feedback when an extension is installed/uninstalled.

This PR also partially addresses #1398 (point 1).

<img width="296" height="68" alt="image" src="https://github.com/user-attachments/assets/fa7faaa3-3860-4727-be60-89d62905075f" />
<br>
<img width="299" height="136" alt="image" src="https://github.com/user-attachments/assets/9277b7f1-7914-4e4a-8246-03b307f5e101" />


fix: #3632

## Summary by Sourcery

Add explicit installing/updating state handling for Kraken extensions and surface it in the UI.

New Features:
- Show in-card and modal feedback while an extension is being installed or updated, including disabled controls and loading states.
- Persist the active extension installation/update operation in local storage to restore UI state across reloads and detect successful completion based on running containers.
- Display success notifications when extensions are installed, updated, or uninstalled.

Bug Fixes:
- Correct notification keys for extension update and uninstall failure messages to use operation-specific identifiers.

Enhancements:
- Propagate active operation metadata through Kraken extension list and detail components to coordinate UI state.
- Automatically clear stale installing state when containers indicate an extension operation has completed.