### PR TITLE
frontend: views: ExtensionManagerView: center extension manager tabs

### DIFF
--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -216,10 +216,17 @@
       :extension-name="selected_log_extension_name"
     />
     <v-toolbar>
-      <v-spacer />
+      <v-btn
+        icon
+        class="extension-toolbar-spacer"
+        aria-hidden="true"
+        tabindex="-1"
+      />
       <v-tabs
         v-model="tab"
         fixed-tabs
+        show-arrows
+        class="extension-tabs flex-grow-1"
       >
         <v-tab key="0" href="#0" class="tab-text">
           <v-icon class="mr-3">
@@ -240,11 +247,9 @@
           Installed
         </v-tab>
       </v-tabs>
-      <v-spacer />
       <v-btn
         v-tooltip="'Settings'"
         icon
-        hide-details="auto"
         @click="show_settings = true"
       >
         <v-icon>mdi-cog</v-icon>
@@ -1212,6 +1217,15 @@ pre.logs {
 
 .tab-text {
   white-space: nowrap !important;
+}
+
+.extension-tabs {
+  min-width: 0;
+}
+
+.extension-toolbar-spacer {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .scrollable-content {


### PR DESCRIPTION
fix #2942 

before: 
<img width="1578" height="250" alt="image" src="https://github.com/user-attachments/assets/6b5cf023-9156-404c-b354-48c2d519aecf" />

zoomed-in:
<img width="1807" height="507" alt="image" src="https://github.com/user-attachments/assets/18e8f605-4f8e-41f2-9870-bc28bf11e84b" />


after:
<img width="1577" height="264" alt="image" src="https://github.com/user-attachments/assets/99c9ecec-7e1e-4eec-90d8-860f50558790" />

zoomed-in:
<img width="1735" height="416" alt="image" src="https://github.com/user-attachments/assets/0209d835-d0f3-4f97-9e38-2562f6f3f388" />

## Summary by Sourcery

Center the extension manager tab bar while keeping the settings button consistently positioned.

Enhancements:
- Adjust ExtensionManagerView toolbar layout so tabs fill available space and remain centered across viewport sizes.
- Pin the extension manager settings button to the right side of the toolbar on larger screens for a stable, predictable location.