### PR TITLE
Frontend: fix SERVOn_TRIM parameter editor being grayed out

### DIFF
--- a/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
@@ -77,8 +77,8 @@
         <v-card
           outlined
           class="parameter-card"
-          :disabled="!trimParam"
-          :class="{ 'disabled-card': !trimParam }"
+          :disabled="!resolvedTrimParam?.name"
+          :class="{ 'disabled-card': !resolvedTrimParam?.name }"
         >
           <v-card-text class="py-2">
             <inline-parameter-editor


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix SERVOn_TRIM parameter editor being incorrectly disabled when a resolved trim parameter is available.