### PR TITLE
core: tools: nginx: Add a 404 if extension is not registered

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -313,6 +313,19 @@ http {
         location ~ ^/redirect-port/(?<port>\d+) {
             return 301 $scheme://$host:$port;
         }
+
+        # Catch-all for unknown extensions: returns a real 404 instead of
+        # falling through to the Vue SPA.
+        location ^~ /extensionv2/ {
+            error_page 404 = @extension_not_found;
+            return 404;
+        }
+
+        location @extension_not_found {
+            default_type application/json;
+            return 404 '{"error":"extension_not_found","message":"No registered extension matches this URL, the extension might not be running or installed."}';
+        }
+
         include /home/pi/tools/nginx/extensions/*.conf;
     }
 }


### PR DESCRIPTION
Fix #3904

## Summary by Sourcery

Bug Fixes:
- Ensure unknown /extensionv2/ routes return a 404 error rather than being handled by the single-page application.