### PR TITLE
frontend: Discard tray MAVLink listeners on destroy

### DIFF
--- a/core/frontend/src/components/health/GpsTrayMenu.vue
+++ b/core/frontend/src/components/health/GpsTrayMenu.vue
@@ -78,9 +78,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { markRaw } from 'vue'
 
 import mavlink2rest from '@/libs/MAVLink2Rest'
+import Listener from '@/libs/MAVLink2Rest/Listener'
 import { GpsFixType } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
 import {
   GlobalPositionInt,
@@ -105,6 +106,7 @@ export default Vue.extend({
       gps_detected: false,
       global_position_int: undefined as undefined | GlobalPositionInt,
       gps_raw_int: undefined as undefined | GpsRawInt,
+      listeners: [] as Listener[],
     }
   },
   computed: {
@@ -266,25 +268,33 @@ export default Vue.extend({
     },
   },
   mounted() {
-    mavlink2rest.startListening('GLOBAL_POSITION_INT').setCallback((message) => {
-      if (message?.header.system_id !== autopilot_data.system_id || message?.header.component_id !== 1) {
-        return
-      }
+    // markRaw: Listener → Endpoint.latestData must not be deep-observed per GPS frame.
+    this.listeners.push(
+      markRaw(mavlink2rest.startListening('GLOBAL_POSITION_INT').setCallback((message) => {
+        if (message?.header.system_id !== autopilot_data.system_id || message?.header.component_id !== 1) {
+          return
+        }
 
-      this.last_message_date = new Date()
-      this.global_position_int = message?.message as GlobalPositionInt
-    }).setFrequency(0)
+        this.last_message_date = new Date()
+        this.global_position_int = message?.message as GlobalPositionInt
+      }).setFrequency(0)),
+    )
 
     const message_name = this.instance === 1 ? 'GPS_RAW_INT' : 'GPS2_RAW'
-    mavlink2rest.startListening(message_name).setCallback((message) => {
-      if (message?.header.system_id !== autopilot_data.system_id || message?.header.component_id !== 1) {
-        return
-      }
+    this.listeners.push(
+      markRaw(mavlink2rest.startListening(message_name).setCallback((message) => {
+        if (message?.header.system_id !== autopilot_data.system_id || message?.header.component_id !== 1) {
+          return
+        }
 
-      this.last_message_date = new Date()
-      this.gps_raw_int = message?.message as GpsRawInt | Gps2Raw
-      this.gps_detected = this.gps_raw_int?.fix_type?.type !== GpsFixType.GPS_FIX_TYPE_NO_GPS
-    }).setFrequency(0)
+        this.last_message_date = new Date()
+        this.gps_raw_int = message?.message as GpsRawInt | Gps2Raw
+        this.gps_detected = this.gps_raw_int?.fix_type?.type !== GpsFixType.GPS_FIX_TYPE_NO_GPS
+      }).setFrequency(0)),
+    )
+  },
+  beforeDestroy() {
+    this.listeners.forEach((listener) => listener.discard())
   },
 })
 </script>

--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -111,10 +111,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { markRaw } from 'vue'
 
 import { convertHexToRgbd } from '@/cosmos'
 import mavlink2rest from '@/libs/MAVLink2Rest'
+import Listener from '@/libs/MAVLink2Rest/Listener'
 import { MavModeFlag, MavType } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
 import ardupilot_sensors, { ArdupilotSensorsStore } from '@/store/ardupilot_sensors'
 import autopilot_data from '@/store/autopilot'
@@ -132,6 +133,7 @@ export default Vue.extend({
   data() {
     return {
       time_limit_heartbeat: 3000,
+      heartbeat_listener: undefined as Listener | undefined,
     }
   },
   computed: {
@@ -185,7 +187,8 @@ export default Vue.extend({
   },
   mounted() {
     system_information.subscribeSystemInformation(FETCH_TYPES)
-    mavlink2rest.startListening('HEARTBEAT').setCallback((message) => {
+    // markRaw: Listener → Endpoint.latestData must not be deep-observed per HEARTBEAT.
+    this.heartbeat_listener = markRaw(mavlink2rest.startListening('HEARTBEAT').setCallback((message) => {
       if (!this.is_vehicle(message?.message.mavtype.type) || message?.header.component_id !== 1) {
         return
       }
@@ -193,10 +196,11 @@ export default Vue.extend({
       autopilot_data.setAutopilotType(message?.message.autopilot.type)
       autopilot_data.setVehicleArmed(Boolean(message?.message.base_mode.bits & MavModeFlag.MAV_MODE_FLAG_SAFETY_ARMED))
       autopilot_data.setLastHeartbeatDate(new Date())
-    }).setFrequency(0)
+    }).setFrequency(0))
   },
   beforeDestroy() {
     system_information.unsubscribeSystemInformation(FETCH_TYPES)
+    this.heartbeat_listener?.discard()
   },
   methods: {
     heartbeat_age(): number {


### PR DESCRIPTION
## Summary
- HealthTray HEARTBEAT and GpsTrayMenu GPS listeners are stored with `markRaw` and `discard()`ed in `beforeDestroy`.
- Avoids stacking callbacks on shared MAVLink2Rest endpoints (and deep-observing `Endpoint.latestData` every frame).

## Test plan
- [ ] Heartbeat icon and GPS trays still update normally
- [ ] Remount / HMR of App tray: listener count does not grow (no duplicate HEARTBEAT handling)
- [ ] No regression in armed state / GPS fix display