### PR TITLE
Update board_identification.py

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
@@ -25,7 +25,7 @@ identifiers: List[SerialBoardIdentifier] = [
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v6X.x", platform=Platform.Pixhawk6X),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v6C.x", platform=Platform.Pixhawk6C),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="CubeOrange", platform=Platform.CubeOrange),
-    SerialBoardIdentifier(attribute=SerialAttr.manufacturer, id_value="ArduPilot", platform=Platform.GenericSerial),
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="USB-Serial Controller D", platform=Platform.GenericSerial),
     SerialBoardIdentifier(attribute=SerialAttr.manufacturer, id_value="Arduino", platform=Platform.GenericSerial),
     SerialBoardIdentifier(attribute=SerialAttr.manufacturer, id_value="3D Robotics", platform=Platform.GenericSerial),
     SerialBoardIdentifier(attribute=SerialAttr.manufacturer, id_value="Hex/ProfiCNC", platform=Platform.GenericSerial),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct generic serial board detection by matching on the 'USB-Serial Controller D' product string rather than the ArduPilot manufacturer field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to device-identification heuristics; main risk is misclassifying some serial devices if the new product string is not broadly applicable.
> 
> **Overview**
> Fixes generic serial flight-controller detection by updating `board_identification.identifiers` to match `Platform.GenericSerial` on the `product` value `USB-Serial Controller D` rather than the `manufacturer` value `ArduPilot`.
> 
> This changes which serial devices are classified as generic serial during detection in `flight_controller_detector/Detector.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53fca8ac1f66daef330e3c2f384c3386e96b402f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->