### PR TITLE
ci: test-and-deploy: Print img checksum

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -346,6 +346,9 @@ jobs:
             echo "ASSET_NAME_SUFFIX=-pi4" >> $GITHUB_ENV
           fi
 
+      - name: Print image checksum
+        run: sha256sum deploy/pimod/blueos.img
+
       - name: Zip image
         run: |
           sudo apt install zip


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a CI step to output the SHA-256 checksum of deploy/pimod/blueos.img during the test-and-deploy workflow.