### PR TITLE
core: start-blueos-core: Remove zenoh from mavlink-camera-manager

### DIFF
--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -117,7 +117,7 @@ find /usr/blueos/userdata -type f -exec chmod a+rw {} \;
 PRIORITY_SERVICES=(
     'autopilot',0,0,0,0,"nice --19 $SERVICES_PATH/ardupilot_manager/main.py"
     'cable_guy',0,0,0,0,"$SERVICES_PATH/cable_guy/main.py"
-    'video',0,0,0,0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --mavlink-camera-component-id-range=100-105 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --stun-server stun://stun.l.google.com:19302 --zenoh --enable-realtime-threads --verbose"
+    'video',0,0,0,0,"nice --19 mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --mavlink-system-id $MAV_SYSTEM_ID --mavlink-camera-component-id-range=100-105 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/services/mavlink-camera-manager --stun-server stun://stun.l.google.com:19302 --enable-realtime-threads --verbose"
     'mavlink2rest',0,0,0,0,"mavlink2rest --connect=udpout:127.0.0.1:14001 --server [::]:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
 )
 


### PR DESCRIPTION
This is a temporary solution until will work to a better video recording/extraction

## Summary by Sourcery

Enhancements:
- Simplify mavlink-camera-manager startup by dropping zenoh-related usage in the core startup sequence.