### PR TITLE
frontend: video-manager: Add block list support for MCM sources

### DIFF
--- a/core/frontend/src/components/video-manager/VideoDevice.vue
+++ b/core/frontend/src/components/video-manager/VideoDevice.vue
@@ -15,7 +15,10 @@
                 mdi-circle
               </v-icon>
             </template>
-            <span v-if="!are_video_streams_available">
+            <span v-if="device.blocked">
+              Video source is blocked
+            </span>
+            <span v-else-if="!are_video_streams_available">
               No streams added to this video source
             </span>
             <span v-else-if="has_healthy_streams">
@@ -43,12 +46,21 @@
           </v-btn>
           <v-btn
             class="my-1"
-            :disabled="!is_redirect_source && (are_video_streams_available || updating_streams)"
+            :disabled="device.blocked || (!is_redirect_source && (are_video_streams_available || updating_streams))"
             @click="openStreamCreationDialog"
           >
             <v-icon>mdi-plus</v-icon>
             Add stream
           </v-btn>
+          <v-switch
+            v-if="is_pirate_mode"
+            :input-value="device.blocked"
+            dense
+            hide-details
+            class="mt-2"
+            label="Block source"
+            @change="toggleBlocked"
+          />
         </div>
       </div>
       <div>
@@ -104,6 +116,7 @@
 import Vue, { PropType } from 'vue'
 
 import SpinningLogo from '@/components/common/SpinningLogo.vue'
+import settings from '@/libs/settings'
 import video from '@/store/video'
 import {
   CreatedStream, Device, StreamStatus,
@@ -160,7 +173,13 @@ export default Vue.extend({
         (stream) => stream.video_and_stream.stream_information?.extended_configuration?.disable_thumbnails === true,
       )
     },
+    is_pirate_mode(): boolean {
+      return settings.is_pirate_mode
+    },
     status_color(): string {
+      if (this.device.blocked) {
+        return 'warning'
+      }
       if (!this.are_video_streams_available) {
         return 'grey'
       }
@@ -176,6 +195,14 @@ export default Vue.extend({
     },
     openStreamCreationDialog(): void {
       this.show_stream_creation_dialog = true
+    },
+
+    async toggleBlocked(): Promise<void> {
+      if (this.device.blocked) {
+        await video.unblockSource(this.device.source)
+      } else {
+        await video.blockSource(this.device.source)
+      }
     },
 
     async createNewStream(stream: CreatedStream): Promise<void> {

--- a/core/frontend/src/store/video.ts
+++ b/core/frontend/src/store/video.ts
@@ -246,6 +246,42 @@ class VideoStore extends VuexModule {
   }
 
   @Action
+  async blockSource(source: string): Promise<void> {
+    await back_axios({
+      method: 'post',
+      url: `${this.API_URL}/block_source`,
+      timeout: 10000,
+      params: { source_string: source },
+    })
+      .then(() => {
+        this.fetchDevices()
+        this.fetchStreams()
+      })
+      .catch((error) => {
+        const message = `Could not block video source: ${error.message}.`
+        notifier.pushError('VIDEO_SOURCE_BLOCK_FAIL', message)
+      })
+  }
+
+  @Action
+  async unblockSource(source: string): Promise<void> {
+    await back_axios({
+      method: 'post',
+      url: `${this.API_URL}/unblock_source`,
+      timeout: 10000,
+      params: { source_string: source },
+    })
+      .then(() => {
+        this.fetchDevices()
+        this.fetchStreams()
+      })
+      .catch((error) => {
+        const message = `Could not unblock video source: ${error.message}.`
+        notifier.pushError('VIDEO_SOURCE_UNBLOCK_FAIL', message)
+      })
+  }
+
+  @Action
   async resetSettings(): Promise<void> {
     await back_axios({
       url: `${this.API_URL}/reset_settings`,

--- a/core/frontend/src/types/video.ts
+++ b/core/frontend/src/types/video.ts
@@ -98,6 +98,7 @@ export interface Device {
   source: string
   formats: Format[]
   controls: Control[]
+  blocked?: boolean
 }
 
 export enum VideoCaptureType {


### PR DESCRIPTION
`master` counterpart of the 1.4 PR: https://github.com/bluerobotics/BlueOS/pull/3837

This branch **includes the commits from the thumbnail rework and MCM Idle `master` PRs** so the UI and types stay consistent and CI can pass.

**Suggested merge order:** merge the thumbnail and Idle PRs to `master` first, then **rebase this branch onto `master`** so this PR collapses to a single commit (the block-list change) before final merge.

Related `master` PRs:
- Thumbnail rework: https://github.com/bluerobotics/BlueOS/pull/3844
- MCM Idle: https://github.com/bluerobotics/BlueOS/pull/3845

Block-list commit: `33e42773` (equivalent to the rebased 1.4 head).

## Summary by Sourcery

Add video source block list support and enhanced thumbnail controls to the video manager UI and store.

New Features:
- Allow blocking and unblocking video sources from the video manager, including visual status and controls.
- Expose per-stream options to disable lazy mode, mavlink, thumbnails, and Zenoh in the stream creation and editing UI.
- Provide user-facing controls to fetch single or continuous thumbnails per device, with idle/disabled states and debug overlay in pirate mode.

Enhancements:
- Refine device and stream status handling to distinguish running, idle, and stopped states and update corresponding UI text and colors.
- Centralize thumbnail fetch scheduling in a shared, window-scoped state, tracking round-trip latency and preventing overlapping requests.
- Improve thumbnail placeholder and layout styling and ensure blob URLs are cleaned up when thumbnails are updated or components destroyed.

## Summary by Sourcery

Add support in the video manager to block and unblock video sources and reflect their blocked status in the UI and device model.

New Features:
- Introduce Vuex actions to block and unblock video sources via backend API and refresh devices/streams afterward.
- Expose a block/unblock control for each video device in the video manager (pirate mode only) and prevent adding streams to blocked sources.
- Extend the video device type to track whether a source is blocked and display corresponding status text and color in the UI.