### PR TITLE
migrate nmea_injector from Pykson to Pydantic

### DIFF
--- a/core/services/nmea_injector/nmea_injector/TrafficController.py
+++ b/core/services/nmea_injector/nmea_injector/TrafficController.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple, Union
 
 import pynmea2
 from commonwealth.mavlink_comm.MavlinkComm import MavlinkMessenger
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
 from loguru import logger
 from nmea_injector.exceptions import UnsupportedSocketKind
 from nmea_injector.MavlinkNMEA import MavlinkGpsInput, parse_mavlink_from_sentence
@@ -96,7 +96,7 @@ class TrafficController:
 
     def __init__(self) -> None:
         self._socks: Dict[NMEASocket, Union[asyncio.AbstractServer, asyncio.BaseTransport]] = {}
-        self._settings_manager = Manager("nmea-injector", SettingsV1)
+        self._settings_manager = PydanticManager("nmea-injector", SettingsV1)
 
     async def load_socks_from_settings(self) -> None:
         self._settings_manager.load()

--- a/core/services/nmea_injector/nmea_injector/settings.py
+++ b/core/services/nmea_injector/nmea_injector/settings.py
@@ -1,13 +1,13 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
-import pykson  # type: ignore
-from commonwealth.settings import settings
+from commonwealth.settings.settings import PydanticSettings
+from pydantic import BaseModel, Field
 
 
-class NmeaInjectorSettingsSpecV1(pykson.JsonObject):
-    kind = pykson.StringField()
-    port = pykson.IntegerField()
-    component_id = pykson.IntegerField()
+class NmeaInjectorSettingsSpecV1(BaseModel):
+    kind: str
+    port: int
+    component_id: int
 
     def __eq__(self, other: object) -> Any:
         if isinstance(other, NmeaInjectorSettingsSpecV1):
@@ -15,20 +15,14 @@ class NmeaInjectorSettingsSpecV1(pykson.JsonObject):
         return False
 
 
-class SettingsV1(settings.BaseSettings):
-    VERSION = 1
-    specs = pykson.ObjectListField(NmeaInjectorSettingsSpecV1)
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-
-        self.VERSION = SettingsV1.VERSION
+class SettingsV1(PydanticSettings):
+    specs: List[NmeaInjectorSettingsSpecV1] = Field(default_factory=list)
 
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV1.VERSION:
+        if data["VERSION"] == SettingsV1.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV1.VERSION:
+        if data["VERSION"] < SettingsV1.STATIC_VERSION:
             super().migrate(data)
 
-        data["VERSION"] = SettingsV1.VERSION
+        data["VERSION"] = SettingsV1.STATIC_VERSION


### PR DESCRIPTION
## Summary by Sourcery

Migrate the nmea_injector service configuration from the legacy Pykson-based settings to Pydantic-based settings and management.

Enhancements:
- Replace NmeaInjectorSettingsSpecV1 Pykson model with a Pydantic BaseModel definition.
- Update SettingsV1 to extend PydanticSettings with a list of specs and adjusted version handling.
- Switch TrafficController to use PydanticManager for loading nmea-injector settings.