### PR TITLE
frontend: kraken: InstalledExtensionCard: Fix style of cards in different pages sizes

### DIFF
--- a/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
@@ -17,12 +17,12 @@
     >
       mdi-robot-dead
     </v-icon>
-    <v-card-title class="pb-1 d-flex justify-space-between align-center">
-      <div class="d-flex align-center">
+    <v-card-title class="pb-1 d-flex justify-space-between align-center flex-nowrap card-title">
+      <div class="d-flex align-center title-info">
         <v-avatar
           v-if="extensionData && extensionData.extension_logo"
           size="60"
-          class="mr-3"
+          class="mr-3 flex-shrink-0"
           rounded="0"
         >
           <v-img
@@ -30,10 +30,16 @@
             :alt="extension.name"
           />
         </v-avatar>
-        <div>
-          <div>{{ extension.name }}</div>
+        <div class="title-text">
+          <div
+            v-tooltip="extension.name"
+            class="text-truncate"
+          >
+            {{ extension.name }}
+          </div>
           <span
-            class="d-block"
+            v-tooltip="extension.tag"
+            class="d-block text-truncate"
             style="color: grey;"
           >
             {{ extension.tag }}
@@ -42,8 +48,10 @@
       </div>
       <v-btn
         v-if="update_available"
-        class="card-update-button"
+        v-tooltip="`Update to ${update_available}`"
+        class="card-update-button ml-2 flex-shrink-0"
         color="primary"
+        small
         @click="$emit('update', extension, update_available)"
       >
         Update to {{ update_available }}
@@ -394,22 +402,33 @@ export default Vue.extend({
   max-width: 300px;
 }
 
+.card-title {
+  gap: 8px;
+}
+
+.title-info {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.title-text {
+  min-width: 0;
+  overflow: hidden;
+}
+
 .card-update-button {
-  width: 200px;
   font-size: 0.8rem;
+  max-width: 100%;
+}
+
+.card-update-button :deep(.v-btn__content) {
+  white-space: nowrap;
 }
 
 @media (max-width: 994px) {
   .main-card {
     width: 600px;
     min-width: 400px;
-  }
-}
-
-@media (max-width: 545px) {
-  .card-update-button {
-    margin-top: 5px;
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
Old:
<img width="3568" height="1123" alt="old-1" src="https://github.com/user-attachments/assets/041df713-462c-455c-8190-fbfeeba8a461" />
New:
<img width="3567" height="1190" alt="fix-1" src="https://github.com/user-attachments/assets/9fcc6701-df40-43cb-95e4-8b177cbf387f" />

Old:
<img width="3362" height="1897" alt="old-2" src="https://github.com/user-attachments/assets/81a264f0-941e-4448-b2d9-3acc6275b381" />
New:
<img width="3372" height="1860" alt="fix-2" src="https://github.com/user-attachments/assets/04487808-5a58-4ea2-9848-5f7cd2fbb9ff" />

## Summary by Sourcery

Improve the layout and responsiveness of the InstalledExtensionCard header and update button across different page sizes.

Bug Fixes:
- Prevent the extension name, tag, avatar, and update button from overlapping or wrapping awkwardly on smaller screens by adjusting flex behavior and truncation.
- Ensure the update button remains usable and visually consistent at various widths by constraining its size and preserving its content on a single line.

Enhancements:
- Add text truncation to the extension name and tag and introduce spacing adjustments for a cleaner card header presentation.
- Add a tooltip and smaller sizing to the update button to surface the target version more clearly without expanding the card layout.