### PR TITLE
bag-of-holding: make /set request body visible in OpenAPI again

### DIFF
--- a/core/services/bag_of_holding/main.py
+++ b/core/services/bag_of_holding/main.py
@@ -12,7 +12,6 @@ from commonwealth.utils.logs import InterceptHandler, init_logger
 from commonwealth.utils.sentry_config import init_sentry_async
 from fastapi import Body, Depends, FastAPI, HTTPException
 from fastapi import Path as FastPath
-from fastapi import Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
@@ -63,15 +62,8 @@ def write_db(data: Dict[str, Any]) -> None:
         json.dump(data, f)
 
 
-async def parse_nullable_body(request: Request) -> Any:
-    body = await request.body()
-    if not body:
-        return None
-
-    try:
-        return json.loads(body)
-    except json.JSONDecodeError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid JSON: {e}") from e
+async def parse_nullable_body(payload: Any | None = Body(None)) -> Any:
+    return payload
 
 
 @app.post("/overwrite")


### PR DESCRIPTION
Follow-up to #3731.

We hit this while updating our bag-of-holding client: the request body for `/set/{path}` had disappeared from the generated OpenAPI schema, so the generated client no longer sent a body.

The endpoint still worked at runtime, but parsing the body via `Request` meant FastAPI couldn't describe it properly in OpenAPI.

Use `Body(None)` in the nullable-body dependency instead, so `/set/{path}` still accepts `null` and the request body shows up in the schema again.

## Validation

- started the bag-of-holding service locally and fetched its live OpenAPI schema
- confirmed that, before this change, `/set/{path}` had no `requestBody`
- confirmed that, after this change, `/set/{path}` includes a `requestBody` again
- verified that `POST /set/test-null` with a `null` body still succeeds, and `GET /get/test-null` returns `null`

## Summary by Sourcery

Restore OpenAPI visibility of the nullable request body for the bag-of-holding /set endpoint by changing how the request payload is parsed.

Bug Fixes:
- Fix missing requestBody in the OpenAPI schema for /set/{path} so generated clients include the body again.

Enhancements:
- Simplify nullable request body handling by using a FastAPI Body parameter instead of manually reading and decoding the request.