### PR TITLE
migrate kraken from Pykson to Pydantic

### DIFF
--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -72,7 +72,7 @@ class Extension:
 
     @property
     def settings(self) -> ExtensionSettings:
-        return cast(ExtensionSettings, self._fetch_settings(self.identifier, self.tag))
+        return self._fetch_settings(self.identifier, self.tag)
 
     @classmethod
     def lock(cls, key: str) -> None:
@@ -95,20 +95,19 @@ class Extension:
         cls.start_attempts.pop(key, None)
 
     @classmethod
-    def _fetch_settings(
-        cls, identifier: Optional[str] = None, tag: Optional[str] = None
-    ) -> List[ExtensionSettings] | ExtensionSettings:
-        extensions: List[ExtensionSettings] = [
+    def _list_settings(cls, identifier: Optional[str] = None, tag: Optional[str] = None) -> List[ExtensionSettings]:
+        return [
             ext
             for ext in cast(List[ExtensionSettings], cls._settings.extensions)
             if (identifier is None or ext.identifier == identifier) and (tag is None or ext.tag == tag)
         ]
 
-        if identifier is not None and tag is not None:
-            if not extensions:
-                raise ExtensionNotFound(f"Extension {identifier}:{tag} not found")
-            return extensions[0]
-        return extensions
+    @classmethod
+    def _fetch_settings(cls, identifier: str, tag: str) -> ExtensionSettings:
+        extensions = cls._list_settings(identifier, tag)
+        if not extensions:
+            raise ExtensionNotFound(f"Extension {identifier}:{tag} not found")
+        return extensions[0]
 
     def _save_settings(self, extension: Optional[ExtensionSettings] = None) -> None:
         self._settings.extensions = [
@@ -353,13 +352,11 @@ class Extension:
     async def from_settings(
         cls, identifier: Optional[str] = None, tag: Optional[str] = None
     ) -> List["Extension"] | "Extension":
-        extensions: List[ExtensionSettings] | ExtensionSettings = cls._fetch_settings(identifier, tag)
-
-        if isinstance(extensions, ExtensionSettings):
-            return Extension(ExtensionSource.from_settings(extensions))
+        if identifier is not None and tag is not None:
+            return Extension(ExtensionSource.from_settings(cls._fetch_settings(identifier, tag)))
 
         return sorted(
-            [Extension(ExtensionSource.from_settings(ext)) for ext in extensions],
+            [Extension(ExtensionSource.from_settings(ext)) for ext in cls._list_settings(identifier, tag)],
             key=lambda ext: ext.source.name,
         )
 
@@ -671,7 +668,7 @@ class Extension:
         """
         Refresh the keep-alive timestamp for a temporary extension identified by temp_tag.
         """
-        temp_settings = cast(ExtensionSettings, cls._fetch_settings("", temp_tag))
+        temp_settings = cls._fetch_settings("", temp_tag)
         if temp_settings.identifier:
             raise ExtensionNotFound(f"Extension with tag {temp_tag} is not temporary")
 
@@ -684,7 +681,7 @@ class Extension:
         """
         Clean up temporary extensions (those with empty identifiers) and their images when expired.
         """
-        extensions: List[ExtensionSettings] = cls._fetch_settings()
+        extensions: List[ExtensionSettings] = cls._list_settings()
         temp_extensions = [ext for ext in extensions if not ext.identifier or ext.identifier == ""]
         active_temp_refs: Set[str] = {f"{ext.docker}:{ext.tag}" for ext in temp_extensions}
 

--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 from aiodocker.exceptions import DockerError
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
 from config import DEFAULT_INJECTED_ENV_VARIABLES, SERVICE_NAME
 from extension.exceptions import (
     ExtensionInsufficientStorage,
@@ -51,7 +51,7 @@ class Extension:
     start_attempts: Dict[str, Tuple[int, int]] = {}
     temp_extension_activity: Dict[str, Tuple[int, int]] = {}
 
-    _manager: Manager = Manager(SERVICE_NAME, SettingsV2)
+    _manager: PydanticManager = PydanticManager(SERVICE_NAME, SettingsV2)
     _settings = _manager.settings
 
     def __init__(self, source: ExtensionSource, digest: Optional[str] = None) -> None:

--- a/core/services/kraken/kraken.py
+++ b/core/services/kraken/kraken.py
@@ -4,7 +4,7 @@ import traceback
 from typing import Any, List
 
 import aiohttp
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
 from config import DEFAULT_EXTENSIONS, SERVICE_NAME
 from extension.exceptions import IncompatibleExtension
 from extension.extension import Extension
@@ -21,7 +21,7 @@ from settings import ExtensionSettings, SettingsV2
 
 class Kraken:
     def __init__(self) -> None:
-        self._manager: Manager = Manager(SERVICE_NAME, SettingsV2)
+        self._manager: PydanticManager = PydanticManager(SERVICE_NAME, SettingsV2)
         self._settings = self._manager.settings
         self.is_running = True
         self.manifest = ManifestManager.instance()

--- a/core/services/kraken/kraken.py
+++ b/core/services/kraken/kraken.py
@@ -54,7 +54,7 @@ class Kraken:
             logger.error(f"Unable to list docker containers: {e}")
             return
 
-        extensions: List[ExtensionSettings] = Extension._fetch_settings()
+        extensions: List[ExtensionSettings] = Extension._list_settings()
 
         for extension in extensions:
             if not self._extension_start_try_valid(extension):
@@ -104,7 +104,7 @@ class Kraken:
         return True
 
     async def setup_default_extensions(self) -> None:
-        extensions: List[ExtensionSettings] = Extension._fetch_settings()
+        extensions: List[ExtensionSettings] = Extension._list_settings()
         for ext in [
             ext
             for ext in DEFAULT_EXTENSIONS
@@ -124,7 +124,7 @@ class Kraken:
                 logger.info(f"Created job to install default extension {ext['identifier']}")
 
     async def kill_invalid_extensions(self) -> None:
-        extensions: List[ExtensionSettings] = Extension._fetch_settings()
+        extensions: List[ExtensionSettings] = Extension._list_settings()
 
         for extension in extensions:
             if not extension.is_valid():
@@ -150,7 +150,7 @@ class Kraken:
             logger.error(f"Unable to list docker containers: {e}")
             return
 
-        extensions: List[ExtensionSettings] = Extension._fetch_settings()
+        extensions: List[ExtensionSettings] = Extension._list_settings()
 
         for container in containers:
             container_name = container.name[1:]

--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, List, Optional, Set, Tuple, cast
 import aiohttp
 import semver
 from aiocache import cached
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
 from config import DEFAULT_MANIFESTS, SERVICE_NAME
 from manifest.exceptions import (
     ManifestBackendOffline,
@@ -33,7 +33,7 @@ class ManifestManager:
     """
 
     _instance: Optional["ManifestManager"] = None
-    _manager: Manager = Manager(SERVICE_NAME, SettingsV2)
+    _manager: PydanticManager = PydanticManager(SERVICE_NAME, SettingsV2)
     _settings = _manager.settings
 
     def __init__(self) -> None:

--- a/core/services/kraken/settings.py
+++ b/core/services/kraken/settings.py
@@ -1,25 +1,25 @@
 import json
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from commonwealth.settings import settings
-from commonwealth.settings.manager import Manager
+from commonwealth.settings.manager import PydanticManager
+from commonwealth.settings.settings import PydanticSettings
 from config import SERVICE_NAME
-from pykson import BooleanField, IntegerField, JsonObject, ObjectListField, StringField
+from pydantic import BaseModel, Field
 
 
 def get_extension_settings() -> List["ExtensionSettings"]:
-    return list(Manager(SERVICE_NAME, SettingsV2).settings.extensions)
+    return list(PydanticManager(SERVICE_NAME, SettingsV2).settings.extensions)
 
 
-class ExtensionSettings(JsonObject):
-    identifier = StringField()
-    name = StringField()
-    docker = StringField()
-    tag = StringField()
-    permissions = StringField()
-    enabled = BooleanField()
-    user_permissions = StringField()
+class ExtensionSettings(BaseModel):
+    identifier: str
+    name: str
+    docker: str
+    tag: str
+    permissions: str
+    enabled: bool
+    user_permissions: Optional[str] = None
 
     def settings(self) -> Any:
         if self.user_permissions:
@@ -39,49 +39,37 @@ class ExtensionSettings(JsonObject):
         return "extension-" + regex.sub("", f"{self.docker}{self.tag}")
 
 
-class ManifestSettings(JsonObject):
-    identifier = StringField()
-    enabled = BooleanField()
-    priority = IntegerField()
-    factory = BooleanField()
-    name = StringField()
-    url = StringField()
+class ManifestSettings(BaseModel):
+    identifier: str
+    enabled: bool
+    priority: int
+    factory: bool
+    name: str
+    url: str
 
 
-class SettingsV1(settings.BaseSettings):
-    VERSION = 1
-    extensions = ObjectListField(ExtensionSettings)
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-
-        self.VERSION = SettingsV1.VERSION
+class SettingsV1(PydanticSettings):
+    extensions: List[ExtensionSettings] = Field(default_factory=list)
 
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV1.VERSION:
+        if data["VERSION"] == SettingsV1.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV1.VERSION:
+        if data["VERSION"] < SettingsV1.STATIC_VERSION:
             super().migrate(data)
 
-        data["VERSION"] = SettingsV1.VERSION
+        data["VERSION"] = SettingsV1.STATIC_VERSION
 
 
 class SettingsV2(SettingsV1):
-    VERSION = 2
-    manifests = ObjectListField(ManifestSettings)
-
-    def __init__(self, *args: str, **kwargs: int) -> None:
-        super().__init__(*args, **kwargs)
-
-        self.VERSION = SettingsV2.VERSION
+    manifests: List[ManifestSettings] = Field(default_factory=list)
 
     def migrate(self, data: Dict[str, Any]) -> None:
-        if data["VERSION"] == SettingsV2.VERSION:
+        if data["VERSION"] == SettingsV2.STATIC_VERSION:
             return
 
-        if data["VERSION"] < SettingsV2.VERSION:
+        if data["VERSION"] < SettingsV2.STATIC_VERSION:
             super().migrate(data)
 
-            data["VERSION"] = SettingsV2.VERSION
+            data["VERSION"] = SettingsV2.STATIC_VERSION
             data["manifests"] = []


### PR DESCRIPTION
## Summary by Sourcery

Migrate Kraken service settings and related models from the legacy Pykson-based settings system to Pydantic-based settings management.

New Features:
- Introduce Pydantic-based models for extension and manifest settings used by the Kraken service.

Enhancements:
- Update Kraken, extension, and manifest managers to use the new Pydantic settings manager and static versioning for settings migration.
- Simplify settings schemas by replacing Pykson field declarations with standard Pydantic model fields and defaults.