### PR TITLE
frontend: Stop NetworkSpeedTest reconnect interval multiply

### DIFF
--- a/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
+++ b/core/frontend/src/components/speedtest/NetworkSpeedTest.vue
@@ -139,10 +139,21 @@ export default Vue.extend({
     this.websocket?.close()
   },
   mounted() {
-    this.openWebSocket()
+    this.connectWebSocket()
+    this.interval = window.setInterval(() => {
+      if (this.websocket === undefined || this.websocket.readyState === WebSocket.CLOSED) {
+        this.connectWebSocket()
+        return
+      }
+
+      if (this.websocket.readyState === WebSocket.OPEN) {
+        this.websocket.send(window.performance.now().toString())
+      }
+    }, 200)
   },
   methods: {
-    openWebSocket() {
+    connectWebSocket() {
+      this.websocket?.close()
       const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
       this.websocket = new WebSocket(`${protocol}://${window.location.host}/network-test/ws`)
       this.websocket.onmessage = (message: MessageEvent): void => {
@@ -151,16 +162,6 @@ export default Vue.extend({
       this.websocket.onerror = () => {
         this.latency_ms = -1
       }
-
-      this.interval = setInterval(() => {
-        if (this.websocket === undefined || this.websocket?.readyState === WebSocket.CLOSED) {
-          this.openWebSocket()
-        }
-
-        if (this.websocket?.readyState === WebSocket.OPEN) {
-          this.websocket?.send(window.performance.now().toString())
-        }
-      }, 200)
     },
     start(): void {
       // eslint-disable-next-line


### PR DESCRIPTION
## Summary
- Keep a single 200ms ping interval for the page lifetime.
- On disconnect, only recreate the WebSocket (do not nest another `setInterval`).

## Test plan
- [ ] Open Tools → Network test, leave the page open with a flaky WS: interval count stays at one
- [ ] Latency updates while connected; reconnect recovers without runaway timers
- [ ] Leave the page: interval cleared, socket closed

---
Supersedes #4032 (recreated from fork `joaoantoniocardoso/BlueOS-docker` instead of same-repo head).