### PR TITLE
[backports] core:services:cable-guy: Fix static IP not recover

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -902,8 +902,8 @@ class EthernetManager:
                     if not any(addr.mode == AddressMode.Client for addr in current_interface.addresses):
                         logger.info(f"Mismatch detected for {current_interface.name}: missing dhcp client address")
                         mismatches.add(saved_interface)
-                # Handle Server and Unmanaged modes
-                elif saved_address.mode in [AddressMode.Server, AddressMode.Unmanaged]:
+                # Handle Server/BackupServer and Unmanaged modes
+                elif saved_address.mode in [AddressMode.Server, AddressMode.BackupServer, AddressMode.Unmanaged]:
                     if saved_address not in current_interface.addresses:
                         logger.info(
                             f"Mismatch detected for {current_interface.name}: "


### PR DESCRIPTION
This is a backport of https://github.com/bluerobotics/BlueOS/pull/3634 into 1.4

## Summary by Sourcery

Bug Fixes:
- Ensure network configuration mismatch detection also treats BackupServer addresses like Server and Unmanaged modes so static/server IPs can be recovered correctly after changes.