### PR TITLE
[Backport] Fix thumbnail dashboard card

### DIFF
--- a/core/frontend/src/components/video-manager/VideoThumbnail.vue
+++ b/core/frontend/src/components/video-manager/VideoThumbnail.vue
@@ -33,7 +33,7 @@
       <img
         v-else
         :src="thumbnail?.source"
-        style="width: 100%; height: 100%; object-fit: cover;"
+        style="width: 100%; height: 100%; object-fit: contain;"
       >
       <div
         v-if="is_pirate_mode && register"
@@ -230,6 +230,7 @@ export default Vue.extend({
   overflow: hidden;
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.08);
+  max-height: 100%;
 }
 
 .thumbnail-overlay {


### PR DESCRIPTION
## Summary
- Backport of #3849 into 1.4
- Stop click propagation on VideoThumbnail controls so buttons don't trigger parent navigation
- Constrain thumbnail frame height and use `object-fit: contain` so the full image fits within its parent

## Test plan
- [x] Verify camera thumbnail play/camera buttons work without navigating away
- [x] Verify thumbnail image is fully contained within its parent card

## Summary by Sourcery

Backport video thumbnail interaction and layout improvements to the 1.4 branch.

Bug Fixes:
- Prevent video thumbnail control clicks from triggering parent navigation actions.

Enhancements:
- Ensure video thumbnails are fully visible within their container by constraining frame height and using contained object-fit behavior.