### PR TITLE
ci: claude-pr-review: Add missing id-token

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,6 +18,7 @@ jobs:
           && github.event.pull_request.user.type != 'Bot' }}
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
     steps:
       # SECURITY: do not pass `ref:` here. `pull_request_target` checks out the


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the claude-pr-review GitHub Actions workflow to include id-token: write in the job permissions.