### PR TITLE
frontend: Use linux2rest network probe deltas for tray rates

### DIFF
--- a/core/frontend/src/components/system-information/NetworkCard.vue
+++ b/core/frontend/src/components/system-information/NetworkCard.vue
@@ -62,9 +62,9 @@
           mdi-package-down
         </v-icon>
       </v-list-item-icon>
-      <v-list-item-subtitle>Received package:</v-list-item-subtitle>
+      <v-list-item-subtitle>Packets received:</v-list-item-subtitle>
       <v-list-item-subtitle class="text-right">
-        {{ network.total_packets_received }}
+        {{ network.packets_received }} / {{ network.total_packets_received }} total
       </v-list-item-subtitle>
     </v-list-item>
 
@@ -74,21 +74,9 @@
           mdi-package-up
         </v-icon>
       </v-list-item-icon>
-      <v-list-item-subtitle>Transmitted package:</v-list-item-subtitle>
+      <v-list-item-subtitle>Packets transmitted:</v-list-item-subtitle>
       <v-list-item-subtitle class="text-right">
-        {{ network.total_packets_transmitted }}
-      </v-list-item-subtitle>
-    </v-list-item>
-
-    <v-list-item>
-      <v-list-item-icon>
-        <v-icon>
-          mdi-cloud-upload
-        </v-icon>
-      </v-list-item-icon>
-      <v-list-item-subtitle>Bytes received:</v-list-item-subtitle>
-      <v-list-item-subtitle class="text-right">
-        {{ formatSize(network.total_received_B) }}
+        {{ network.packets_transmitted }} / {{ network.total_packets_transmitted }} total
       </v-list-item-subtitle>
     </v-list-item>
 
@@ -98,9 +86,21 @@
           mdi-cloud-download
         </v-icon>
       </v-list-item-icon>
+      <v-list-item-subtitle>Bytes received:</v-list-item-subtitle>
+      <v-list-item-subtitle class="text-right">
+        {{ formatSize(network.received_B) }} / {{ formatSize(network.total_received_B) }} total
+      </v-list-item-subtitle>
+    </v-list-item>
+
+    <v-list-item>
+      <v-list-item-icon>
+        <v-icon>
+          mdi-cloud-upload
+        </v-icon>
+      </v-list-item-icon>
       <v-list-item-subtitle>Bytes transmitted:</v-list-item-subtitle>
       <v-list-item-subtitle class="text-right">
-        {{ formatSize(network.total_transmitted_B) }}
+        {{ formatSize(network.transmitted_B) }} / {{ formatSize(network.total_transmitted_B) }} total
       </v-list-item-subtitle>
     </v-list-item>
   </v-card>

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -20,6 +20,7 @@ import {
   CPU, Disk, Info, Memory, Network, Process, System, Temperature,
 } from '@/types/system-information/system'
 import back_axios, { isBackendOffline } from '@/utils/api'
