### PR TITLE
Frontend: Lights: fix detection and setup for ArduSub >= 4.5.6

### DIFF
--- a/core/frontend/src/components/vehiclesetup/PwmSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/PwmSetup.vue
@@ -154,7 +154,6 @@
 </template>
 
 <script lang="ts">
-import { lte as sem_ver_lte } from 'semver'
 import Vue from 'vue'
 
 import { fetchCurrentBoard } from '@/components/autopilot/AutopilotManagerUpdater'
@@ -202,8 +201,7 @@ const param_value_map = {
   },
 } as Dictionary<Dictionary<string>>
 
-// ArduSub <= 4.5.4 used RCIN9/RCIN10 for lights control; newer versions handle lights natively
-const LEGACY_SUB_LIGHTS_MAX_VERSION = '4.5.5'
+// Legacy ArduSub versions used RCIN9/RCIN10 for lights control; newer versions handle lights natively
 const legacy_sub_param_value_map: Dictionary<string> = {
   RCIN9: 'Lights 1',
   RCIN10: 'Lights 2',
@@ -237,8 +235,9 @@ export default Vue.extend({
   computed: {
     effective_param_value_map(): Dictionary<Dictionary<string>> {
       const map = { ...param_value_map }
-      const version = autopilot.firmware_info?.version
-      if (this.is_sub && version && sem_ver_lte(version, LEGACY_SUB_LIGHTS_MAX_VERSION)) {
+      // Apply legacy RCIN9/RCIN10 -> Lights labels only when the store resolves
+      // to the legacy ArduSub function numbers.
+      if (autopilot.lights1_servo_function !== SERVO_FUNCTION.LIGHTS1) {
         map.Submarine = { ...legacy_sub_param_value_map, ...map.Submarine }
       }
       return map

--- a/core/frontend/src/components/vehiclesetup/configuration/lights.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/lights.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main-container">
     <v-card>
-      <v-card-title> Lights 1 (RCIN9) </v-card-title>
+      <v-card-title> Lights 1 </v-card-title>
       <v-card-text>
         The output pin for the primary set of lights:
         <v-select
@@ -14,7 +14,7 @@
       </v-card-text>
     </v-card>
     <v-card>
-      <v-card-title> Lights 2 (RCIN10) </v-card-title>
+      <v-card-title> Lights 2 </v-card-title>
       <v-card-text>
         The output pin for the secondary set of lights:
         <v-select
@@ -48,13 +48,10 @@
 <script lang="ts">
 import mavlink2rest from '@/libs/MAVLink2Rest'
 import autopilot_data from '@/store/autopilot'
+import autopilot from '@/store/autopilot_manager'
 import Parameter, { printParam } from '@/types/autopilot/parameter'
 
-enum Lights {
-  Lights1 = 59, // RCIN9
-  Lights2 = 60, // RCIN10
-  DISABLED = 0,
-}
+const DISABLED = 0
 
 export default {
   name: 'LightsConfigration',
@@ -66,6 +63,12 @@ export default {
     }
   },
   computed: {
+    lights1_value(): number {
+      return autopilot.lights1_servo_function
+    },
+    lights2_value(): number {
+      return autopilot.lights2_servo_function
+    },
     light_steps(): Parameter | undefined {
       return autopilot_data.parameter('JS_LIGHTS_STEPS')
     },
@@ -73,10 +76,10 @@ export default {
       return autopilot_data.parameterRegex('SERVO[0-9]+_FUNCTION')
     },
     lights1_param(): Parameter | undefined {
-      return this.servo_params.filter((param) => param.value === Lights.Lights1)[0]
+      return this.servo_params.filter((param) => param.value === this.lights1_value)[0]
     },
     lights2_param(): Parameter | undefined {
-      return this.servo_params.filter((param) => param.value === Lights.Lights2)[0]
+      return this.servo_params.filter((param) => param.value === this.lights2_value)[0]
     },
   },
   watch: {
@@ -99,10 +102,10 @@ export default {
       this.lights2_new_param = new_value?.name
     },
     lights1_new_param(new_param_name: string | undefined) {
-      this.setLights(new_param_name, Lights.Lights1)
+      this.setLights(new_param_name, this.lights1_value)
     },
     lights2_new_param(new_param_name: string | undefined) {
-      this.setLights(new_param_name, Lights.Lights2)
+      this.setLights(new_param_name, this.lights2_value)
     },
   },
   mounted() {
@@ -111,7 +114,7 @@ export default {
     this.steps_new_value = this.light_steps?.value ?? 0
   },
   methods: {
-    setLights(new_param_name: string | undefined, lights: Lights) {
+    setLights(new_param_name: string | undefined, lights: number) {
       if (new_param_name) {
         // reset any other parameter using lights1 to undefined
         for (const old_param of this.servo_params) {
@@ -119,8 +122,7 @@ export default {
             continue
           }
           if (old_param.value === lights) {
-            // set the old parameter to DISABLED
-            mavlink2rest.setParam(old_param.name, Lights.DISABLED, autopilot_data.system_id)
+            mavlink2rest.setParam(old_param.name, DISABLED, autopilot_data.system_id)
           }
         }
         mavlink2rest.setParam(new_param_name, lights, autopilot_data.system_id)

--- a/core/frontend/src/components/vehiclesetup/overview/LightsInfo.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/LightsInfo.vue
@@ -30,7 +30,6 @@ import Vue from 'vue'
 
 import autopilot_data from '@/store/autopilot'
 import autopilot from '@/store/autopilot_manager'
-import { SERVO_FUNCTION } from '@/types/autopilot/parameter-sub-enums'
 
 import toBoardFriendlyChannel from './common'
 
@@ -42,8 +41,10 @@ export default Vue.extend({
     },
     lights() {
       const servo_params = autopilot_data.parameterRegex('SERVO.*_FUNCTION')
+      const lights1 = autopilot.lights1_servo_function
+      const lights2 = autopilot.lights2_servo_function
       const light_params = servo_params.filter(
-        (parameter) => parameter.value === SERVO_FUNCTION.RCIN9 || parameter.value === SERVO_FUNCTION.RCIN10,
+        (parameter) => parameter.value === lights1 || parameter.value === lights2,
       )
       return light_params.map((parameter) => parameter.name)
     },

--- a/core/frontend/src/store/autopilot.ts
+++ b/core/frontend/src/store/autopilot.ts
@@ -74,10 +74,6 @@ class AutopilotStore extends VuexModule {
     )
   }
 
-  get vehicle_type(): string {
-    return autopilot_manager.vehicle_type
-  }
-
   get frame_type(): number | undefined {
     const mav_type = 'MAV_TYPE_' + autopilot_manager.vehicle_type?.toUpperCase().replace(' ', '_')
     switch (mav_type) {
@@ -92,7 +88,7 @@ class AutopilotStore extends VuexModule {
   }
 
   get frame_name(): string | undefined {
-    switch (this.vehicle_type) {
+    switch (autopilot_manager.vehicle_type) {
       case 'Submarine':
         return Object.entries(SUB_FRAME_CONFIG).find((key, value) => value === this.frame_type)?.[1] as string
       case 'Surface Boat':
@@ -107,7 +103,7 @@ class AutopilotStore extends VuexModule {
 
   get vehicle_model() {
     const frame = this.frame_type
-    if (!this.vehicle_type || frame === undefined) {
+    if (!autopilot_manager.vehicle_type || frame === undefined) {
       return ''
     }
     const release_path = `assets/vehicles/models/${vehicle_folder()}/${this.frame_name}.glb`

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -1,3 +1,4 @@
+import { lte as sem_ver_lte } from 'semver'
 import {
   getModule, Module, Mutation, VuexModule,
 } from 'vuex-module-decorators'
@@ -7,6 +8,12 @@ import {
   AutopilotEndpoint, FirmwareInfo, FirmwareVehicleType,
   FlightController, SerialEndpoint, SITLFrame,
 } from '@/types/autopilot'
+import { SERVO_FUNCTION as SUB_SERVO_FUNCTION } from '@/types/autopilot/parameter-sub-enums'
+
+// ArduSub <= 4.5.5 used RCIN9/RCIN10 for lights control; newer versions handle lights natively
+const LEGACY_SUB_LIGHTS_MAX_VERSION = '4.5.5'
+const LEGACY_SUB_LIGHTS1 = 59 // RCIN9
+const LEGACY_SUB_LIGHTS2 = 60 // RCIN10
 
 @Module({
   dynamic: true,
@@ -38,6 +45,25 @@ class AutopilotManagerStore extends VuexModule {
   restarting = false
 
   autopilot_serials: SerialEndpoint[] = []
+
+  // All vehicle types include the values ArduSub overloaded for legacy lights support, so we need to filter by it
+  get lights1_servo_function(): number {
+    const is_sub = this.firmware_vehicle_type === FirmwareVehicleType.ArduSub
+    const version = this.firmware_info?.version
+    if (is_sub && version && sem_ver_lte(version, LEGACY_SUB_LIGHTS_MAX_VERSION)) {
+      return LEGACY_SUB_LIGHTS1
+    }
+    return SUB_SERVO_FUNCTION.LIGHTS1
+  }
+
+  get lights2_servo_function(): number {
+    const is_sub = this.firmware_vehicle_type === FirmwareVehicleType.ArduSub
+    const version = this.firmware_info?.version
+    if (is_sub && version && sem_ver_lte(version, LEGACY_SUB_LIGHTS_MAX_VERSION)) {
+      return LEGACY_SUB_LIGHTS2
+    }
+    return SUB_SERVO_FUNCTION.LIGHTS2
+  }
 
   @Mutation
   setAutopilotSerialConfigurations(serials: SerialEndpoint[]): void {


### PR DESCRIPTION
## Summary by Sourcery

Update lights configuration and detection to support both legacy and native ArduSub lights handling based on firmware version.

New Features:
- Introduce centralized getters for lights servo function values in the autopilot manager store to abstract legacy vs. new ArduSub behavior.

Bug Fixes:
- Fix lights parameter detection and labeling for ArduSub firmware versions >= 4.5.6 by no longer hardcoding RCIN9/RCIN10 IDs.

Enhancements:
- Simplify lights UI titles by removing hardcoded RC input references.
- Unify vehicle type access through the autopilot manager store in various setup components.
- Align PWM setup and overview components with the new lights servo function resolution logic.