### PR TITLE
frontend: prevent external-link extensions from showing as active in the sidebar

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -123,7 +123,7 @@
           nav
           dense
         >
-          <v-list-item-group color="primary">
+          <v-list-item-group :color="menu.new_page ? undefined : 'primary'">
             <v-list-group
               v-if="menu.submenus"
               :id="`button-to-${menu.title.toLowerCase().replace(' ', '-')}`"
@@ -208,6 +208,7 @@
             <v-list-item
               v-else
               :id="`button-to-${menu.title.toLowerCase().replace(' ', '-')}`"
+              :class="{ 'external-link': menu.new_page }"
               :to="menu.new_page || menu.disabled ? null : menu.route"
               :target="menu.new_page ? '_blank' : '_self'"
               :href="menu.extension && !menu.disabled ? menu.route : undefined"
@@ -935,6 +936,11 @@ export default Vue.extend({
 ::-webkit-scrollbar-thumb:hover {
   background: var(--v-primary-base);
 }
+
+.external-link.v-list-item--active::before {
+  opacity: 0 !important;
+}
+
 </style>
 
 <style scoped>


### PR DESCRIPTION
fix #2521 

remove highlight/color if the item opens in a new tab (aka is a new_page)

## Summary by Sourcery

Adjust sidebar navigation styling so external-link menu entries that open in a new tab are not shown as active.

Bug Fixes:
- Prevent external-link sidebar items that open in a new tab from being highlighted as active.

Enhancements:
- Introduce a dedicated CSS class and conditional color binding to distinguish external-link sidebar items from normal navigation entries.