### PR TITLE
[1.4 backport] Configure docker to NOT use containerd-snapshotter

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -133,6 +133,19 @@ docker --version || curl -fsSL https://get.docker.com | env -u VERSION sh || (
 
 systemctl enable docker
 
+# Docker 29+ defaults to the containerd image store (containerd-snapshotter=true).
+# That store breaks BlueOS installation, the booted docker.service talks to the
+# system containerd (a different data-root), so images baked into the image during
+# the build are invisible at runtime;
+mkdir -p /etc/docker
+cat <<'EOF' > /etc/docker/daemon.json
+{
+    "features": {
+        "containerd-snapshotter": false
+    }
+}
+EOF
+
 if [ $RUNNING_IN_CI -eq 1 ]
 then
 


### PR DESCRIPTION
That caused incompatibilities with DinD and increased disk usage

Backport of https://github.com/bluerobotics/BlueOS/pull/3951

## Summary by Sourcery

Bug Fixes:
- Disable Docker’s containerd snapshotter feature to fix runtime visibility of images baked into the system image and avoid related DinD incompatibilities and disk usage issues.