### PR TITLE
core: tools: Mavlink2REST: Update to t0.11.25

### DIFF
--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="t0.11.24"
+VERSION="t0.11.25"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink2rest"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
MAVLink2REST t0.11.25 introduces new debug output which is useful for some users. This update does not introduce any breaking changes to the MAVLink2Rest API.

## Summary by Sourcery

Build:
- Bump MAVLink2REST bootstrap VERSION from t0.11.24 to t0.11.25.