### PR TITLE
Frontend: bump Ardupilot Parameter repository submodule

### DIFF
--- a/core/frontend/src/types/autopilot/parameter-table.ts
+++ b/core/frontend/src/types/autopilot/parameter-table.ts
@@ -1,4 +1,5 @@
 import { isNumber } from 'lodash'
+import ardupilotParamPaths from 'virtual:ardupilot-param-index'
 
 import { fetchVehicleType } from '@/components/autopilot/AutopilotManagerUpdater'
 import { MavAutopilot } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
@@ -108,7 +109,7 @@ export default class ParametersTable {
       console.debug(`Metadata override not present`)
     }
     await fetchFirmwareVehicleType() // required to populate autopilot.vehicle_type
-    const jsons = Object.keys(await import.meta.glob('/public/assets/ArduPilot-Parameter-Repository/**/*.json')) as string[]
+    const jsons = ardupilotParamPaths
     let folder = "Copter"
     switch (autopilot.firmware_vehicle_type) {
       case FirmwareVehicleType.ArduSub:

--- a/core/frontend/src/types/parameter_repository.d.ts
+++ b/core/frontend/src/types/parameter_repository.d.ts
@@ -2,3 +2,8 @@ declare module 'https://bluerobotics.github.io/Blueos-Parameter-Repository/param
   const parameters: Dictionary<Dictionary<number>>
   export default parameters
 }
+
+declare module 'virtual:ardupilot-param-index' {
+  const paths: string[]
+  export default paths
+}

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -79,6 +79,38 @@ export default defineConfig(({ command, mode }) => {
           })
         }
       },
+      // Expose the list of ArduPilot parameter JSON paths without bundling their contents.
+      // Using import.meta.glob would pull every (multi-MB) file into the module graph and blow up
+      // build memory; we only need the paths, the contents are fetched at runtime from public/.
+      {
+        name: 'ardupilot-param-index',
+        resolveId(id) {
+          if (id === 'virtual:ardupilot-param-index') {
+            return '\0virtual:ardupilot-param-index'
+          }
+          return null
+        },
+        load(id) {
+          if (id !== '\0virtual:ardupilot-param-index') return null
+          const fs = require('fs')
+          const publicDir = path.resolve(__dirname, 'public')
+          const repoDir = path.resolve(publicDir, 'assets/ArduPilot-Parameter-Repository')
+          const paths = []
+          const walk = (dir) => {
+            if (!fs.existsSync(dir)) return
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const fullPath = path.join(dir, entry.name)
+              if (entry.isDirectory()) {
+                walk(fullPath)
+              } else if (entry.name.endsWith('.json')) {
+                paths.push(`/public/${path.relative(publicDir, fullPath).split(path.sep).join('/')}`)
+              }
+            }
+          }
+          walk(repoDir)
+          return `export default ${JSON.stringify(paths)}`
+        },
+      },
       // Remove non-JSON files from ArduPilot parameter repository to reduce image size
       {
         name: 'cleanup-ardupilot-files',


### PR DESCRIPTION
## Summary by Sourcery

Index ArduPilot parameter repository JSON files at build time via a virtual module instead of import-time globbing to avoid bundling file contents and reduce frontend build memory usage.

New Features:
- Expose a virtual module that provides the list of ArduPilot parameter JSON paths for runtime fetching.

Enhancements:
- Update the parameters table logic to consume the new virtual index of ArduPilot parameter JSON files instead of using import.meta.glob.