### PR TITLE
Improve zenoh publishers

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/logs.py
@@ -2,14 +2,20 @@ import json
 import logging
 from logging import LogRecord
 from types import FrameType
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import zenoh
-from commonwealth.utils.zenoh_helper import ZenohSession
+from commonwealth.utils.zenoh_helper import ZenohRouter
 from loguru import logger
 
 if TYPE_CHECKING:
     from loguru import Message
+
+LOG_PUBLISHER_OPTIONS: dict[str, Any] = {
+    "encoding": zenoh.Encoding.APPLICATION_JSON.with_schema("foxglove.Log"),
+    "congestion_control": zenoh.CongestionControl.BLOCK,
+    "priority": zenoh.Priority.DATA,
+}
 
 
 class InterceptHandler(logging.Handler):
@@ -68,8 +74,13 @@ def create_log_sink(service_name: str) -> Callable[["Message"], None]:
     Returns:
         A function that can be used as a loguru sink
     """
-    zenoh_session = ZenohSession(service_name)
+    zenoh_router = ZenohRouter(service_name)
     topic = f"services/{service_name}/log"
+    publisher = zenoh_router.add_publisher(
+        topic,
+        absolute=True,
+        publisher_options=LOG_PUBLISHER_OPTIONS,
+    )
 
     def sink(message: "Message") -> None:
         # Transform the message to the Foxglove log format
@@ -104,14 +115,10 @@ def create_log_sink(service_name: str) -> Callable[["Message"], None]:
         }
 
         try:
-            if zenoh_session.session is not None:
-                zenoh_session.session.put(
-                    topic,
-                    json.dumps(foxglove_log),
-                    encoding=zenoh.Encoding.APPLICATION_JSON.with_schema("foxglove.Log"),
-                )
+            if publisher is not None:
+                publisher.put(json.dumps(foxglove_log))
         except Exception as e:
-            logger.debug(f"Failed to publish log to zenoh session: {e}")
+            logger.debug(f"Failed to publish log to {topic}: {e}")
         # fmt: on
 
     return sink

--- a/core/libs/commonwealth/src/commonwealth/utils/zenoh_helper.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/zenoh_helper.py
@@ -100,6 +100,25 @@ class ZenohRouter:
         if self.zenoh_session.session:
             self.zenoh_session.session.declare_queryable(full_path, wrapper)
 
+    def add_publisher(
+        self,
+        path: str,
+        *,
+        absolute: bool = False,
+        publisher_options: dict[str, Any] | None = None,
+    ) -> zenoh.Publisher | None:
+        if absolute:
+            full_path = path
+        else:
+            full_path = self.prefix
+            if path:
+                full_path += f"/{path}"
+
+        if self.zenoh_session.session is None:
+            return None
+
+        return self.zenoh_session.session.declare_publisher(full_path, **(publisher_options or {}))
+
     def add_routes_to_zenoh(self, app: fastapi.FastAPI) -> None:
         queryables = []
         for route in app.router.routes:

--- a/core/services/kraken/extension_logs.py
+++ b/core/services/kraken/extension_logs.py
@@ -3,7 +3,9 @@ import json
 import time
 from typing import Callable, Dict, Optional, Tuple
 
-from commonwealth.utils.zenoh_helper import ZenohSession
+import zenoh
+from commonwealth.utils.logs import LOG_PUBLISHER_OPTIONS
+from commonwealth.utils.zenoh_helper import ZenohRouter
 from config import SERVICE_NAME
 from harbor import ContainerManager
 from loguru import logger
@@ -24,7 +26,8 @@ class ExtensionLogPublisher:
     }
 
     def __init__(self) -> None:
-        self._zenoh_session = ZenohSession(SERVICE_NAME)
+        self._zenoh_router = ZenohRouter(SERVICE_NAME)
+        self._publishers: Dict[str, zenoh.Publisher] = {}
         self._tasks: Dict[str, asyncio.Task[None]] = {}
 
     async def sync_with_running_extensions(self) -> None:
@@ -35,12 +38,12 @@ class ExtensionLogPublisher:
         self._stop_removed_streams(desired_streams)
 
     async def shutdown(self) -> None:
-        if not self._tasks:
-            return
-        for task in self._tasks.values():
-            task.cancel()
-        await asyncio.gather(*self._tasks.values(), return_exceptions=True)
-        self._tasks.clear()
+        if self._tasks:
+            for task in self._tasks.values():
+                task.cancel()
+            await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+            self._tasks.clear()
+        self._undeclare_publishers()
 
     async def _collect_desired_streams(self) -> Optional[Dict[str, ExtensionSettings]]:
         try:
@@ -94,24 +97,54 @@ class ExtensionLogPublisher:
         topic = self._topic_for(extension)
         logger.debug(f"Starting extension log stream for {container_name} -> {topic}")
 
+        publisher = self._declare_publisher(container_name, extension)
+        if publisher is None:
+            logger.debug(f"Unable to declare extension log publisher for {container_name}")
+            return
+
         try:
             async for raw_line in ContainerManager.get_container_log_by_name(container_name):
                 payload = self._format_log_payload(container_name, raw_line.rstrip("\n"))
-                self._publish(topic, payload)
+                self._publish(publisher, topic, payload)
         except asyncio.CancelledError:
             logger.debug(f"Extension log stream for {container_name} cancelled")
             raise
         except Exception as error:
             logger.debug(f"Extension log stream for {container_name} stopped: {error}")
+        finally:
+            self._undeclare_publisher(container_name)
 
-    def _publish(self, topic: str, log_line: str) -> None:
-        session = self._zenoh_session.session
-        if session is None:
-            return
+    def _publish(self, publisher: zenoh.Publisher, topic: str, log_line: str) -> None:
         try:
-            session.put(topic, log_line.encode("utf-8"))
+            publisher.put(log_line)
         except Exception as error:
             logger.debug(f"Failed to publish extension log to {topic}: {error}")
+
+    def _declare_publisher(self, container_name: str, extension: ExtensionSettings) -> zenoh.Publisher | None:
+        if container_name in self._publishers:
+            return self._publishers[container_name]
+
+        publisher = self._zenoh_router.add_publisher(
+            self._topic_for(extension),
+            absolute=True,
+            publisher_options=LOG_PUBLISHER_OPTIONS,
+        )
+        if publisher is not None:
+            self._publishers[container_name] = publisher
+        return publisher
+
+    def _undeclare_publisher(self, container_name: str) -> None:
+        publisher = self._publishers.pop(container_name, None)
+        if publisher is None:
+            return
+        try:
+            publisher.undeclare()  # type: ignore[no-untyped-call]
+        except Exception as error:
+            logger.debug(f"Failed to undeclare extension log publisher for {container_name}: {error}")
+
+    def _undeclare_publishers(self) -> None:
+        for container_name in list(self._publishers.keys()):
+            self._undeclare_publisher(container_name)
 
     @staticmethod
     def _topic_for(extension: ExtensionSettings) -> str:


### PR DESCRIPTION
Fixes:

1. We should use publishers whenever possible instead of direct `put`.
2. Extensions logs were missing encoding/schema.

Question: I'm not sure about the design: I've placed the add_publishers inside the ZenohRouter, but maybe we should do that inside the ZenohSession?

<img width="2261" height="1030" alt="image" src="https://github.com/user-attachments/assets/d19a8f44-bdd3-4c0b-8aed-f84be8058408" />


## Summary by Sourcery

Use zenoh publishers for service and extension log streaming instead of ad-hoc put calls, with proper encoding and QoS options.

New Features:
- Add a ZenohRouter.add_publisher helper to declare publishers with optional encoding, congestion control, and priority.

Bug Fixes:
- Ensure extension and service logs are published with the correct JSON encoding and foxglove.Log schema metadata.
- Fix missing cleanup of zenoh publishers and improve shutdown handling for extension log streaming tasks.

Enhancements:
- Refactor service and extension logging to reuse zenoh publishers per stream instead of creating ad-hoc put operations.

## Summary by Sourcery

Use zenoh publishers for streaming service and extension logs and add a helper to declare publishers with consistent options.

New Features:
- Introduce a ZenohRouter.add_publisher helper to declare zenoh publishers with optional encoding and QoS settings.

Bug Fixes:
- Publish service and extension logs with the correct JSON encoding and foxglove.Log schema metadata.
- Ensure zenoh publishers for extension log streams are properly undeclared and cleaned up on shutdown.

Enhancements:
- Refactor service and extension logging to reuse persistent zenoh publishers per stream instead of issuing ad-hoc put calls.