### PR TITLE
Add missing identifiers for commonly used flight controllers

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
@@ -22,6 +22,8 @@ identifiers: List[SerialBoardIdentifier] = [
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v3.x", platform=Platform.Pixhawk1),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="Pixhawk4", platform=Platform.Pixhawk4),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v5.x", platform=Platform.Pixhawk4),
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="CUAVv5", platform=Platform.Pixhawk4),
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="Pixhawk6X", platform=Platform.Pixhawk6X),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v6X.x", platform=Platform.Pixhawk6X),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v6C.x", platform=Platform.Pixhawk6C),
     SerialBoardIdentifier(attribute=SerialAttr.product, id_value="CubeOrange", platform=Platform.CubeOrange),


### PR DESCRIPTION
This update adds missing board identifiers for commonly used flight controllers that were not previously recognized.

## Summary by Sourcery

Add support for additional flight controller board identifiers in the ArduPilot manager detector.

New Features:
- Recognize CUAVv5 boards as Pixhawk4 platform via serial product identification.
- Recognize Pixhawk6X boards as Pixhawk6X platform via serial product identification.