### PR TITLE
Fix API root redirects behind Nginx

### DIFF
--- a/core/services/kraken/api/v1/routers/index.py
+++ b/core/services/kraken/api/v1/routers/index.py
@@ -59,4 +59,4 @@ async def root() -> RedirectResponse:
     """
     Root endpoint for the Kraken API V1.
     """
-    return RedirectResponse(url="/v1.0/docs")
+    return RedirectResponse(url="docs")

--- a/core/services/kraken/api/v2/routers/index.py
+++ b/core/services/kraken/api/v2/routers/index.py
@@ -14,4 +14,4 @@ async def root() -> RedirectResponse:
     """
     Root endpoint for the Kraken API V2.
     """
-    return RedirectResponse(url="/v2.0/docs")
+    return RedirectResponse(url="docs")

--- a/core/services/kraken/test_kraken.py
+++ b/core/services/kraken/test_kraken.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_api_root_redirects_to_relative_docs(version: str, tmp_path: Path) -> None:
+    service_path = Path(__file__).parent
+    environment = os.environ | {
+        "PYTHONPATH": str(service_path / "api" / version / "routers"),
+        "XDG_CONFIG_HOME": str(tmp_path),
+    }
+    script = 'import asyncio; from index import root; print(asyncio.run(root()).headers["location"])'
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=service_path,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.stdout == "docs\n"

--- a/core/services/kraken/test_kraken.py
+++ b/core/services/kraken/test_kraken.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.mark.parametrize("version", ["v1", "v2"])
 def test_api_root_redirects_to_relative_docs(version: str, tmp_path: Path) -> None:
     service_path = Path(__file__).parent
-    environment = os.environ | {
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("COV_CORE_")} | {
         "PYTHONPATH": str(service_path / "api" / version / "routers"),
         "XDG_CONFIG_HOME": str(tmp_path),
     }

--- a/core/services/versionchooser/api/v1/routers/index.py
+++ b/core/services/versionchooser/api/v1/routers/index.py
@@ -14,4 +14,4 @@ async def root() -> RedirectResponse:
     """
     Root endpoint for the Version Chooser API V1.
     """
-    return RedirectResponse(url="/v1.0/docs")
+    return RedirectResponse(url="docs")

--- a/core/services/versionchooser/test_versionchooser.py
+++ b/core/services/versionchooser/test_versionchooser.py
@@ -4,6 +4,7 @@ from unittest import mock
 from unittest.mock import AsyncMock
 
 import pytest
+from api.v1.routers.index import root as api_root
 from utils.chooser import VersionChooser
 from utils.dockerhub import TagFetcher, TagMetadata
 
@@ -43,6 +44,12 @@ SAMPLE_IMAGE = json.loads(
    "id":"856fdf5e66c9b3697c25015556e7895c9066febb1a8ac8657a4eb41f2fc95a57"
 }"""
 )
+
+
+async def test_api_root_redirects_to_relative_docs() -> None:
+    response = await api_root()
+
+    assert response.headers["location"] == "docs"
 
 
 @pytest.mark.asyncio

--- a/core/services/versionchooser/test_versionchooser.py
+++ b/core/services/versionchooser/test_versionchooser.py
@@ -1,10 +1,11 @@
 import json
+from pathlib import Path
+from runpy import run_path
 from typing import Tuple
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import pytest
-from api.v1.routers.index import root as api_root
 from utils.chooser import VersionChooser
 from utils.dockerhub import TagFetcher, TagMetadata
 
@@ -47,6 +48,7 @@ SAMPLE_IMAGE = json.loads(
 
 
 async def test_api_root_redirects_to_relative_docs() -> None:
+    api_root = run_path(str(Path(__file__).parent / "api/v1/routers/index.py"))["root"]
     response = await api_root()
 
     assert response.headers["location"] == "docs"


### PR DESCRIPTION
## Summary
- Change the VersionChooser v1 API root redirect to use the relative `docs` URL
- Apply the same fix to the Kraken v1 and v2 API root redirects
- Add regression tests that verify the returned `Location` header

## Problem
The affected API root endpoints returned root-relative paths such as
`/v1.0/docs` and `/v2.0/docs`.

When accessed through their Nginx service paths, these redirects dropped the
`/version-chooser/` or `/kraken/` prefix. For example:

```text
/version-chooser/v1.0/
```

redirected to:

```text
/v1.0/docs
```

instead of preserving the VersionChooser service path.

## Solution
The affected endpoints now return a relative redirect:

```text
Location: docs
```

This allows the client to resolve the documentation URL relative to the
requested endpoint, preserving the Nginx service path.

The same change is also applied to Kraken v2 because it used the identical
root-relative redirect pattern.

## Testing
- Focused regression tests: 3 passed
- Full VersionChooser and Kraken test files: 12 passed
- isort: passed
- Black: passed
- Ruff: passed
- Pylint: 10.00/10
- mypy: passed
- `git diff --check`: passed

The repository-wide pre-push hook could not be completed because Poetry is
not available in my local environment.

Fixes #3452