### PR TITLE
[backport/1.4] Video Manager: Check default route ip for RTSP availability

### DIFF
--- a/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
+++ b/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
@@ -44,7 +44,14 @@ export default Vue.extend({
       return video.available_streams.map((x) => x.video_and_stream.stream_information.endpoints).flat(1)
     },
     has_accessible_rtsp_streams(): boolean {
-      return !this.all_streams.filter((x) => x.toLowerCase().startsWith(`rtsp://${this.vehicle_ip_address}`)).isEmpty()
+      return !this.all_streams
+        .filter((x) => {
+          const route = x.toLowerCase()
+          return (
+            route.startsWith(`rtsp://${this.vehicle_ip_address}`) || route.startsWith('rtsp://0.0.0.0')
+          )
+        })
+        .isEmpty()
     },
     has_accessible_udp_streams(): boolean {
       return !this.all_streams.filter((x) => x.toLowerCase().startsWith(`udp://${this.user_ip_address}`)).isEmpty()

--- a/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
+++ b/core/frontend/src/components/video-manager/VideoDiagnosticHelper.vue
@@ -13,7 +13,8 @@
         elevation="2"
         dismissible
       >
-        It looks like there's no video stream accessible from your device's detected IP address ({{ user_ip_address }}).
+        It looks like no available video streams are configured to reach your device's detected IP address
+        ({{ user_ip_address }}).
         <span v-if="is_connected_to_wifi">
           That should be fine if you are using this wi-fi connection for something other than piloting.
         </span>


### PR DESCRIPTION
Backport from https://github.com/bluerobotics/BlueOS/pull/3893

## Summary by Sourcery

Update video diagnostics to better detect RTSP stream availability when using the default route and clarify messaging when no accessible streams are found.

Enhancements:
- Include RTSP streams bound to 0.0.0.0 in accessibility checks alongside vehicle-specific IP streams.
- Refine user-facing diagnostic text to describe lack of reachable video streams rather than a single IP-specific issue.