### PR TITLE
migrate Beacon from Pykson to Pydantic

### DIFF
--- a/core/services/beacon/main.py
+++ b/core/services/beacon/main.py
@@ -8,7 +8,7 @@ import socket
 from typing import Any, Dict, List, Optional
 
 import psutil
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
 from commonwealth.utils.apis import PrettyJSONResponse
 from commonwealth.utils.logs import init_logger
 from commonwealth.utils.sentry_config import init_sentry_async
@@ -78,14 +78,14 @@ class Beacon:
     def __init__(self) -> None:
         self.runners: Dict[str, AsyncRunner] = {}
         try:
-            self.manager = Manager(SERVICE_NAME, SettingsV4)
+            self.manager = PydanticManager(SERVICE_NAME, SettingsV4)
         except Exception as e:
             logger.warning(f"failed to load configuration file ({e}), loading defaults")
             self.load_default_settings()
 
-        # manager still returns "valid" settings even if file is absent, so we check for the "default" field
+        # manager still returns "valid" settings even if file is absent, so we check for empty advertisement_types
         # TODO: fix after https://github.com/bluerobotics/BlueOS-docker/issues/880 is solved
-        if self.manager.settings.default is None:
+        if not self.manager.settings.advertisement_types:
             logger.warning("No configuration found, loading defaults...")
             self.load_default_settings()
         self.settings = self.manager.settings
@@ -95,7 +95,7 @@ class Beacon:
         current_folder = pathlib.Path(__file__).parent.resolve()
         default_settings_file = current_folder / "default-settings.json"
         logger.debug("loading settings from ", default_settings_file)
-        self.manager = Manager(SERVICE_NAME, SettingsV4, load=False)
+        self.manager = PydanticManager(SERVICE_NAME, SettingsV4, load=False)
         self.manager.settings = self.manager.load_from_file(SettingsV4, default_settings_file)
         self.manager.save()
 

--- a/core/services/beacon/settings.py
+++ b/core/services/beacon/settings.py
@@ -1,37 +1,29 @@
 import json
 import re
 import socket
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal, Optional
 
 import psutil
-from commonwealth.settings import settings
+from commonwealth.settings.settings import PydanticSettings
 from loguru import logger
-from pykson import (
-    IntegerField,
-    JsonObject,
-    ListField,
-    MultipleChoiceStringField,
-    ObjectField,
-    ObjectListField,
-    StringField,
-)
+from pydantic import BaseModel, Field
 
 
 class InvalidIpAddress(Exception):
     pass
 
 
-class DefaultSettings(JsonObject):
-    domain_names = ListField(item_type=str)
-    advertise = ListField(item_type=str)
-    ip = StringField()
+class DefaultSettings(BaseModel):
+    domain_names: List[str] = Field(default_factory=list)
+    advertise: List[str] = Field(default_factory=list)
+    ip: str = ""
 
 
-class Interface(JsonObject):
-    name = StringField()
-    domain_names = ListField(item_type=str)
-    advertise = ListField(item_type=str)
-    ip = StringField()
+class Interface(BaseModel):
+    name: str
+    domain_names: List[str] = Field(default_factory=list)
+    advertise: List[str] = Field(default_factory=list)
+    ip: str = ""
 
     def get_phys(self) -> List[psutil._common.snicaddr]:
         """
@@ -83,11 +75,11 @@ class Interface(JsonObject):
         return str(self.name)
 
 
-class ServiceTypes(JsonObject):
-    name = StringField()
-    protocol = MultipleChoiceStringField(options=["_udp", "_tcp"], null=False)
-    port = IntegerField()
-    properties = StringField()
+class ServiceTypes(BaseModel):
+    name: str
+    protocol: Literal["_udp", "_tcp"]
+    port: int
+    properties: Optional[str] = None
 
     def get_properties(self) -> Dict[str, Any]:
         if self.properties is None:
@@ -95,26 +87,20 @@ class ServiceTypes(JsonObject):
         return json.loads(self.properties)  # type: ignore
 
 
-class SettingsV1(settings.BaseSettings):
-    VERSION = 1
-    default = ObjectField(DefaultSettings)
-    blacklist = ListField(item_type=str)
-    interfaces = ObjectListField(Interface)
-    advertisement_types = ObjectListField(ServiceTypes)
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-
-        self.VERSION = SettingsV1.VERSION
+class SettingsV1(PydanticSettings):
+    default: DefaultSettings = Field(default_factory=DefaultSettings)
+    blacklist: List[str] = Field(default_factory=list)
+    interfaces: List[Interface] = Field(default_factory=list)
+    advertisement_types: List[ServiceTypes] = Field(default_factory=list)
 
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV1.VERSION:
+        if data["VERSION"] == SettingsV1.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV1.VERSION:
+        if data["VERSION"] < SettingsV1.STATIC_VERSION:
             super().migrate(data)
 
-        data["VERSION"] = SettingsV1.VERSION
+        data["VERSION"] = SettingsV1.STATIC_VERSION
 
     def get_interface_or_create_default(self, name: str) -> Interface:
         """
