### PR TITLE
core: Update docker base to 0.2.6

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,5 +1,5 @@
 # Override with --build-arg BASE_IMAGE=blueos-base:dev for local builds
-ARG BASE_IMAGE=bluerobotics/blueos-base:0.2.5
+ARG BASE_IMAGE=bluerobotics/blueos-base:0.2.6
 
 # Build frontend
 FROM --platform=$BUILDPLATFORM oven/bun:1.0.3-slim AS frontend-builder


### PR DESCRIPTION
This fixes a problem in MCM in which the fake streams would not render the time overlay correctly because of a missing font.