### PR TITLE
Change title for v-tooltip

### DIFF
--- a/core/frontend/src/components/app/InternetTrayMenu.vue
+++ b/core/frontend/src/components/app/InternetTrayMenu.vue
@@ -17,8 +17,8 @@
         v-on="on"
       >
         <v-icon
+          v-tooltip="tooltip"
           color="white"
-          :title="tooltip"
         >
           {{ icon }}
         </v-icon>

--- a/core/frontend/src/components/app/ThemeTrayMenu.vue
+++ b/core/frontend/src/components/app/ThemeTrayMenu.vue
@@ -1,8 +1,8 @@
 <template>
   <v-icon
+    v-tooltip="`Change theme between dark and light mode.`"
     height="100%"
     color="white"
-    title="Change theme between dark and light mode."
     @click="toggleDarkTheme"
   >
     {{ settings.is_dark_theme ? 'mdi-weather-night' : 'mdi-white-balance-sunny' }}

--- a/core/frontend/src/components/health/GpsTrayMenu.vue
+++ b/core/frontend/src/components/health/GpsTrayMenu.vue
@@ -15,9 +15,9 @@
       >
         <v-badge
           v-if="gps_connected"
+          v-tooltip="`${connection_description} (Number of satellites: ${satellites_number})`"
           :content="satellites_number"
           :value="satellites_number"
-          :title="`${connection_description} (Number of satellites: ${satellites_number})`"
           :color="number_color"
           :dot="!mouse_hover"
           v-bind="attrs"

--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -11,25 +11,25 @@
     </v-icon>
     <v-icon
       v-if="cpu_temperature_limit_reached"
+      v-tooltip="`CPU temperature too high (${cpu_temperature} ºC), please cool down your vehicle!`"
       class="px-1 blinking white-shadow"
       color="error"
-      :title="`CPU temperature too high (${cpu_temperature} ºC), please cool down your vehicle!`"
     >
       mdi-thermometer
     </v-icon>
     <v-icon
       v-if="cpu_throttled"
+      v-tooltip="`CPU is throttled. Performance may be affected. Please check your power supply and cooling!`"
       class="px-1 blinking white-shadow"
       color="error"
-      :title="`CPU is throttled. Performance may be affected. Please check your power supply and cooling!`"
     >
       mdi-gauge-empty
     </v-icon>
     <v-icon
       v-if="cpu_undervoltage"
+      v-tooltip="`CPU has reported low voltage. Please check your power supply!`"
       class="px-1 blinking white-shadow"
       color="error"
-      :title="`CPU has reported low voltage. Please check your power supply!`"
     >
       mdi-lightning-bolt
     </v-icon>
@@ -49,17 +49,17 @@
         >
           <v-icon
             v-if="heartbeat_age() < time_limit_heartbeat"
+            v-tooltip="heartbeat_message()"
             class="px-1"
             :color="heartbeat_color()"
-            :title="heartbeat_message()"
           >
             mdi-heart-pulse
           </v-icon>
           <v-icon
             v-if="heartbeat_age() >= time_limit_heartbeat"
+            v-tooltip="`MAVLink heartbeat lost`"
             class="px-1 white-shadow"
             color="error"
-            title="MAVLink heartbeat lost"
           >
             mdi-heart-broken
           </v-icon>


### PR DESCRIPTION
Closes #3935

Replaces `title` attributes with the `v-tooltip` directive in four tray menu components:
 - `InternetTrayMenu`
 - `ThemeTrayMenu`
 - `GpsTrayMenu`
 - `HealthTrayMenu`
  
This makes tooltips consistent with the rest of the codebase.

 Tested locally.

## Summary by Sourcery

Enhancements:
- Standardize tooltip usage in Internet, Theme, GPS, and Health tray menus by switching from title attributes to the v-tooltip directive.