### PR TITLE
[backport/1.4] Allow websockets for extensions

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -496,6 +496,9 @@ class Helper:
         text = f"""
         location /extensionv2/{name}/ {{
         proxy_pass http://127.0.0.1:{port}/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This is a backport of https://github.com/bluerobotics/BlueOS/pull/4020 into 1.4.