### PR TITLE
core: autopilot_manager: Check for 'should_start_on_boot'

### DIFF
--- a/core/services/ardupilot_manager/api/v1/routers/index.py
+++ b/core/services/ardupilot_manager/api/v1/routers/index.py
@@ -236,6 +236,7 @@ async def restart() -> Any:
 @index_to_http_exception
 async def start() -> Any:
     logger.debug("Starting ardupilot...")
+    autopilot.set_start_on_boot(True)
     await autopilot.start_ardupilot()
     logger.debug("Ardupilot successfully started.")
 
@@ -264,6 +265,7 @@ def available_routers() -> Any:
 @index_to_http_exception
 async def stop() -> Any:
     logger.debug("Stopping ardupilot...")
+    autopilot.set_start_on_boot(False)
     await autopilot.kill_ardupilot()
     logger.debug("Ardupilot successfully stopped.")
 

--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -414,6 +414,21 @@ class AutoPilotManager(metaclass=Singleton):
         except KeyError:
             return None
 
+    def set_start_on_boot(self, enabled: bool) -> None:
+        # self.configuration is only created in setup(), fall back to building
+        # off self.settings.content when called pre-setup.
+        # e.g. /start right after a boot where auto-start was disabled
+        if not hasattr(self, "configuration"):
+            content = dict(self.settings.content)
+            content["start_on_boot"] = enabled
+            self.settings.save(content)
+            return
+        self.configuration["start_on_boot"] = enabled
+        self.settings.save(self.configuration)
+
+    def should_start_on_boot(self) -> bool:
+        return bool(self.settings.content.get("start_on_boot", True))
+
     def get_available_routers(self) -> List[str]:
         return [router.name() for router in self.mavlink_manager.available_interfaces()]
 

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -38,10 +38,14 @@ async def main() -> None:
 
     if args.sitl:
         autopilot.set_preferred_board(BoardDetector.detect_sitl())
-    try:
-        await autopilot.start_ardupilot()
-    except Exception as start_error:
-        logger.exception(start_error)
+
+    if autopilot.should_start_on_boot():
+        try:
+            await autopilot.start_ardupilot()
+        except Exception as start_error:
+            logger.exception(start_error)
+    else:
+        logger.info("Autopilot was stopped by the user, skipping auto-start on boot.")
 
     asyncio.create_task(autopilot.auto_restart_ardupilot())
     asyncio.create_task(autopilot.start_mavlink_manager_watchdog())


### PR DESCRIPTION
Fix #2135

## Summary by Sourcery

Gate ArduPilot auto-start on boot on a persisted user preference and expose controls via the API.

New Features:
- Add persistent start_on_boot setting to control whether ArduPilot should auto-start on boot.
- Expose start_on_boot toggling through the existing start and stop API endpoints.

Bug Fixes:
- Prevent automatically restarting ArduPilot on boot when the user has previously stopped it via the API.

Enhancements:
- Improve logging around auto-start behavior and configuration changes to aid debugging.