### PR TITLE
core:services:kraken: Add explicit python-multipart dependency

### DIFF
--- a/core/services/kraken/pyproject.toml
+++ b/core/services/kraken/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "loguru==0.7.3",
     "psutil==7.1.3",
     "pydantic==2.12.5",
+    "python-multipart==0.0.21",
     "semver==3.0.4",
     "uvicorn==0.38.0",
 ]


### PR DESCRIPTION
Kraken was getting it from versionchooser, makes it explicit