### PR TITLE
Commonwealth: deal with race condition in Beacon

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/settings/bases/pydantic_base.py
+++ b/core/libs/commonwealth/src/commonwealth/settings/bases/pydantic_base.py
@@ -2,6 +2,7 @@ import abc
 import json
 import os
 import pathlib
+import threading
 from typing import Any, ClassVar, Dict, List, Type, TypeVar, cast
 
 from commonwealth.settings.exceptions import (
@@ -13,6 +14,8 @@ from commonwealth.settings.exceptions import (
 )
 from loguru import logger
 from pydantic import BaseModel, ValidationError
+
+_save_lock = threading.Lock()
 
 try:
     from pydantic.version import VERSION as PYDANTIC_VERSION
@@ -120,18 +123,22 @@ class PydanticSettings(BaseModel):
 
         # Prepare data prior to operation
         logger.debug(f"Saving settings on: {file_path}")
-        json_data = self._model_dump()
 
-        # Create a temporary file in same directory, write and rename it to the original file
-        temp_file = file_path.with_suffix(".tmp")
-        with open(temp_file, "w", encoding="utf-8") as settings_file:
-            json.dump(json_data, settings_file, indent=4)
-            # Ensure data is written to disk
-            settings_file.flush()
-            os.fsync(settings_file.fileno())
-        # Replace the original file with the temporary file, this operation is atomic if in the same filesystem
-        # https://docs.python.org/3/library/os.html#os.replace
-        temp_file.replace(file_path)
+        # Serialize inside the lock so the write section runs by a single thread at a time. This keeps the
+        # temporary file from colliding and ensures the last writer serializes every mutation made before it.
+        with _save_lock:
+            json_data = self._model_dump()
+
+            # Create a temporary file in same directory, write and rename it to the original file
+            temp_file = file_path.with_suffix(".tmp")
+            with open(temp_file, "w", encoding="utf-8") as settings_file:
+                json.dump(json_data, settings_file, indent=4)
+                # Ensure data is written to disk
+                settings_file.flush()
+                os.fsync(settings_file.fileno())
+            # Replace the original file with the temporary file, this operation is atomic if in the same filesystem
+            # https://docs.python.org/3/library/os.html#os.replace
+            temp_file.replace(file_path)
 
     def reset(self) -> None:
         """Reset internal data to default values"""

--- a/core/libs/commonwealth/src/commonwealth/settings/tests/test_manager_pydantic.py
+++ b/core/libs/commonwealth/src/commonwealth/settings/tests/test_manager_pydantic.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import tempfile
+import threading
 from typing import Any, Dict
 
 from ..bases.pydantic_base import PydanticSettings
@@ -247,3 +248,41 @@ def test_invalid_json_fallback_to_defaults_v2_from_invalid_v2_and_v1() -> None:
     assert settings_manager.settings.VERSION == 2
     assert settings_manager.settings.version_1_variable == 42
     assert settings_manager.settings.version_2_variable == 66
+
+
+def test_concurrent_saves_preserve_all_updates() -> None:
+    # Regression test for https://github.com/bluerobotics/BlueOS/issues/3998: two requests mutating and saving
+    # the same settings object at once must not crash on the temporary file and must both end up persisted.
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+
+    settings_manager = PydanticManager("ManagerTest", SettingsV2, config_path)
+
+    errors: list[Exception] = []
+    start = threading.Barrier(2)
+
+    def mutate_and_save(variable: str, value: int) -> None:
+        try:
+            start.wait()
+            for _ in range(100):
+                setattr(settings_manager.settings, variable, value)
+                settings_manager.save()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    threads = [
+        threading.Thread(target=mutate_and_save, args=("version_1_variable", 111)),
+        threading.Thread(target=mutate_and_save, args=("version_2_variable", 222)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, f"Concurrent saves raised: {errors}"
+
+    # Both updates must survive, and only the versioned settings file should remain (no leftover temp files).
+    reloaded = PydanticManager("ManagerTest", SettingsV2, config_path)
+    assert reloaded.settings.version_1_variable == 111
+    assert reloaded.settings.version_2_variable == 222
+    assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]


### PR DESCRIPTION
Fix #3998

<img width="1116" height="140" alt="image" src="https://github.com/user-attachments/assets/a3616585-7ee8-4506-898c-d34d782ba054" />


Also adds a regresstion test

## Summary by Sourcery

Serialize concurrent settings saves to avoid file races and ensure all updates are durably persisted.

Bug Fixes:
- Fix race condition in settings save that could corrupt or fail writes when multiple concurrent mutations occur.

Enhancements:
- Add global save lock to pydantic and pykson settings bases so only one thread performs the temporary-file write and replace at a time.

Tests:
- Add regression test verifying concurrent saves on the same settings object complete without errors and persist all updates with no leftover temporary files.

## Summary by Sourcery

Guard settings file writes with a global lock to prevent concurrent saves from corrupting or colliding on temporary files.

Bug Fixes:
- Prevent race conditions when multiple threads concurrently save settings, ensuring durable and consistent writes.

Enhancements:
- Add a global save lock to pydantic and pykson settings bases to serialize file write and replace operations across threads.

Tests:
- Add a regression test that mutates and saves shared settings concurrently to verify all updates are persisted and no temporary files are left behind.