### PR TITLE
install: configure docker to NOT use containerd-snapshotter

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -163,6 +163,19 @@ docker --version || curl -fsSL https://get.docker.com | env -u VERSION sh || (
 
 systemctl enable docker
 
+# Docker 29+ defaults to the containerd image store (containerd-snapshotter=true).
+# That store breaks BlueOS installation, the booted docker.service talks to the
+# system containerd (a different data-root), so images baked into the image during
+# the build are invisible at runtime;
+mkdir -p /etc/docker
+cat <<'EOF' > /etc/docker/daemon.json
+{
+    "features": {
+        "containerd-snapshotter": false
+    }
+}
+EOF
+
 if [ $RUNNING_IN_CI -eq 1 ]
 then
 


### PR DESCRIPTION
That caused incompatibilities with DinD and increased disk usage

fix #3917 

image for testing is available at https://github.com/Williangalvani/BlueOS/actions/runs/27427008535

## Summary by Sourcery

Build:
- Add Docker daemon configuration to disable the containerd snapshotter feature during installation.

## Summary by Sourcery

Build:
- Add Docker daemon configuration file to turn off the containerd-snapshotter feature on install.