### PR TITLE
frontend: fix usage of autopilot_data instead of autopilot

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/ArdupilotVehicleBodySetup.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/ArdupilotVehicleBodySetup.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
       return autopilot_data.parameter('FRAME_CONFIG') || autopilot_data.parameter('FRAME_CLASS')
     },
     frame_type_parameter(): Parameter | undefined {
-      switch (autopilot_data.vehicle_type) {
+      switch (autopilot.vehicle_type) {
         case 'Submarine':
         case 'Surface Boat':
           return autopilot_data.parameter('FRAME_TYPE')


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix frame type parameter resolution by switching on the correct autopilot vehicle type property.