### PR TITLE
[1.4 backport] Frontend: fix SERVOn_TRIM parameter editor being grayed out

### DIFF
--- a/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
@@ -77,8 +77,8 @@
         <v-card
           outlined
           class="parameter-card"
-          :disabled="!trimParam"
-          :class="{ 'disabled-card': !trimParam }"
+          :disabled="!resolvedTrimParam?.name"
+          :class="{ 'disabled-card': !resolvedTrimParam?.name }"
         >
           <v-card-text class="py-2">
             <inline-parameter-editor


### PR DESCRIPTION
Backport of https://github.com/bluerobotics/BlueOS/pull/3954

## Summary by Sourcery

Bug Fixes:
- Correct the disabled state of the servo trim parameter editor card to depend on the resolved trim parameter name instead of the raw trim parameter reference.