### PR TITLE
Allow websockets for extensions

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -481,6 +481,9 @@ class Helper:
         text = f"""
         location /extensionv2/{name}/ {{
         proxy_pass http://127.0.0.1:{port}/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This is a less strict approach than #3947: extensions can normally use upgrade headers (from 1.1) and have WebSocket running with `extensionsv2`, without any ties to a specific path.

Resulting config:

<img width="480" height="243" alt="image" src="https://github.com/user-attachments/assets/60ca7b44-ebd7-45ee-b206-1b927cad976e" />
