### PR TITLE
Improve frontend 2: Deduplicate /status requests

### DIFF
--- a/core/frontend/src/utils/api.ts
+++ b/core/frontend/src/utils/api.ts
@@ -12,8 +12,47 @@ export const isBackendOffline = (error: any): boolean => {
   return false;
 }
 
+// Every back_axios call used to hit /status first, which piled up under normal polling.
+// Cache a recent "online" result for 3s (same cadence as BackendStatusChecker.vue's UI poll;
+// that component only reads frontend.backend_offline -- it does not hit /status itself).
+// Offline is never cached.
+const STATUS_TTL_MS = 3000
+
+let last_online_at = 0
+
+function applyStatusResult(backend_offline: boolean): void {
+  frontend.setBackendOffline(backend_offline)
+  if (!backend_offline) {
+    last_online_at = Date.now()
+  }
+}
+
 const axios_backend_instance: AxiosInstance = axios.create()
 axios_backend_instance.interceptors.request.use(async (config) => {
+  const is_recently_online = last_online_at > 0 && !frontend.backend_offline
+  if (is_recently_online && (Date.now() - last_online_at) < STATUS_TTL_MS) {
+    return config
+  }
+
+  // Still recently online: refresh /status in the background, but do not block this request.
+  if (is_recently_online) {
+    if (frontend.backend_status_request === null) {
+      const request = axios.get(frontend.backend_status_url, { timeout: 5000 })
+      frontend.setBackendStatusRequest(request)
+      request
+        .then((response) => {
+          applyStatusResult(response.status !== 204)
+        })
+        .catch(() => {
+          applyStatusResult(true)
+        })
+        .finally(() => {
+          frontend.setBackendStatusRequest(null)
+        })
+    }
+    return config
+  }
+
   // Check if there's already a backend status request running. If yes, use it. If not, start one.
   if (frontend.backend_status_request === null) {
     frontend.setBackendStatusRequest(axios.get(frontend.backend_status_url, { timeout: 5000 }))
@@ -26,7 +65,7 @@ axios_backend_instance.interceptors.request.use(async (config) => {
       .catch(() => true)
 
     // Update backend status and reset status-request variable
-    frontend.setBackendOffline(backend_offline)
+    applyStatusResult(backend_offline)
     frontend.setBackendStatusRequest(null)
 
     if (backend_offline) {


### PR DESCRIPTION
When checking the Network tab in Chrome devtools, there was a pile of `/status` requests being fired. Digging in, every axios call was first checking whether the backend was online with an extra request. Example:

<img width="967" height="706" alt="image" src="https://github.com/user-attachments/assets/d767d8e7-d6bb-42ee-9a97-d61484a31fd3" />

This patch works around that with a short time-based cache (3 seconds, same as `BackendStatusChecker`) so we only actually hit `/status` when the cache is stale, and only one of those checks runs at a time while others wait on it or reuse the last "online" result. 

Example after:
<img width="968" height="709" alt="image" src="https://github.com/user-attachments/assets/ccd2bd46-b990-44de-8050-7db8a5754e98" />

When the backend gets online, we now have a few requests that will fail while the 3-second cache is valid:

<img width="552" height="332" alt="image" src="https://github.com/user-attachments/assets/c474bb1d-aafb-4d35-bfeb-dc0f2b8f1790" />

But once it gets back online, it returns to normality:
<img width="426" height="634" alt="image" src="https://github.com/user-attachments/assets/fa1a9742-50df-4a3a-8165-e153d67e06d7" />

This happens equally in both 1.4 and 1.5, and the impact on performance is probably minimal in most cases. It reduces the overall latency and reduces simultaneous connections, which is helpful when we expect low-grade connections as well.