### PR TITLE
[1.4 backport] core: frontend: wizard: rover/BOAT exists but no boat/UNDEFINED

### DIFF
--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -361,7 +361,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      boat_model: get_model('boat', 'UNDEFINED'),
+      boat_model: get_model('rover', 'BOAT'),
       scripts: [] as string[],
       configuration_failed: false,
       error_message: 'The operation failed!',


### PR DESCRIPTION
backport of #3679

## Summary by Sourcery

Bug Fixes:
- Fix incorrect default model selection in the wizard by using the rover BOAT model rather than an undefined boat model.