### PR TITLE
Backports/1.4/longer hashes

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -7,7 +7,7 @@ ENV GIT_DESCRIBE_TAGS=${GIT_DESCRIBE_TAGS:-0.0.0-0-g00000000}
 RUN <<-EOF
 set -e
 
-    if ! echo "$GIT_DESCRIBE_TAGS" | grep -Eq -- '-[0-9]+-g[a-f0-9]{8}$'; then
+    if ! echo "$GIT_DESCRIBE_TAGS" | grep -Eq -- '-[0-9]+-g[a-f0-9]{8,}$'; then
         echo "Invalid format: $GIT_DESCRIBE_TAGS (E.g: <TAG>-<COMMIT_NUMBER>-g<SHORT_HASH>)"
         exit 1
     fi

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -55,7 +55,7 @@ set -e
         exit 1
     fi
 
-    if ! echo "$GIT_DESCRIBE_TAGS" | grep -Eq -- '-[0-9]+-g[a-f0-9]{8}$'; then
+    if ! echo "$GIT_DESCRIBE_TAGS" | grep -Eq -- '-[0-9]+-g[a-f0-9]{8,}$'; then
         echo "Invalid format: $GIT_DESCRIBE_TAGS (E.g: <TAG>-<COMMIT_NUMBER>-g<SHORT_HASH>)"
         exit 1
     fi


### PR DESCRIPTION
This is a backport of https://github.com/bluerobotics/BlueOS/pull/3614 into 1.4

.. I made this change locally while building the `next` branches, but forgot to send it.