@@ -133,17 +119,11 @@ class SettingsV1(settings.BaseSettings):
 
 
 class SettingsV2(SettingsV1):
-    VERSION = 2
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-        self.VERSION = SettingsV2.VERSION
-
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV2.VERSION:
+        if data["VERSION"] == SettingsV2.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV2.VERSION:
+        if data["VERSION"] < SettingsV2.STATIC_VERSION:
             super().migrate(data)
 
         data["default"]["domain_names"] = [domain for domain in data["default"]["domain_names"] if domain != "blueos"]
@@ -156,47 +136,36 @@ class SettingsV2(SettingsV1):
         except Exception as e:
             logger.error(f"unable to update SettingsV1 to SettingsV2: {e}")
 
-        data["VERSION"] = SettingsV2.VERSION
+        data["VERSION"] = SettingsV2.STATIC_VERSION
 
 
 class SettingsV3(SettingsV2):
-    VERSION = 3
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-        self.VERSION = SettingsV3.VERSION
-
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV3.VERSION:
+        if data["VERSION"] == SettingsV3.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV3.VERSION:
+        if data["VERSION"] < SettingsV3.STATIC_VERSION:
             super().migrate(data)
 
         try:
             if not any(interface["name"] == "uap0" for interface in data["interfaces"]):
                 data["interfaces"].append(
-                    Interface(name="uap0", domain_names=["blueos-hotspot"], advertise=["_http"], ip="ips[0]")._data
+                    Interface(name="uap0", domain_names=["blueos-hotspot"], advertise=["_http"], ip="ips[0]").dict()
                 )
         except Exception as e:
             logger.error(f"unable to update SettingsV2 to SettingsV3: {e}")
 
-        data["VERSION"] = SettingsV3.VERSION
+        data["VERSION"] = SettingsV3.STATIC_VERSION
 
 
 class SettingsV4(SettingsV3):
-    VERSION = 4
-    vehicle_name = StringField()
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-        self.VERSION = SettingsV4.VERSION
+    vehicle_name: Optional[str] = None
 
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV4.VERSION:
+        if data["VERSION"] == SettingsV4.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV4.VERSION:
+        if data["VERSION"] < SettingsV4.STATIC_VERSION:
             super().migrate(data)
 
-        data["VERSION"] = SettingsV4.VERSION
+        data["VERSION"] = SettingsV4.STATIC_VERSION


### PR DESCRIPTION
## Summary by Sourcery

Migrate Beacon service configuration from the legacy settings/serialization system to Pydantic-based models and manager.

Enhancements:
- Replace Pykson-based settings models with Pydantic BaseModel and PydanticSettings implementations for Beacon configuration.
- Update configuration manager usage from Manager to PydanticManager in the Beacon service startup.
- Align settings migration logic and version handling with the new Pydantic settings infrastructure, including safer defaults and interface serialization.