### PR TITLE
migrate ping from Pykson to Pydantic

### DIFF
--- a/core/services/ping/ping1d_driver.py
+++ b/core/services/ping/ping1d_driver.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from bridges.bridges import Bridge
 from bridges.serialhelper import Baudrate
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
 from loguru import logger
 from ping1d_mavlink import Ping1DMavlinkDriver
 from pingdriver import PingDriver
@@ -19,7 +19,7 @@ class Ping1DDriver(PingDriver):
     def __init__(self, ping: PingDeviceDescriptor, port: int) -> None:
         super().__init__(ping, port)
         # load settings
-        self.manager = Manager(SERVICE_NAME, SettingsV1, USERDATA / "settings" / SERVICE_NAME)
+        self.manager = PydanticManager(SERVICE_NAME, SettingsV1, USERDATA / "settings" / SERVICE_NAME)
         # our settings file is a list for each sensor type.
         # check the list to find our current sensor in it
         connection_info = self.ping.get_hw_or_eth_info()


### PR DESCRIPTION
## Summary by Sourcery

Migrate the ping service configuration from the legacy Pykson-based settings system to Pydantic-based models and settings manager.

Enhancements:
- Replace Pykson JsonObject models with Pydantic BaseModel for Ping1D settings specifications.
- Update the ping service settings container to use PydanticSettings with a typed list field and static version constant.
- Switch the ping driver to use PydanticManager for loading and managing service settings.