### PR TITLE
fix(i2c): prevent file descriptor leak in SMBus usage

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
@@ -23,8 +23,8 @@ class LinuxFlightController(FlightController):
 
     def check_for_i2c_device(self, bus_number: int, address: int) -> bool:
         try:
-            bus = SMBus(bus_number)
-            bus.read_byte_data(address, 0)
+            with SMBus(bus_number) as bus:
+                bus.read_byte_data(address, 0)
             return True
         except OSError:
             return False


### PR DESCRIPTION
Tested on Raspberry Pi with repeated I2C scans.  

Fix a file descriptor leak in check_for_i2c_device.

SMBus instances were opened without being closed, causing file descriptors to accumulate over time. In long-running scenarios, this could reach the system ulimit and trigger:

    OSError: [Errno 24] Too many open files

As a result, flight controller boards may fail to be detected or become inaccessible.

### Changes
- Use context manager (`with SMBus(...) as bus`) to ensure proper cleanup

### Impact
- Prevents FD exhaustion
- Improves reliability of board detection

## Summary by Sourcery

Bug Fixes:
- Fix a file descriptor leak in I2C SMBus usage during device detection that could lead to exhausting available file handles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized resource-management change that preserves existing behavior while reducing the chance of FD exhaustion during repeated I2C scans.
> 
> **Overview**
> Prevents file descriptor leaks during I2C probing by switching `LinuxFlightController.check_for_i2c_device` to use `with SMBus(bus_number) as bus` so the bus handle is always closed after each check.
> 
> This improves reliability of repeated board-detection scans that call `check_for_i2c_device` (e.g., in `navigator.py`) by avoiding exhaustion of open file descriptors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59240a8856691d0d603cfbb6f017f39304fd2f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->