### PR TITLE
Add nginx websocket locations for v2 extensions

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -485,6 +485,16 @@ class Helper:
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         }}
+
+        location /extensionv2/{name}/ws {{
+        proxy_pass http://127.0.0.1:{port}/ws;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        }}
         """
         filename = f"/home/pi/tools/nginx/extensions/{name}.conf"
         Path.mkdir(Path("/home/pi/tools/nginx/extensions/"), parents=True, exist_ok=True)


### PR DESCRIPTION
There are currently no nginx location blocks generated for v2 extensions that use websockets, this pull request aims to solve that.

## Summary by Sourcery

New Features:
- Introduce nginx location blocks to proxy websocket traffic for v2 extensions.