### PR TITLE
Frontend: allow calibrating without a global position, add warning

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/compass/FullCompassCalibrator.vue
@@ -26,7 +26,7 @@
             readings to the expected local magnetic field.
           </p>
           <p>
-            A valid global region/position is <strong>recomended</strong> for Onboard Calibration to
+            A valid global region/position is <strong>recommended</strong> for Onboard Calibration to
             estimate the local world magnetic field.
           </p>
         </span>
@@ -76,12 +76,15 @@
 
         <StatusTextWatcher :filter="/.*/" :style="`display : ${status_type === 'error' ? 'block' : 'none'};`" />
       </v-card-text>
+      <v-alert v-if="!coordinates" type="warning" dense text class="text-caption mx-4 mb-0">
+        Calibration without a valid global region/position is not recommended.
+      </v-alert>
       <v-card-actions>
         <v-spacer />
         <v-btn
           v-if="state !== states.CALIBRATING && state !== states.FAILED"
           color="primary"
-          :disabled="!compass_mask || !coordinates"
+          :disabled="!compass_mask"
           @click="calibrate()"
         >
           Calibrate


### PR DESCRIPTION
needs testing

## Summary by Sourcery

Allow compass calibration to proceed without a global region/position while warning users that this is not recommended.

Enhancements:
- Relax the calibration button requirement to no longer depend on having coordinates.
- Fix the spelling of the recommendation text in the onboard calibration description.