### PR TITLE
core: ardupilot_manager: use SIM_OPOS_* defaults instead of --home for SITL

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 from copy import deepcopy
 from typing import Any, List, Optional, Set
+from uuid import uuid4
 
 import psutil
 from commonwealth.mavlink_comm.VehicleManager import VehicleManager
@@ -472,11 +473,23 @@ class AutoPilotManager(metaclass=Singleton):
         # The default spawn location (Florianópolis) is provided as SIM_OPOS_* parameter
         # defaults instead of --home, which would lock the location and prevent users
         # from overriding it with the SIM_OPOS_* parameters.
+        sitl_defaults = "SIM_OPOS_LAT -27.563\nSIM_OPOS_LNG -48.459\nSIM_OPOS_ALT 0.0\nSIM_OPOS_HDG 270.0\n"
         sitl_defaults_path = pathlib.Path(self.settings.firmware_folder, "sitl_defaults.parm")
-        sitl_defaults_path.write_text(
-            "SIM_OPOS_LAT -27.563\nSIM_OPOS_LNG -48.459\nSIM_OPOS_ALT 0.0\nSIM_OPOS_HDG 270.0\n",
-            encoding="utf-8",
-        )
+        try:
+            current_defaults = sitl_defaults_path.read_text(encoding="utf-8") if sitl_defaults_path.is_file() else None
+            if current_defaults != sitl_defaults:
+                # Unique temporary name plus atomic replace so concurrent calls cannot
+                # race each other or expose a partially written file.
+                temp_defaults_path = sitl_defaults_path.with_name(f"sitl_defaults.parm.{uuid4().hex}.tmp")
+                temp_defaults_path.write_text(sitl_defaults, encoding="utf-8")
+                os.replace(temp_defaults_path, sitl_defaults_path)
+            defaults_args = ["--defaults", str(sitl_defaults_path)]
+        except OSError as error:
+            logger.warning(
+                f"Failed to write SITL defaults file, falling back to --home "
+                f"(SIM_OPOS_* position overrides will not apply): {error}"
+            )
+            defaults_args = ["--home", "-27.563,-48.459,0.0,270.0"]
 
         # pylint: disable=consider-using-with
         self.ardupilot_subprocess = subprocess.Popen(
@@ -486,8 +499,7 @@ class AutoPilotManager(metaclass=Singleton):
                 self.current_sitl_frame.value,
                 "--base-port",
                 str(master_endpoint.argument),
-                "--defaults",
-                str(sitl_defaults_path),
+                *defaults_args,
             ],
             shell=False,
             encoding="utf-8",

--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -469,6 +469,15 @@ class AutoPilotManager(metaclass=Singleton):
             argument=5760,
             protected=True,
         )
+        # The default spawn location (Florianópolis) is provided as SIM_OPOS_* parameter
+        # defaults instead of --home, which would lock the location and prevent users
+        # from overriding it with the SIM_OPOS_* parameters.
+        sitl_defaults_path = pathlib.Path(self.settings.firmware_folder, "sitl_defaults.parm")
+        sitl_defaults_path.write_text(
+            "SIM_OPOS_LAT -27.563\nSIM_OPOS_LNG -48.459\nSIM_OPOS_ALT 0.0\nSIM_OPOS_HDG 270.0\n",
+            encoding="utf-8",
+        )
+
         # pylint: disable=consider-using-with
         self.ardupilot_subprocess = subprocess.Popen(
             [
@@ -477,8 +486,8 @@ class AutoPilotManager(metaclass=Singleton):
                 self.current_sitl_frame.value,
                 "--base-port",
                 str(master_endpoint.argument),
-                "--home",
-                "-27.563,-48.459,0.0,270.0",
+                "--defaults",
+                str(sitl_defaults_path),
             ],
             shell=False,
             encoding="utf-8",


### PR DESCRIPTION
## Problem

The built-in SITL spawn location is hardcoded via `--home` in `start_sitl()`. Because `--home` sets `home_is_set` on the ArduPilot side, the standard `SIM_OPOS_*` parameters are never read (`SIM_Aircraft.cpp::update_home()` only falls back to them when `--home` is absent), so there is currently no way to change where SITL spawns — not via parameters, API, or UI.

## Solution

Stop passing `--home` and instead provide the same default location (Florianópolis) as parameter defaults, via a generated `--defaults` file setting `SIM_OPOS_LAT/LNG/ALT/HDG`.

Since user-stored parameter values take precedence over defaults, the spawn location becomes configurable from any GCS (QGC parameter editor, MAVProxy `param set`, …) and persists across restarts, while the location itself is resolved entirely by ArduPilot's parameter system:

| State | Spawn location |
|---|---|
| `SIM_OPOS_*` never set (or reset) | Florianópolis — identical to current behavior |
| `SIM_OPOS_*` set by the user | The user's location |

No UI, API, or settings changes are needed, and there is zero behavior change for existing users. This also follows the existing `--defaults` usage for physical Linux boards (`get_default_params_cmdline()` in `start_linux_board()`).

## Testing

Verified on a Raspberry Pi running BlueOS `master` with the distributed ArduCopter SITL binary (`--model quad`, `ardupilot_sitl_arm_linux_gnueabihf`):

- The distributed SITL binary supports `--defaults`, and the file is layered on top of the embedded per-frame defaults: `Loaded defaults from @ROMFS/default_params/copter.parm,.../sitl_defaults.parm`
- With no user-set parameters, SITL spawns at the previous default: `Home: -27.563000 -48.459000 alt=0.000000m hdg=270.000000`
- Setting `SIM_OPOS_LAT/LNG` via GCS and restarting the autopilot spawns the vehicle at the new location, persisting across restarts

## Note

This change was developed with AI assistance (Claude Code) and reviewed, tested, and committed by me. I'm aware of the recent `block-ai-commits.yml` workflow — happy to discuss or rework the contribution if AI-assisted changes are not acceptable.

## Summary by Sourcery

Enhancements:
- Generate a sitl_defaults.parm file with default SIM_OPOS_LAT/LNG/ALT/HDG values matching the previous Florianópolis home location and pass it via --defaults when starting SITL.