### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.25.0

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.24.1"
+VERSION="t3.25.0"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
This is a backport of #3940 into 1.4-dev.

## Summary by Sourcery

Enhancements:
- Align mavlink-camera-manager tooling with upstream t3.25.0 release in the 1.4-dev branch.