### PR TITLE
frontend: kraken: KrakenManager: Move from 2min to 30min to upload tar file

### DIFF
--- a/core/frontend/src/components/kraken/KrakenManager.ts
+++ b/core/frontend/src/components/kraken/KrakenManager.ts
@@ -339,7 +339,7 @@ export async function uploadExtensionTarFile(
     headers: {
       'Content-Type': 'multipart/form-data',
     },
-    timeout: 120000,
+    timeout: 30 * 60 * 1000,
     onUploadProgress: progressHandler,
   })
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Extend Kraken extension tar file upload timeout from 2 minutes to 30 minutes to accommodate larger or slower uploads.