### PR TITLE
Update mavlink server

### DIFF
--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -93,6 +93,7 @@ export enum EndpointType {
     tcpout = 'tcpout',
     serial = 'serial',
     zenoh = 'zenoh',
+    zenohraw = 'zenohraw',
 }
 
 export function vehicleTypeFromString(vehicle_type: string): Vehicle {
@@ -111,6 +112,7 @@ export function userFriendlyEndpointType(type: EndpointType): string {
     case EndpointType.tcpout: return 'TCP Client'
     case EndpointType.serial: return 'Serial'
     case EndpointType.zenoh: return 'Zenoh'
+    case EndpointType.zenohraw: return 'Zenoh Raw'
     default: return 'Undefined type'
   }
 }

--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -100,6 +100,15 @@ class AutoPilotManager(metaclass=Singleton):
                 protected=True,
             ),
             Endpoint(
+                name="ZenohRaw",
+                owner=self.settings.app_name,
+                connection_type=EndpointType.ZenohRaw,
+                place="0.0.0.0",
+                argument=7117,
+                persistent=True,
+                protected=True,
+            ),
+            Endpoint(
                 name="Internal Link",
                 owner=self.settings.app_name,
                 connection_type=EndpointType.TCPServer,

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -15,6 +15,7 @@ class EndpointType(str, Enum):
     TCPClient = "tcpout"
     Serial = "serial"
     Zenoh = "zenoh"
+    ZenohRaw = "zenohraw"
 
 
 @dataclass
@@ -43,6 +44,7 @@ class Endpoint:
             EndpointType.TCPServer,
             EndpointType.TCPClient,
             EndpointType.Zenoh,
+            EndpointType.ZenohRaw,
         ]:
             if not (validators.domain(place) or validators.ipv4(place) or validators.ipv6(place)):
                 raise ValueError(f"Invalid network address: {place}")

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -39,6 +39,8 @@ class MAVLinkServer(AbstractRouter):
                 return f"udpc:{endpoint.place}:{endpoint.argument}"
             if endpoint.connection_type == EndpointType.Zenoh:
                 return f"zenoh:{endpoint.place}:{endpoint.argument}"
+            if endpoint.connection_type == EndpointType.ZenohRaw:
+                return f"zenohraw:{endpoint.place}:{endpoint.argument}"
             raise ValueError(f"Endpoint of type {endpoint.connection_type} not supported on MAVLink-Server.")
 
         filtered_endpoints = Endpoint.filter_enabled(self.endpoints())
@@ -70,6 +72,7 @@ class MAVLinkServer(AbstractRouter):
             EndpointType.TCPClient,
             EndpointType.Serial,
             EndpointType.Zenoh,
+            EndpointType.ZenohRaw,
         ]
         if endpoint.connection_type not in valid_connection_types:
             raise ValueError(f"Connection_type '{endpoint.connection_type}' not supported by {MAVLinkServer.name()}.")

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkServer.py
@@ -26,6 +26,7 @@ class MAVLinkServer(AbstractRouter):
 
     def assemble_command(self, master_endpoint: Endpoint) -> str:
         # Convert endpoint format to mavlink-router format
+        # pylint: disable=too-many-return-statements
         def convert_endpoint(endpoint: Endpoint) -> str:
             if endpoint.connection_type == EndpointType.Serial:
                 return f"serial:{endpoint.place}:{endpoint.argument}"

--- a/core/tools/mavlink_server/bootstrap.sh
+++ b/core/tools/mavlink_server/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.7.4"
+VERSION="0.9.0"
 PROJECT_NAME="mavlink-server"
 REPOSITORY_ORG="bluerobotics"
 REPOSITORY_NAME="$PROJECT_NAME"


### PR DESCRIPTION
This brings the ZenohRaw endpoint (required by https://github.com/bluerobotics/blueos-recorder/issues/19) and MavFTP. 

Changelog [here](https://github.com/bluerobotics/mavlink-server/releases/tag/0.9.0)

## Summary by Sourcery

Introduce Zenoh Raw endpoint support and update the bundled mavlink-server to version 0.9.0 to enable new capabilities such as the ZenohRaw endpoint and related functionality.

New Features:
- Add support for Zenoh Raw endpoints throughout the MAVLink server and autopilot manager, including validation and frontend type mapping.

Enhancements:
- Update the default Zenoh Raw endpoint configuration in the autopilot manager for MAVLink server usage.

Build:
- Bump bundled mavlink-server version to 0.9.0 in the bootstrap script to align with new features.