### PR TITLE
Improve frontend: only get Kernel/Journal when needed

### DIFF
--- a/core/frontend/src/components/system-information/Journal.vue
+++ b/core/frontend/src/components/system-information/Journal.vue
@@ -38,7 +38,10 @@
 <script lang="ts">
 import Vue from 'vue'
 
-import system_information, { FetchType } from '@/store/system-information'
+import system_information, {
+  subscribeJournalEntries,
+  unsubscribeJournalEntries,
+} from '@/store/system-information'
 import { JournalEntry } from '@/types/system-information/journal'
 
 export default Vue.extend({
@@ -48,8 +51,11 @@ export default Vue.extend({
       return system_information?.journal_entries ?? []
     },
   },
-  created() {
-    system_information.fetchSystemInformation(FetchType.JournalType)
+  mounted() {
+    subscribeJournalEntries()
+  },
+  beforeDestroy() {
+    unsubscribeJournalEntries()
   },
   methods: {
     formatTimestamp(value?: string): string {

--- a/core/frontend/src/components/system-information/Kernel.vue
+++ b/core/frontend/src/components/system-information/Kernel.vue
@@ -41,7 +41,10 @@
 <script lang="ts">
 import Vue from 'vue'
 
-import system_information from '@/store/system-information'
+import system_information, {
+  subscribeKernelMessages,
+  unsubscribeKernelMessages,
+} from '@/store/system-information'
 import { Dictionary } from '@/types/common'
 import { KernelMessage } from '@/types/system-information/kernel'
 
@@ -55,6 +58,12 @@ export default Vue.extend({
     messages() {
       return system_information?.kernel_message
     },
+  },
+  mounted() {
+    subscribeKernelMessages()
+  },
+  beforeDestroy() {
+    unsubscribeKernelMessages()
   },
   methods: {
     getClass(message: KernelMessage): string {

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -22,8 +22,6 @@ import {
 import back_axios, { isBackendOffline } from '@/utils/api'
 
 export enum FetchType {
-    KernelType = 'kernel_buffer',
-    JournalType = 'journal',
     ModelType = 'model',
     NetstatType = 'netstat',
     PlatformType = 'platform',
@@ -107,16 +105,6 @@ class SystemInformationStore extends VuexModule {
   @Mutation
   updateModel(model: Model): void {
     this.model = model
-  }
-
-  @Mutation
-  updateKernelMessage(kernel_message: KernelMessage[]): void {
-    this.kernel_message = kernel_message
-  }
-
-  @Mutation
-  updateJournalEntries(response: JournalResponse): void {
-    this.journal_entries = response.entries
   }
 
   @Mutation
@@ -229,11 +217,6 @@ class SystemInformationStore extends VuexModule {
   }
 
   @Action
-  async fetchKernelMessage(): Promise<void> {
-    await this.fetchSystemInformation(FetchType.KernelType)
-  }
-
-  @Action
   async fetchModel(): Promise<void> {
     await this.fetchSystemInformation(FetchType.ModelType)
   }
@@ -335,13 +318,6 @@ class SystemInformationStore extends VuexModule {
     })
       .then((response) => {
         switch (type) {
-          case FetchType.KernelType:
-            this.updateKernelMessage(response.data)
-            break
-          case FetchType.JournalType: {
-            this.updateJournalEntries(response.data)
-            break
-          }
           case FetchType.ModelType:
             this.updateModel(response.data)
             break

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -95,6 +95,16 @@ class SystemInformationStore extends VuexModule {
   }
 
   @Mutation
+  clearKernelMessages(): void {
+    this.kernel_message = []
+  }
+
+  @Mutation
+  clearJournalEntries(): void {
+    this.journal_entries = []
+  }
+
+  @Mutation
   updateModel(model: Model): void {
     this.model = model
   }
@@ -393,22 +403,69 @@ system_information.fetchPlatformTask.setAction(system_information.fetchPlatform)
 system_information.fetchSystemNetworkTask.setAction(system_information.fetchNetworkInformation)
 system_information.fetchSubscribedSystemInformationTask.setAction(system_information.fetchSubscribedSystemInformation)
 
-// It appears that the store is incompatible with websockets or callbacks.
-// Right now the only way to have it working is to have the websocket definition outside the store
+// Vuex store modules are a poor fit for WebSocket callbacks; keep sockets outside the store and
+// open them only while a UI consumer is mounted (Kernel / Journal tabs).
 const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
-const websocketUrl = `${protocol}://${window.location.host}${system_information.API_URL}/ws/kernel_buffer`
-const socket = new WebSocket(websocketUrl)
-socket.onmessage = (message) => {
-  system_information.appendKernelMessage(JSON.parse(message.data))
+
+let kernel_socket: WebSocket | null = null
+let journal_socket: WebSocket | null = null
+let kernel_subscribers = 0
+let journal_subscribers = 0
+
+function closeSocket(socket: WebSocket | null): void {
+  if (!socket) {
+    return
+  }
+  socket.onmessage = null
+  socket.onerror = null
+  socket.onclose = null
+  if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+    socket.close()
+  }
 }
 
-const journalWebsocketUrl = `${protocol}://${window.location.host}${system_information.API_URL}/ws/journal`
-const journalSocket = new WebSocket(journalWebsocketUrl)
-journalSocket.onmessage = (message) => {
-  const payload = JSON.parse(message.data)
-  system_information.appendJournalEntries(payload)
+export function subscribeKernelMessages(): void {
+  kernel_subscribers += 1
+  if (kernel_socket) {
+    return
+  }
+  const socket = new WebSocket(`${protocol}://${window.location.host}${system_information.API_URL}/ws/kernel_buffer`)
+  socket.onmessage = (message) => {
+    system_information.appendKernelMessage(JSON.parse(message.data))
+  }
+  kernel_socket = socket
 }
 
-system_information.fetchSystemInformation(FetchType.JournalType)
+export function unsubscribeKernelMessages(): void {
+  kernel_subscribers = Math.max(0, kernel_subscribers - 1)
+  if (kernel_subscribers > 0) {
+    return
+  }
+  closeSocket(kernel_socket)
+  kernel_socket = null
+  system_information.clearKernelMessages()
+}
+
+export function subscribeJournalEntries(): void {
+  journal_subscribers += 1
+  if (journal_socket) {
+    return
+  }
+  const socket = new WebSocket(`${protocol}://${window.location.host}${system_information.API_URL}/ws/journal`)
+  socket.onmessage = (message) => {
+    system_information.appendJournalEntries(JSON.parse(message.data))
+  }
+  journal_socket = socket
+}
+
+export function unsubscribeJournalEntries(): void {
+  journal_subscribers = Math.max(0, journal_subscribers - 1)
+  if (journal_subscribers > 0) {
+    return
+  }
+  closeSocket(journal_socket)
+  journal_socket = null
+  system_information.clearJournalEntries()
+}
 
 export default system_information

--- a/core/frontend/src/views/SystemInformationView.vue
+++ b/core/frontend/src/views/SystemInformationView.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
         },
         { title: 'About', icon: 'mdi-information', value: 'about' },
       ] as Item[],
-      page_selected: null as string | null,
+      page_selected: 0 as number,
     }
   },
   computed: {

--- a/core/frontend/src/views/SystemInformationView.vue
+++ b/core/frontend/src/views/SystemInformationView.vue
@@ -19,17 +19,20 @@
     </v-tabs>
     <v-tabs-items v-model="page_selected">
       <v-tab-item
-        v-for="page in pages"
+        v-for="(page, index) in pages"
         :key="page.value"
       >
-        <processes v-if="page.value === 'process'" />
-        <system-condition v-else-if="page.value === 'system_condition'" />
-        <network v-else-if="page.value === 'network'" />
-        <usb v-else-if="page.value === 'usb'" />
-        <kernel v-else-if="page.value === 'kernel'" />
-        <journal v-else-if="page.value === 'journal'" />
-        <firmware v-else-if="page.value === 'firmware'" />
-        <about-this-system v-else-if="page.value === 'about'" />
+        <!-- Only mount the active tab so heavy consumers (kernel/journal WS) tear down when leaving -->
+        <template v-if="page_selected === index">
+          <processes v-if="page.value === 'process'" />
+          <system-condition v-else-if="page.value === 'system_condition'" />
+          <network v-else-if="page.value === 'network'" />
+          <usb v-else-if="page.value === 'usb'" />
+          <kernel v-else-if="page.value === 'kernel'" />
+          <journal v-else-if="page.value === 'journal'" />
+          <firmware v-else-if="page.value === 'firmware'" />
+          <about-this-system v-else-if="page.value === 'about'" />
+        </template>
       </v-tab-item>
     </v-tabs-items>
   </v-card>


### PR DESCRIPTION
During my tests, it was found that there's an initial ~22 + linear ~5 MB/h of Chrome heap growth just from Journal+Kernel, regardless of the page loaded. This certainly is not the single or greatest cause of instability, but can be a contributor.

The strategy here is to only connect the WebSocket when we need it, which is not even common.

Note: In 1.4, we only have the Kernel ones, so this can be a contributor to why the 1.5 frontend is heavier than 1.4.