### PR TITLE
Fix bag-of-holding log spamming errors on normal operation

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/utils/apis.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/apis.py
@@ -29,7 +29,8 @@ class GenericErrorHandlingRoute(APIRoute):
             try:
                 return await original_route_handler(request)
             except HTTPException as error:
-                logger.exception(error)
+                if error.status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR:
+                    logger.exception(error)
                 raise error
             except Exception as error:
                 logger.error("Unhandled service exception.")

--- a/core/services/bag_of_holding/main.py
+++ b/core/services/bag_of_holding/main.py
@@ -98,8 +98,8 @@ async def read_data(path: str) -> JSONResponse:
     try:
         result = dpath.get(current_data, path)
         return JSONResponse(result)
-    except KeyError:
-        raise HTTPException(status_code=400, detail="Invalid path") from KeyError
+    except KeyError as error:
+        raise HTTPException(status_code=400, detail="Invalid path") from error
 
 
 app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)


### PR DESCRIPTION
Example of spam:

```
ERROR][5:08:58.496 PM -03][service/bag-of-holding][apis.py:32]: 
KeyError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/pi/libs/commonwealth/src/commonwealth/utils/apis.py", line 30, in custom_route_handler
    return await original_route_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/blueos/venv/lib/python3.11/site-packages/fastapi/routing.py", line 274, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/blueos/venv/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/services/bag_of_holding/main.py", line 102, in read_data
    raise HTTPException(status_code=400, detail="Invalid path") from KeyError
fastapi.exceptions.HTTPException

[ERROR][5:09:10.582 PM -03][service/bag-of-holding][apis.py:32]: 
KeyError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/pi/libs/commonwealth/src/commonwealth/utils/apis.py", line 30, in custom_route_handler
    return await original_route_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/blueos/venv/lib/python3.11/site-packages/fastapi/routing.py", line 274, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/blueos/venv/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/services/bag_of_holding/main.py", line 102, in read_data
    raise HTTPException(status_code=400, detail="Invalid path") from KeyError
fastapi.exceptions.HTTPException
```