+import { networkProbeRateBps } from '@/utils/networking'
 
 export enum FetchType {
     KernelType = 'kernel_buffer',
@@ -182,16 +183,12 @@ class SystemInformationStore extends VuexModule {
   @Mutation
   updateSystemNetwork(networks: [Network]): void {
     if (this.system) {
-      // derivate interface upload and download speeds from the previous values
-      const now = Date.now()
-      for(let network of networks) {
-        const previousNetwork = this.system.network.find(n => n.name === network.name)
-        const dt = (now - (previousNetwork?.last_update ?? 5)) / 1000
-        network.last_update = now
-        if (previousNetwork) {
-          network.download_speed = (network.total_received_B - previousNetwork.total_received_B) / dt
-          network.upload_speed = (network.total_transmitted_B - previousNetwork.total_transmitted_B) / dt
-        }
+      // Use linux2rest/sysinfo per-sample deltas (received_B / transmitted_B), not a
+      // frontend re-diff of total_*. Those deltas are already saturating and match the
+      // Sampler window (LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S).
+      for (const network of networks) {
+        network.download_speed = networkProbeRateBps(network.received_B)
+        network.upload_speed = networkProbeRateBps(network.transmitted_B)
       }
       this.system.network = networks
     }

--- a/core/frontend/src/types/system-information/system.ts
+++ b/core/frontend/src/types/system-information/system.ts
@@ -83,15 +83,16 @@ export interface Network {
      * @param name - Name of the interface, E.g: "lo", "eth0"
      * @param packets_received - Number of packages received since last probe
      * @param packets_transmitted - Number of packages transmitted since last probe
-     * @param received_B - Number of bytes received since last probe
+     * @param received_B - Bytes received since last linux2rest/sysinfo probe
      * @param total_errors_on_received - Total number of errors when receiving packages
      * @param total_errors_on_transmitted - Total number of errors when transmitting packages
      * @param total_packets_received - Total number of packages received
      * @param total_packets_transmitted - Total number of packages transmitted
      * @param total_received_B - Total number of bytes received
      * @param total_transmitted_B - Total number of bytes transmitted
-     * @param transmitted_B - Number of bytes received since last probe
-     * @param last_update - Unix time in seconds
+     * @param transmitted_B - Bytes transmitted since last linux2rest/sysinfo probe
+     * @param upload_speed - Frontend: transmitted_B / linux2rest sample interval (B/s)
+     * @param download_speed - Frontend: received_B / linux2rest sample interval (B/s)
     * */
     description: string,
     errors_on_received: number,
@@ -111,7 +112,6 @@ export interface Network {
     total_received_B: number,
     total_transmitted_B: number,
     transmitted_B: number
-    last_update?: number
     upload_speed?: number
     download_speed?: number
 }

--- a/core/frontend/src/utils/networking.ts
+++ b/core/frontend/src/utils/networking.ts
@@ -1,3 +1,12 @@
+// Must match linux2rest Sampler interval (src/main.rs: Duration::from_secs(5)).
+// TODO: prefer a probed interval if/when linux2rest exposes it (Mbps silently drift if Sampler cadence changes).
+export const LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S = 5
+
+/** Convert a linux2rest per-sample byte delta into a bytes-per-second rate. Negative deltas are clamped to zero. */
+export function networkProbeRateBps(bytesSinceLastProbe: number): number {
+  return Math.max(0, bytesSinceLastProbe) / LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S
+}
+
 export function formatBandwidth(bytesPerSecond: number): string {
   const mbps = (8 * bytesPerSecond / 1024 / 1024)
   const decimal_places = mbps < 10 ? 2 : mbps < 100 ? 1 : 0


### PR DESCRIPTION
## Summary
- Derive tray upload/download speeds from linux2rest `received_B` / `transmitted_B` (sysinfo per-sample deltas) divided by the Sampler interval (5s), instead of re-differencing `total_*` across frontend polls.
- That removes negative Mbps when totals reset and avoids flicker/spikes against the ≥0.9 sample cache.
- NetworkCard now shows probe deltas alongside totals (same shape as linux2rest's own UI).
- Also fixes the `transmitted_B` type docstring (was copy-pasted as "bytes received"), swaps the swapped `mdi-cloud-upload`/`mdi-cloud-download` icons on the byte rows, and rewords labels to `Packets received/transmitted`.

Closes #3587

Note: The target is BlueOS 1.5 only.

## Test plan
- [ ] Against BlueOS with linux2rest 0.9.x: enable eth0 Networking widget under steady traffic
- [ ] Rate stays stable across 2s polls within a 5s sample window (no flicker to 0)
- [ ] Rate updates when the Sampler advances; never goes negative
- [ ] System Information → Network cards show `delta / total` for packets and bytes
- [ ] Byte-row icons match direction (download on received, upload on transmitted)

---
Supersedes #4028 (recreated from fork `joaoantoniocardoso/BlueOS-docker` instead of same-repo head).