### PR TITLE
frontend: settings: make user reboot after reset settings operation

### DIFF
--- a/core/frontend/src/views/SettingsView.vue
+++ b/core/frontend/src/views/SettingsView.vue
@@ -474,8 +474,11 @@
           </v-card-text>
           <v-card-actions>
             <v-spacer />
-            <v-btn color="primary" text @click="show_reset_dialog = false">
-              Close
+            <v-btn color="primary" @click="reboot_system">
+              <v-icon left>
+                mdi-restart-alert
+              </v-icon>
+              Reboot
             </v-btn>
           </v-card-actions>
         </v-card>
@@ -494,6 +497,8 @@ import Notifier from '@/libs/notifier'
 import settings from '@/libs/settings'
 import { OneMoreTime } from '@/one-more-time'
 import bag from '@/store/bag'
+import commander from '@/store/commander'
+import { ShutdownType } from '@/types/commander'
 import { commander_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
 import { prettifySize } from '@/utils/helper_functions'
@@ -664,6 +669,10 @@ export default Vue.extend({
           notifier.pushBackError('RESET_SETTINGS_FAIL', error)
         })
       this.operation_in_progress = false
+    },
+
+    reboot_system(): void {
+      commander.shutdown(ShutdownType.Reboot)
     },
 
     async remove_service_log_files(): Promise<void> {

--- a/core/frontend/src/views/SettingsView.vue
+++ b/core/frontend/src/views/SettingsView.vue
@@ -461,7 +461,7 @@
         @confirm="onConfirmClearLogs"
       />
 
-      <v-dialog width="400" :value="show_reset_dialog" @input="show_reset_dialog = false">
+      <v-dialog width="400" :value="show_reset_dialog" persistent @input="show_reset_dialog = false">
         <v-card>
           <v-card-title class="text-h6">
             <v-icon left color="success">


### PR DESCRIPTION
fix: #1723 

Since the success message of reset settings is to restart the system I changed the requested reload page button to reboot.

<img width="454" height="214" alt="image" src="https://github.com/user-attachments/assets/b3c90a37-214c-4394-9d3c-ae9718473af8" />

## Summary by Sourcery

Enhancements:
- Make the reset-settings success dialog persistent and replace the close action with a reboot action that initiates a system restart.