### PR TITLE
[backport/1.4] core:frontend:views:MainView: Fix check internet 

### DIFF
--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -6,7 +6,7 @@
       no-gutters
     >
       <v-alert
-        v-if="!current_network"
+        v-if="!has_internet"
         border="top"
         colored-border
         type="info"
@@ -95,8 +95,8 @@ import Vue from 'vue'
 
 import SelfHealthTest from '@/components/health/SelfHealthTest.vue'
 import settings from '@/libs/settings'
-import wifi from '@/store/wifi'
-import { Network } from '@/types/wifi'
+import helper from '@/store/helper'
+import { InternetConnectionState } from '@/types/helper'
 
 import menus, { menuItem } from '../menus'
 
@@ -126,8 +126,8 @@ export default Vue.extend({
       }
       return items
     },
-    current_network(): Network | null {
-      return wifi.current_network
+    has_internet(): boolean {
+      return helper.has_internet !== InternetConnectionState.OFFLINE
     },
   },
 })


### PR DESCRIPTION
This is a backport from https://github.com/bluerobotics/BlueOS/pull/3619 into 1.4

* Make sure the connect to internet banner only appears when no internet connection is available instead of WiFi network

## Summary by Sourcery

Bug Fixes:
- Correct the internet connection banner condition so it only appears when there is no internet connectivity instead of when no Wi‑Fi network is selected.