### PR TITLE
AutoCoordinateDetector: round lat/lon before sending SET_GPS_GLOBAL_ORIGIN

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/compass/AutoCoordinateDetector.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/AutoCoordinateDetector.vue
@@ -185,8 +185,8 @@ export default {
           },
           message: {
             type: 'SET_GPS_GLOBAL_ORIGIN',
-            latitude: lat * 1e7,
-            longitude: lon * 1e7,
+            latitude: Math.round(lat * 1e7),
+            longitude: Math.round(lon * 1e7),
             altitude: 0,
             target_system: autopilot_data.system_id,
             time_usec: 0,


### PR DESCRIPTION
Closes #3958

### Problem

When setting the GPS origin (compass learn flow), `lat * 1e7` and `lon * 1e7` produce floating-point values (e.g. `492513999.99999994`) instead of integers. MAVLink's `SET_GPS_GLOBAL_ORIGIN` expects `latitude` and `longitude` as `int32` (degE7).

### Fix

Wrap both values with `Math.round()` before passing them to the MAVLink message, ensuring a valid integer is always sent.

### Test
  
Opened Compass Learn on ArduSub 4.5.0 SITL, entered lat `49.2514` / lon `-123.0972`, verified the request payload shows `492514000` / `-1230972000` instead of `492513999.99999994` / `-1230972000`.


<img width="283" height="249" alt="input" src="https://github.com/user-attachments/assets/757d4f84-e4c2-486a-9d6e-f2e2e8681a68" />

<img width="450" height="248" alt="payload" src="https://github.com/user-attachments/assets/68133660-12ed-43a0-a834-31d648be597f" />

## Summary by Sourcery

Bug Fixes:
- Ensure GPS origin latitude and longitude sent in SET_GPS_GLOBAL_ORIGIN are rounded to integer degE7 values instead of potentially non-integer floating-point results.