### PR TITLE
frontend:ExtensionManagerView: Disable Bazaar

### DIFF
--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -223,11 +223,11 @@
       >
         <v-tab key="0" href="#0" class="tab-text">
           <v-icon class="mr-3">
-            {{ settings.is_dev_mode ? 'mdi-incognito' : 'mdi-store-search' }}
+            {{ is_bazaar_enabled ? 'mdi-incognito' : 'mdi-store-search' }}
           </v-icon>
-          {{ settings.is_dev_mode ? 'Back Alley' : 'Store' }}
+          {{ is_bazaar_enabled ? 'Back Alley' : 'Store' }}
         </v-tab>
-        <v-tab v-if="settings.is_dev_mode" key="1" href="#1" class="tab-text">
+        <v-tab v-if="is_bazaar_enabled" key="1" href="#1" class="tab-text">
           <v-icon class="mr-3">
             mdi-package-variant
           </v-icon>
@@ -521,6 +521,10 @@ export default Vue.extend({
     },
     is_installed_tab(): boolean {
       return this.tab === '2'
+    },
+    is_bazaar_enabled(): boolean {
+      /** NOTE: Force disable of bazaar for now */
+      return this.settings.is_dev_mode && false
     },
     manifest_as_data(): ExtensionData[] {
       if (this.manifest === undefined || typeof this.manifest === 'string') {


### PR DESCRIPTION
Remove Bazaar from UI for now but leave code available to restore in future.

## Summary by Sourcery

Enhancements:
- Gate Bazaar-specific tabs and labels in the extension manager behind a new computed flag that currently forces Bazaar to remain disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating change that hides a tab via a computed flag; no backend, auth, or data-flow changes.
> 
> **Overview**
> Disables the Bazaar UI in `ExtensionManagerView` by introducing a single `is_bazaar_enabled` flag and wiring all Bazaar/Back Alley tab rendering and labeling through it.
> 
> `is_bazaar_enabled` is currently hardcoded to `false` (even in dev mode), so the Bazaar tab is hidden and the first tab consistently shows the Store icon/label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7feddd75bebcc11f7421d4ffa0712aa16e014c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->