### PR TITLE
frontend: kraken: prevent container-not-up icon from overlapping update button

### DIFF
--- a/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
@@ -8,28 +8,29 @@
         size="150"
       />
     </div>
-    <v-icon
-      v-if="extension.enabled && !container && !loading"
-      v-tooltip="'This extension is enabled but the container is not running.'"
-      class="container-not-up-alert"
-      color="warning"
-      size="35"
-    >
-      mdi-robot-dead
-    </v-icon>
     <v-card-title class="pb-1 d-flex justify-space-between align-center">
       <div class="d-flex align-center">
-        <v-avatar
+        <v-badge
           v-if="extensionData && extensionData.extension_logo"
-          size="60"
-          class="mr-3"
-          rounded="0"
+          v-tooltip="container_not_up ? 'This extension is enabled but the container is not running.' : ''"
+          :value="container_not_up"
+          overlap
+          offset-x="7"
+          offset-y="10"
+          color="warning"
+          icon="mdi-robot-dead"
+          class="mr-3 container-not-up-badge"
         >
-          <v-img
-            :src="extensionData.extension_logo"
-            :alt="extension.name"
-          />
-        </v-avatar>
+          <v-avatar
+            size="60"
+            rounded="0"
+          >
+            <v-img
+              :src="extensionData.extension_logo"
+              :alt="extension.name"
+            />
+          </v-avatar>
+        </v-badge>
         <div>
           <div>{{ extension.name }}</div>
           <span
@@ -292,6 +293,9 @@ export default Vue.extend({
     buttonBgColor() {
       return settings.is_dark_theme ? '#20455e' : '#BDE0F0'
     },
+    container_not_up(): boolean {
+      return this.extension.enabled && !this.container && !this.loading
+    },
     update_available() : false | string {
       if (!this.extensionData) {
         return false
@@ -426,9 +430,15 @@ export default Vue.extend({
   z-index: 9999 !important;
 }
 
-.container-not-up-alert {
-  position: absolute;
-  right: 13px;
-  top: 13px;
+.container-not-up-badge ::v-deep .v-badge__badge {
+  min-width: 20px;
+  height: 20px;
+  padding: 0;
+  opacity: 0.9;
 }
+
+.container-not-up-badge ::v-deep .v-badge__badge .v-icon {
+  font-size: 18px;
+}
+
 </style>

--- a/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
@@ -8,28 +8,27 @@
         size="150"
       />
     </div>
-    <v-icon
-      v-if="extension.enabled && !container && !loading"
-      v-tooltip="'This extension is enabled but the container is not running.'"
-      class="container-not-up-alert"
-      color="warning"
-      size="35"
-    >
-      mdi-robot-dead
-    </v-icon>
     <v-card-title class="pb-1 d-flex justify-space-between align-center flex-nowrap card-title">
       <div class="d-flex align-center title-info">
-        <v-avatar
+        <v-badge
           v-if="extensionData && extensionData.extension_logo"
-          size="60"
-          class="mr-3 flex-shrink-0"
-          rounded="0"
+          v-tooltip="container_not_up && 'This extension is enabled but the container is not running.'"
+          :value="container_not_up"
+          overlap
+          color="warning"
+          icon="mdi-robot-dead"
+          class="mr-3 flex-shrink-0 container-not-up-badge"
         >
-          <v-img
-            :src="extensionData.extension_logo"
-            :alt="extension.name"
-          />
-        </v-avatar>
+          <v-avatar
+            size="60"
+            rounded="0"
+          >
+            <v-img
+              :src="extensionData.extension_logo"
+              :alt="extension.name"
+            />
+          </v-avatar>
+        </v-badge>
         <div class="title-text">
           <div
             v-tooltip="extension.name"
@@ -300,6 +299,9 @@ export default Vue.extend({
     buttonBgColor() {
       return settings.is_dark_theme ? '#20455e' : '#BDE0F0'
     },
+    container_not_up(): boolean {
+      return this.extension.enabled && !this.container && !this.loading
+    },
     update_available() : false | string {
       if (!this.extensionData) {
         return false
@@ -445,9 +447,22 @@ export default Vue.extend({
   z-index: 9999 !important;
 }
 
-.container-not-up-alert {
-  position: absolute;
-  right: 13px;
-  top: 13px;
+.container-not-up-badge ::v-deep .v-badge__badge {
+  min-width: 26px;
+  height: 26px;
+  padding: 0;
+  border-radius: 50%;
+  top: 0 !important;
+  right: 0 !important;
+  bottom: auto !important;
+  left: auto !important;
+  transform: translate(50%, -50%);
+}
+
+.container-not-up-badge ::v-deep .v-badge__badge .v-icon {
+  font-size: 18px;
+  margin: 0;
+  line-height: 1;
+  transform: translateY(0.25em);
 }
 </style>


### PR DESCRIPTION
looks like this now:
<img width="109" height="113" alt="image" src="https://github.com/user-attachments/assets/168c1a09-a542-42a4-b7b1-ed9ea94eafe3" />


## Summary by Sourcery

Indicate the container-not-running state on the installed extension card using a badge over the extension logo instead of an overlapping standalone icon.

Enhancements:
- Replace the absolute-positioned container-not-up icon with a warning badge over the extension logo to avoid overlapping other controls.
- Introduce a computed flag for the container-not-up state to centralize the visibility condition.
- Adjust badge styling to keep the warning icon compact and visually consistent with the card layout.