### PR TITLE
fix: handle disappearing interfaces in Ping discovery

### DIFF
--- a/core/services/ping/ping360_ethernet_prober.py
+++ b/core/services/ping/ping360_ethernet_prober.py
@@ -23,7 +23,7 @@ def list_ips() -> Set[str]:
     for interface in available_networks:
         ips.extend(
             phys.address
-            for phys in network_interface_addresses[interface]
+            for phys in network_interface_addresses.get(interface, [])
             if phys.family == socket.AF_INET and phys.address != "127.0.0.1"
         )
     return set(ips)  # make sure there are not duplicated entries

--- a/core/services/ping/test_ping360_ethernet_prober.py
+++ b/core/services/ping/test_ping360_ethernet_prober.py
@@ -1,0 +1,36 @@
+import socket
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import ping360_ethernet_prober
+import psutil
+
+
+def test_list_ips_ignores_interfaces_missing_from_address_snapshot() -> None:
+    stats = {
+        "eth0": SimpleNamespace(isup=True),
+        "lo": SimpleNamespace(isup=True),
+        "wlan0": SimpleNamespace(isup=False),
+        "noipv4": SimpleNamespace(isup=True),
+        "uap0": SimpleNamespace(isup=True),
+    }
+    addresses = {
+        "eth0": [SimpleNamespace(family=socket.AF_INET, address="192.168.2.2")],
+        "lo": [SimpleNamespace(family=socket.AF_INET, address="127.0.0.1")],
+        "wlan0": [SimpleNamespace(family=socket.AF_INET, address="192.168.10.2")],
+        "noipv4": [SimpleNamespace(family=socket.AF_INET6, address="::1")],
+    }
+
+    with (
+        patch.object(psutil, "net_if_stats", return_value=stats),
+        patch.object(psutil, "net_if_addrs", return_value=addresses),
+    ):
+        assert ping360_ethernet_prober.list_ips() == {"192.168.2.2"}
+
+
+def test_list_ips_returns_empty_set_for_empty_snapshots() -> None:
+    with (
+        patch.object(psutil, "net_if_stats", return_value={}),
+        patch.object(psutil, "net_if_addrs", return_value={}),
+    ):
+        assert ping360_ethernet_prober.list_ips() == set()


### PR DESCRIPTION
## Summary

- Avoid a `KeyError` when an interface disappears between the
  `net_if_stats()` and `net_if_addrs()` snapshots.
- Add regression coverage for inconsistent interface snapshots.
- Preserve the existing IPv4, loopback, and inactive-interface filtering.

## Problem

`list_ips()` collects interface status and address information using two
separate psutil calls. If an interface exists in the status snapshot but is
missing from the address snapshot, directly indexing the address mapping
raises a `KeyError`.

The exception can terminate the Ping sensor watcher task and stop subsequent
device discovery.

## Solution

Treat an interface missing from the address snapshot as having no addresses,
allowing discovery to continue for the remaining interfaces.

## Testing

- Ping regression tests: 2 passed
- Black: passed
- isort: passed
- Ruff: passed
- Pylint: 10.00/10
- mypy: passed
- `git diff --check`: passed

The complete pre-push hook could not run locally because Poetry is not
installed.

Fixes #3247