### PR TITLE
[backport] trigger frontend to re-download parameters

### DIFF
--- a/core/frontend/src/components/autopilot/BoardChangeDialog.vue
+++ b/core/frontend/src/components/autopilot/BoardChangeDialog.vue
@@ -38,6 +38,7 @@
 import Vue from 'vue'
 
 import Notifier from '@/libs/notifier'
+import autopilot_data from '@/store/autopilot'
 import autopilot from '@/store/autopilot_manager'
 import { FlightController, FlightControllerFlags } from '@/types/autopilot'
 import { autopilot_service } from '@/types/frontend_services'
@@ -98,6 +99,7 @@ export default Vue.extend({
       })
         .then(() => {
           this.form.reset()
+          autopilot_data.reset()
         })
         .catch((error) => {
           notifier.pushBackError('AUTOPILOT_BOARD_CHANGE_FAIL', error)


### PR DESCRIPTION
This is a backport of https://github.com/bluerobotics/BlueOS/pull/3623 into 1.4

## Summary by Sourcery

Backport changes to ensure the frontend reliably re-downloads autopilot parameters when the board or autopilot configuration is reset.

Bug Fixes:
- Prevent stale parameter messages from being processed immediately after a reset by temporarily ignoring websocket updates.
- Ensure the autopilot store is fully reset after a board change so that parameters are fetched fresh.