### PR TITLE
migrate wifi from Pykson to Pydantic

### DIFF
--- a/core/services/wifi/settings.py
+++ b/core/services/wifi/settings.py
@@ -1,26 +1,19 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-import pykson  # type: ignore
-from commonwealth.settings import settings
+from commonwealth.settings.settings import PydanticSettings
 
 
-class SettingsV1(settings.BaseSettings):
-    VERSION = 1
-    hotspot_enabled = pykson.BooleanField()
-    hotspot_ssid = pykson.StringField()
-    hotspot_password = pykson.StringField()
-    smart_hotspot_enabled = pykson.BooleanField()
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-
-        self.VERSION = SettingsV1.VERSION
+class SettingsV1(PydanticSettings):
+    hotspot_enabled: Optional[bool] = None
+    hotspot_ssid: Optional[str] = None
+    hotspot_password: Optional[str] = None
+    smart_hotspot_enabled: Optional[bool] = None
 
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV1.VERSION:
+        if data["VERSION"] == SettingsV1.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV1.VERSION:
+        if data["VERSION"] < SettingsV1.STATIC_VERSION:
             super().migrate(data)
 
-        data["VERSION"] = SettingsV1.VERSION
+        data["VERSION"] = SettingsV1.STATIC_VERSION

--- a/core/services/wifi/wifi_handlers/AbstractWifiHandler.py
+++ b/core/services/wifi/wifi_handlers/AbstractWifiHandler.py
@@ -2,7 +2,7 @@ import abc
 from argparse import ArgumentParser, Namespace
 from typing import List, Optional
 
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
 from settings import SettingsV1
 from typedefs import SavedWifiNetwork, ScannedWifiNetwork, WifiCredentials, WifiStatus
 from wifi_handlers.wpa_supplicant.wpa_supplicant import WPASupplicant
@@ -12,7 +12,7 @@ class AbstractWifiManager:
     wpa = WPASupplicant()
 
     def __init__(self) -> None:
-        self._settings_manager = Manager("wifi-manager", SettingsV1)
+        self._settings_manager = PydanticManager("wifi-manager", SettingsV1)
         self._settings_manager.load()
 
     @abc.abstractmethod


### PR DESCRIPTION
## Summary by Sourcery

Migrate the wifi service settings from the legacy Pykson-based configuration system to the Pydantic-based settings framework.

Enhancements:
- Update SettingsV1 to use PydanticSettings with typed optional fields for hotspot configuration.
- Switch the wifi AbstractWifiManager to use the Pydantic-based settings manager implementation.