### PR TITLE
Video Manager: Check default route ip for RTSP availability

### DIFF
--- a/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
+++ b/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
@@ -44,7 +44,14 @@ export default Vue.extend({
       return video.available_streams.map((x) => x.video_and_stream.stream_information.endpoints).flat(1)
     },
     has_accessible_rtsp_streams(): boolean {
-      return !this.all_streams.filter((x) => x.toLowerCase().startsWith(`rtsp://${this.vehicle_ip_address}`)).isEmpty()
+      return !this.all_streams
+        .filter((x) => {
+          const route = x.toLowerCase()
+          return (
+            route.startsWith(`rtsp://${this.vehicle_ip_address}`) || route.startsWith('rtsp://0.0.0.0')
+          )
+        })
+        .isEmpty()
     },
     has_accessible_udp_streams(): boolean {
       return !this.all_streams.filter((x) => x.toLowerCase().startsWith(`udp://${this.user_ip_address}`)).isEmpty()

--- a/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
+++ b/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
@@ -13,7 +13,8 @@
         elevation="2"
         dismissible
       >
-        It looks like there's no video stream accessible from your device's detected IP address ({{ user_ip_address }}).
+        It looks like no available video streams are configured to reach your device's detected IP address
+        ({{ user_ip_address }}).
         <span v-if="is_connected_to_wifi">
           That should be fine if you are using this wi-fi connection for something other than piloting.
         </span>


### PR DESCRIPTION
@dgudiel reported that the existing error display check was giving a false positive for a default, working RadCam setup:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/cd5b7bfd-af2e-44d3-86f7-5633bcb68a3d" />

---

This PR includes the default route (`0.0.0.0`) in that check, and clarifies the error message for when it does occur.

## Summary by Sourcery

Improve video diagnostic handling of RTSP stream availability for default-routed cameras.

Bug Fixes:
- Account for RTSP streams bound to the default route (0.0.0.0) when determining if any camera streams are accessible.

Enhancements:
- Clarify the user-facing error message shown when no accessible video streams are detected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/diagnostic logic tweak that only affects when the Video Manager shows a warning; no auth, persistence, or backend behavior changes.
> 
> **Overview**
> Updates `VideoDiagnosticHelper.vue` to treat RTSP endpoints using the default route (`rtsp://0.0.0.0`) as accessible in addition to the vehicle IP, reducing false “no stream accessible” warnings.
> 
> Rewords the warning text to more clearly indicate that streams may simply not be configured to reach the client IP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a8764970206049eb9c17ede1a4685c2e7b2d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->