### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.24.1

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.24.0"
+VERSION="t3.24.1"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
This is a backport of https://github.com/bluerobotics/BlueOS/pull/3924 into 1.4.

## Summary by Sourcery

Enhancements:
- Align mavlink-camera-manager version in bootstrap script with upstream t3.24.1 release.