### PR TITLE
core: frontend: libs: message-messager: Fix callback order

### DIFF
--- a/core/frontend/src/libs/message-manager.ts
+++ b/core/frontend/src/libs/message-manager.ts
@@ -6,7 +6,7 @@ class MessageManager {
   private static instance: MessageManager
 
   callbacks: ((level: MessageLevel, message: string) => void)[] = [
-    (message, level) => {
+    (level, message) => {
       switch (level) {
         case MessageLevel.Success:
           console.log(message)


### PR DESCRIPTION
The emitMessage function calls (level, message) and not (message, level)

## Summary by Sourcery

Bug Fixes:
- Fix the default message callback parameter ordering so it receives (level, message) instead of (message, level).