### PR TITLE
frontend: components: VersionChooser: Update remote version when the user click in reset

### DIFF
--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -103,7 +103,7 @@
             name="BlueOS Remote Repository"
             label="Remote repository"
             :append-icon="selected_image != default_repository ? 'mdi-restore' : undefined"
-            @click:append="selected_image = default_repository"
+            @click:append="resetToDefaultRepository()"
           />
         </v-form>
         <v-alert
@@ -707,6 +707,10 @@ export default Vue.extend({
     },
     isBeingDeleted(image: Version) {
       return this.deleting === `${image.repository}:${image.tag}`
+    },
+    resetToDefaultRepository() {
+      this.selected_image = this.default_repository
+      this.loadAvailableVersions()
     },
   },
 })


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace inline state assignment on the reset icon with a dedicated resetToDefaultRepository method that also reloads available versions.