### PR TITLE
refresh ethernet interfaces immediately after write actions

### DIFF
--- a/core/frontend/src/components/ethernet/EthernetManager.vue
+++ b/core/frontend/src/components/ethernet/EthernetManager.vue
@@ -3,20 +3,20 @@
     elevation="1"
     width="400"
   >
-    <v-expansion-panels v-if="are_interfaces_available && !updating_interfaces">
+    <v-expansion-panels v-show="are_interfaces_available && !updating_interfaces">
       <interface-card
         v-for="(ethernet_interface, key) in available_interfaces"
         :key="key"
         :adapter="ethernet_interface"
       />
     </v-expansion-panels>
-    <v-container v-else-if="updating_interfaces">
+    <v-container v-if="updating_interfaces">
       <spinning-logo
         size="30%"
         subtitle="Fetching available ethernet interfaces..."
       />
     </v-container>
-    <v-container v-else>
+    <v-container v-else-if="!are_interfaces_available">
       <div>
         No ethernet interfaces available
       </div>

--- a/core/frontend/src/components/ethernet/EthernetUpdater.vue
+++ b/core/frontend/src/components/ethernet/EthernetUpdater.vue
@@ -12,11 +12,17 @@ export default Vue.extend({
   name: 'EthernetUpdater',
   data() {
     return {
-      fetch_available_interfaces_task: new OneMoreTime({ delay: 5000, disposeWith: this }),
+      fetch_available_interfaces_task: new OneMoreTime({ delay: 5000, disposeWith: this, autostart: false }),
     }
   },
-  mounted() {
-    this.fetch_available_interfaces_task.setAction(this.fetchAvailableEthernetInterfaces)
+  async mounted() {
+    try {
+      await this.fetchAvailableEthernetInterfaces()
+    } finally {
+      ethernet.setUpdatingInterfaces(false)
+      this.fetch_available_interfaces_task.setAction(this.fetchAvailableEthernetInterfaces)
+      this.fetch_available_interfaces_task.start()
+    }
   },
   methods: {
     async fetchAvailableEthernetInterfaces(): Promise<void> {

--- a/core/frontend/src/components/ethernet/EthernetUpdater.vue
+++ b/core/frontend/src/components/ethernet/EthernetUpdater.vue
@@ -17,20 +17,12 @@ export default Vue.extend({
   },
   async mounted() {
     try {
-      await this.fetchAvailableEthernetInterfaces()
+      await ethernet.refreshInterfaces()
     } finally {
       ethernet.setUpdatingInterfaces(false)
-      this.fetch_available_interfaces_task.setAction(this.fetchAvailableEthernetInterfaces)
+      this.fetch_available_interfaces_task.setAction(() => ethernet.refreshInterfaces())
       this.fetch_available_interfaces_task.start()
     }
-  },
-  methods: {
-    async fetchAvailableEthernetInterfaces(): Promise<void> {
-      await ethernet.getAvailableEthernetInterfaces()
-        .then((response) => {
-          ethernet.setInterfaces(response.data)
-        })
-    },
   },
 })
 </script>

--- a/core/frontend/src/components/ethernet/InterfaceCard.vue
+++ b/core/frontend/src/components/ethernet/InterfaceCard.vue
@@ -319,16 +319,12 @@ export default Vue.extend({
       await ethernet.deleteAddress({ interface_name: this.adapter.name, ip_address: ip })
     },
     async triggerForDynamicIP(): Promise<void> {
-      ethernet.setUpdatingInterfaces(true)
-
       await ethernet.triggerDynamicIP(this.adapter.name)
     },
     openDHCPServerDialog(): void {
       this.show_dhcp_server_dialog = true
     },
     async removeDHCPServer(): Promise<void> {
-      ethernet.setUpdatingInterfaces(true)
-
       await ethernet.RemoveDHCPServer(this.adapter.name)
     },
     async fetchLeases(): Promise<void> {

--- a/core/frontend/src/store/ethernet.ts
+++ b/core/frontend/src/store/ethernet.ts
@@ -32,7 +32,6 @@ class EthernetStore extends VuexModule {
   @Mutation
   setInterfaces(ethernet_interfaces: EthernetInterface[]): void {
     this.available_interfaces = ethernet_interfaces
-    this.updating_interfaces = false
   }
 
   @Action
@@ -52,6 +51,10 @@ class EthernetStore extends VuexModule {
         notifier.pushBackError('ETHERNET_ADDRESS_CREATION_FAIL', error)
         throw error
       })
+      .finally(async () => {
+        await this.context.dispatch('refreshInterfaces')
+        this.context.commit('setUpdatingInterfaces', false)
+      })
   }
 
   @Action
@@ -70,6 +73,10 @@ class EthernetStore extends VuexModule {
       .catch((error) => {
         notifier.pushError('ETHERNET_ADDRESS_DELETE_FAIL', error)
         throw error
+      })
+      .finally(async () => {
+        await this.context.dispatch('refreshInterfaces')
+        this.context.commit('setUpdatingInterfaces', false)
       })
   }
 
@@ -91,13 +98,16 @@ class EthernetStore extends VuexModule {
         notifier.pushBackError('DHCP_SERVER_ADD_FAIL', error)
         throw error
       })
-      .finally(() => {
+      .finally(async () => {
+        await this.context.dispatch('refreshInterfaces')
         this.context.commit('setUpdatingInterfaces', false)
       })
   }
 
   @Action
   async RemoveDHCPServer(interface_name: string): Promise<void> {
+    this.context.commit('setUpdatingInterfaces', true)
+
     await back_axios({
       method: 'delete',
       url: `${this.API_URL}/dhcp`,
@@ -109,6 +119,10 @@ class EthernetStore extends VuexModule {
       .catch((error) => {
         const message = `Could not remove DHCP server from interface '${interface_name}': ${error.message}.`
         notifier.pushError('DHCP_SERVER_REMOVE_FAIL', message)
+      })
+      .finally(async () => {
+        await this.context.dispatch('refreshInterfaces')
+        this.context.commit('setUpdatingInterfaces', false)
       })
   }
 
@@ -190,6 +204,16 @@ class EthernetStore extends VuexModule {
   }
 
   @Action
+  async refreshInterfaces(): Promise<void> {
+    try {
+      const response = await this.context.dispatch('getAvailableEthernetInterfaces')
+      this.context.commit('setInterfaces', response.data)
+    } catch {
+      // Errors are already pushed to the notifier by getAvailableEthernetInterfaces.
+    }
+  }
+
+  @Action
   async setInterfacesPriority(interfaces: { name: string, priority: number }[]): Promise<void> {
     await back_axios({
       method: 'post',
@@ -213,6 +237,8 @@ class EthernetStore extends VuexModule {
 
   @Action
   async triggerDynamicIP(interface_name: string): Promise<void> {
+    this.context.commit('setUpdatingInterfaces', true)
+
     await back_axios({
       method: 'post',
       url: `${this.API_URL}/dynamic_ip`,
@@ -224,6 +250,10 @@ class EthernetStore extends VuexModule {
       .catch((error) => {
         const message = `Could not trigger for dynamic IP address on '${interface_name}': ${error.message}.`
         notifier.pushError('DYNAMIC_IP_TRIGGER_FAIL', message)
+      })
+      .finally(async () => {
+        await this.context.dispatch('refreshInterfaces')
+        this.context.commit('setUpdatingInterfaces', false)
       })
   }
 }

--- a/core/frontend/src/store/ethernet.ts
+++ b/core/frontend/src/store/ethernet.ts
@@ -24,6 +24,8 @@ class EthernetStore extends VuexModule {
 
   updating_interfaces = true
 
+  latest_refresh_id = 0
+
   @Mutation
   setUpdatingInterfaces(updating: boolean): void {
     this.updating_interfaces = updating
@@ -205,9 +207,14 @@ class EthernetStore extends VuexModule {
 
   @Action
   async refreshInterfaces(): Promise<void> {
+    const refresh_id = this.latest_refresh_id + 1
+    this.context.commit('setLatestRefreshId', refresh_id)
+
     try {
       const response = await this.context.dispatch('getAvailableEthernetInterfaces')
-      this.context.commit('setInterfaces', response.data)
+      if (refresh_id === this.latest_refresh_id) {
+        this.context.commit('setInterfaces', response.data)
+      }
     } catch {
       // Errors are already pushed to the notifier by getAvailableEthernetInterfaces.
     }
@@ -255,6 +262,11 @@ class EthernetStore extends VuexModule {
         await this.context.dispatch('refreshInterfaces')
         this.context.commit('setUpdatingInterfaces', false)
       })
+  }
+
+  @Mutation
+  setLatestRefreshId(refresh_id: number): void {
+    this.latest_refresh_id = refresh_id
   }
 }
 

--- a/core/libs/commonwealth/src/commonwealth/utils/decorators.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/decorators.py
@@ -9,6 +9,9 @@ F = TypeVar("F", bound=Callable[..., Any])
 def temporary_cache(timeout_seconds: float = 10) -> Callable[[F], F]:
     """Decorator that creates a cache for specific inputs with a configured timeout in seconds.
 
+    The wrapped function exposes an `invalidate()` attribute that drops every cached entry,
+    forcing the next call to re-execute the function.
+
     Args:
         timeout_seconds (float, optional): Timeout to be used for cache invalidation. Defaults to 10.
 
@@ -35,6 +38,11 @@ def temporary_cache(timeout_seconds: float = 10) -> Callable[[F], F]:
             cache[args] = function_return
             return function_return
 
+        def invalidate() -> None:
+            cache.clear()
+            last_sample_time.clear()
+
+        wrapper.invalidate = invalidate  # type: ignore[attr-defined]
         return wrapper  # type: ignore
 
     return inner_function

--- a/core/libs/commonwealth/src/commonwealth/utils/tests/test_decorators.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/tests/test_decorators.py
@@ -24,3 +24,16 @@ def test_nested_settings_save_load() -> None:
 
     # Check if all cache values are invalid after waiting for a long time
     assert all(original_output[key] != cached_function(key) for key in inputs)
+
+
+def test_temporary_cache_invalidate() -> None:
+    inputs = ["first", "second", "third"]
+    original_output = {key: cached_function(key) for key in inputs}
+
+    # Cache is still warm: same call returns the same value
+    assert all(original_output[key] == cached_function(key) for key in inputs)
+
+    # Force invalidation; subsequent calls must re-execute the function
+    cached_function.invalidate()  # type: ignore[attr-defined]
+
+    assert all(original_output[key] != cached_function(key) for key in inputs)

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -312,6 +312,8 @@ class EthernetManager:
         self._settings.content = [interface for interface in self._settings.content if interface.name != interface_name]
         self._settings.content.append(updated_interface)
         self._manager.save()
+        # OS state has just been mutated; drop the cached view so the next read returns fresh data.
+        self.get_ethernet_interfaces.invalidate()  # type: ignore[attr-defined]
 
     def add_static_ip(self, interface_name: str, ip: str, mode: AddressMode = AddressMode.Unmanaged) -> None:
         """Set ip address for a specific interface and saves it to the settings file
@@ -477,6 +479,7 @@ class EthernetManager:
 
         return result
 
+    @temporary_cache(timeout_seconds=10)
     def get_ethernet_interfaces(self, include_dhcp_markers: bool = False) -> List[NetworkInterface]:
         """Get ethernet interfaces information
 

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -36,7 +36,6 @@ app.router.route_class = GenericErrorHandlingRoute
 
 @app.get("/ethernet", response_model=List[NetworkInterface], summary="Retrieve ethernet interfaces.")
 @version(1, 0)
-@temporary_cache(timeout_seconds=10)
 def retrieve_ethernet_interfaces() -> Any:
     """REST API endpoint to retrieve the configured ethernet interfaces."""
     return manager.get_ethernet_interfaces()


### PR DESCRIPTION
fix #3076

## Summary by Sourcery

Refresh ethernet interfaces immediately after configuration changes and improve UI loading behavior for ethernet management.

Bug Fixes:
- Ensure ethernet interfaces are re-fetched after creating, deleting, or modifying addresses, DHCP servers, or triggering dynamic IP to keep the UI in sync with backend state.
- Prevent the ethernet interfaces list from getting stuck in an updating state by centralizing updating flag handling in the store and updater component.

Enhancements:
- Introduce a dedicated action to refresh available ethernet interfaces and reuse it across ethernet-related actions.
- Adjust ethernet manager UI conditions to show loading indicators while interfaces are updating and only show the 'no interfaces' message when none are available.
- Change the ethernet updater to perform an immediate initial fetch before starting the periodic refresh task and disable automatic start of the polling task.

Chores:
- Remove temporary caching on the backend endpoint that retrieves ethernet interfaces to always return current interface information.