### PR TITLE
Pin github actions version packages with sha

### DIFF
--- a/.github/workflows/block-ai-commits.yml
+++ b/.github/workflows/block-ai-commits.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -32,7 +32,7 @@ jobs:
       # PR head ref, since the Anthropic API key is available to this job and
       # we do not want fork code to execute with access to it.
       - name: Checkout base ref (trusted)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1 -> v7.0.0 available
         with:
           fetch-depth: 1
 
@@ -52,7 +52,7 @@ jobs:
           echo "Diff size: $(wc -l < pr.diff) lines"
 
       - name: Run Claude PR review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 #v1.0.163
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/duplicate-issue-detection.yml
+++ b/.github/workflows/duplicate-issue-detection.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3 -> 7.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       with:
         python-version: ${{ env.python-version }}
 
@@ -34,14 +34,14 @@ jobs:
         pip install poetry
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 #v8.0.0 -> v8.2.0(avaialable)
 
     - name: Run tests
       run: |
         .hooks/pre-push
 
     - name: Upload coverage
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: coverage
         path: ./core/htmlcov
@@ -51,11 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           submodules: recursive
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2.2.0
         with:
           bun-version: 1.2.1
 
@@ -79,7 +79,7 @@ jobs:
         platforms: ["linux/arm/v7,linux/arm64/v8,linux/amd64"]
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
         with:
           android: true
           dotnet: true
@@ -89,7 +89,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           fetch-depth: 0 #Number of commits to fetch. 0 indicates all history for all branches and tags.
           submodules: recursive
@@ -122,17 +122,17 @@ jobs:
             --file ${{ matrix.docker }}/Dockerfile ./${{ matrix.docker }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 #v4.2.0
         with:
           platforms: all
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c #v4.2.0
         with:
           version: latest
 
       - name: Cache Docker layers
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 #v5.1.0
         id: cache
         with:
           path: /tmp/.buildx-cache
@@ -165,7 +165,7 @@ jobs:
 
       - name: Login to DockerHub
         if: success() && github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 #v4.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -196,7 +196,7 @@ jobs:
             --output "type=docker,dest=BlueOs-core-docker-image-${GIT_HASH_SHORT}-arm64-v8.tar" \
 
       - name: Upload artifact arm64-v8
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         if: success() && matrix.docker == 'core'
         with:
           name: BlueOS-core-docker-image-arm64-v8
@@ -214,7 +214,7 @@ jobs:
             --output "type=docker,dest=BlueOs-core-docker-image-${GIT_HASH_SHORT}-arm-v7.tar" \
 
       - name: Upload artifact arm-v7
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         if: success() && matrix.docker == 'core'
         with:
           name: BlueOS-core-docker-image-arm-v7
@@ -232,14 +232,14 @@ jobs:
             --output "type=docker,dest=BlueOs-core-docker-image-${GIT_HASH_SHORT}-amd64.tar" \
 
       - name: Upload artifact amd64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         if: success() && matrix.docker == 'core'
         with:
           name: BlueOS-core-docker-image-amd64
           path: '*amd64.tar'
 
       - name: Upload docker image for release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de #v2.11.5
         if: startsWith(github.ref, 'refs/tags/') && success() && matrix.docker == 'core'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -295,7 +295,7 @@ jobs:
           sudo losetup -D || true
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           submodules: recursive
 
@@ -356,7 +356,7 @@ jobs:
           ls -lah BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}*
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         timeout-minutes: 120
         with:
           name: BlueOS-raspberry-${{ env.GITHUB_REF_NAME }}${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}
@@ -365,7 +365,7 @@ jobs:
           retention-days: 7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b #v6.2.1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -378,7 +378,7 @@ jobs:
           aws s3 cp deploy/pimod/blueos.img s3://blueos-downloads/releases/${{ github.ref_name }}/BlueOS-raspberry-${{ env.SANITIZED_PLATFORM }}-${{ matrix.os }}${{ env.ASSET_NAME_SUFFIX }}.img
 
       - name: Upload raspberry image for release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de #v2.11.5
         if: startsWith(github.ref, 'refs/tags/')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
Prior to this commit all Github Actions packages looked for the current latest major release of package.This could potentially lead to the execution of malicious code if any package maintainer got compromised and new version tags got release or current ones got re-uploaded. So by pinning each and every one this gets eliminated

### Changed 
- Replaced all action references from the format: <action_name>@<version> to: <action_name>@<sha256>  

Notes:
- Used latest patch available version of each Github action and not the latest available.
- `claude-pr-review` uses actions/checkout@v4 so this has been changed to the latest v4 version and not the latest available version of actions/checkout.This was done to ensure that nothing will break and the same actions will continue to run.
- Not sure if `anthropics/claude-code-action` needs to pinned down since they release ~1-2 versions each day it might need to access latest features of claude action

## Summary by Sourcery

Pin GitHub Actions workflow dependencies to specific commit SHAs for more deterministic and secure CI runs.

Build:
- Update all GitHub Actions and third-party actions in workflows to use pinned commit SHAs instead of floating version tags.

CI:
- Align CI workflows (test-and-deploy, PR review, block AI commits, duplicate issue detection, submodule sync) to use SHA-pinned versions of checkout, setup, Docker, AWS, artifact upload, and Anthropic actions for reproducible pipeline executions.