### PR TITLE
Add usb-power rules to disable autosuspend

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -204,6 +204,7 @@ echo "Going to install BlueOS version ${VERSION}."
 
 echo "Downloading and installing udev rules."
 curl -fsSL $ROOT/install/udev/100.autopilot.rules -o /etc/udev/rules.d/100.autopilot.rules
+curl -fsSL $ROOT/install/udev/110.usb-power.rules -o /etc/udev/rules.d/110.usb-power.rules
 
 if [ -f /etc/dhcpcd.conf ]
 then

--- a/install/udev/110.usb-power.rules
+++ b/install/udev/110.usb-power.rules
@@ -1,0 +1,5 @@
+# Disable USB autosuspend for all USB devices.
+# Power management can suspend USB peripherals which causes them to disappear
+# or move to the `interface_disabled` state, breaking hotspots, cameras and
+# other functionality.
+ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="on"


### PR DESCRIPTION
Helps #3906

## Summary by Sourcery

New Features:
- Add installation of usb-power udev rules to disable USB autosuspend on relevant devices.