### PR TITLE
Timekeeper: Install chronyd as BlueOS tool

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -124,6 +124,8 @@ COPY --from=download-binaries \
     /usr/bin/blueos_startup_update.py \
     /usr/bin/blueos-recorder \
     /usr/bin/bridges \
+    /usr/bin/chronyc \
+    /usr/bin/chronyd \
     /usr/bin/disktest \
     /usr/bin/linux2rest \
     /usr/bin/machineid-cli \

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -130,6 +130,7 @@ SERVICES=(
     'beacon',250,0,0,0,"$SERVICES_PATH/beacon/main.py"
     'bridget',0,0,0,0,"nice -19 $RUN_AS_REGULAR_USER_BEGIN $SERVICES_PATH/bridget/main.py $RUN_AS_REGULAR_USER_END"
     'commander',250,0,0,0,"$SERVICES_PATH/commander/main.py"
+    'chronyd',0,0,0,0,"chronyd -d -f $TOOLS_PATH/chrony/chrony.conf"
     'nmea_injector',250,0,0,0,"nice -19 $SERVICES_PATH/nmea_injector/main.py"
     'helper',250,0,0,0,"$BLUEOS_PYTHON_BIN_SECONDARY $SERVICES_PATH/helper/main.py"
     'iperf3',250,0,0,0," iperf3 --server --port 5201"

--- a/core/tools/chrony/bootstrap.sh
+++ b/core/tools/chrony/bootstrap.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION="4.8"
+SHA256="33ea8eb2a4daeaa506e8fcafd5d6d89027ed6f2f0609645c6f149b560d301706"
+PROJECT_NAME="chrony"
+SOURCE_URL="https://chrony-project.org/releases/$PROJECT_NAME-$VERSION.tar.gz"
+
+echo "Installing project $PROJECT_NAME version $VERSION"
+
+if [ -z "$RUNNING_IN_CI" ]; then
+    mkdir -p /run/chrony
+    echo "Finished configuring $PROJECT_NAME"
+    exit 0
+fi
+
+if [ -n "$VIRTUAL_ENV" ]; then
+    BIN_DIR="$VIRTUAL_ENV/bin"
+else
+    BIN_DIR="/usr/bin"
+fi
+mkdir -p "$BIN_DIR"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ARCHIVE="$TMP_DIR/$PROJECT_NAME-$VERSION.tar.gz"
+wget -q "$SOURCE_URL" -O "$ARCHIVE"
+printf "%s  %s\n" "$SHA256" "$ARCHIVE" | sha256sum -c -
+
+tar -xzf "$ARCHIVE" -C "$TMP_DIR"
+cd "$TMP_DIR/$PROJECT_NAME-$VERSION"
+
+LDFLAGS="${LDFLAGS:-} -static" ./configure \
+    --prefix=/usr \
+    --bindir=/usr/bin \
+    --sbindir=/usr/bin \
+    --sysconfdir=/etc \
+    --localstatedir=/var \
+    --chronyrundir=/run/chrony \
+    --chronyvardir=/usr/blueos/userdata/chrony \
+    --disable-nts \
+    --disable-privdrop \
+    --disable-readline \
+    --disable-sechash \
+    --with-chronyc-user=root \
+    --with-user=root \
+    --without-libcap \
+    --without-seccomp
+
+make -j"$(nproc)" chronyd chronyc
+strip chronyd chronyc
+install -m 0755 chronyd "$BIN_DIR/chronyd"
+install -m 0755 chronyc "$BIN_DIR/chronyc"
+
+if command -v file >/dev/null 2>&1; then
+    echo "Installed binary type: $(file "$BIN_DIR/chronyd")"
+    echo "Installed binary type: $(file "$BIN_DIR/chronyc")"
+fi
+
+echo "Finished installing $PROJECT_NAME"

--- a/core/tools/chrony/chrony.conf
+++ b/core/tools/chrony/chrony.conf
@@ -1,0 +1,32 @@
+# BlueOS chrony configuration.
+#
+# chronyd is started by start-blueos-core and disciplines the shared system clock
+# (the container shares the host's clock). Other services can inspect and extend
+# this at runtime via chronyc.
+
+# Default upstream sources, used whenever the vehicle can reach them (topside /
+# internet). `iburst` speeds up the initial sync. Services can add more sources
+# at runtime.
+pool pool.ntp.org iburst
+
+# Serve NTP to devices on the vehicle network. Restrict to typical BlueOS subnets.
+# TODO(chrony): drive these from settings / detected interfaces.
+allow 192.168.2.0/24
+allow 192.168.0.0/16
+allow 10.0.0.0/8
+
+# Even with no upstream source, act as a stratum-10 server so vehicle-network
+# clients can still synchronize to a single, consistent on-board clock.
+local stratum 10
+
+# Record the rate at which the system clock gains/loses time to speed up sync
+# after a restart.
+driftfile /usr/blueos/userdata/chrony/chrony.drift
+
+# Step the clock (instead of slewing) only during the first few updates after
+# start-up, when the offset is larger than 1 second. Afterwards, only slew, to
+# avoid time jumps while the system is running.
+makestep 1.0 3
+
+# Save/restore clock from the RTC if one is present (no-op otherwise).
+rtcsync

--- a/core/tools/install-static-binaries.sh
+++ b/core/tools/install-static-binaries.sh
@@ -8,6 +8,7 @@ set -e
 TOOLS=(
     blueos_startup_update
     bridges
+    chrony
     disktest
     linux2rest
     machineid

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -6,6 +6,7 @@ set -e
 
 TOOLS=(
     ardupilot_tools
+    chrony
     filebrowser
     logviewer
     scripts


### PR DESCRIPTION
## Summary by Sourcery

Add chrony time synchronization tooling to BlueOS and ensure its binaries are included in the core image.

New Features:
- Provide chronyd and chronyc as bundled BlueOS system tools for time synchronization and NTP serving.
- Add a bootstrap script to build and install static chrony binaries for CI and tooling workflows.
- Introduce a default chrony configuration tailored for BlueOS vehicle networks and shared host clock usage.

Build:
- Include chronyd and chronyc in the core Docker image via static binary installation tooling.

Chores:
- Register chrony in the system and static tools installation scripts so it is set up alongside existing BlueOS tools.