### PR TITLE
[backport/1.4] Improve frontend: Deduplicate system-information requests

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -140,10 +140,12 @@ import mavlink2rest from '@/libs/MAVLink2Rest'
 import { MavModeFlag, MavType } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
 import autopilot_data from '@/store/autopilot'
 import mavlink from '@/store/mavlink'
-import system_information from '@/store/system-information'
+import system_information, { FetchType } from '@/store/system-information'
 import { RaspberryEventType } from '@/types/system-information/platform'
 import { Disk } from '@/types/system-information/system'
 import mavlink_store_get from '@/utils/mavlink'
+
+const FETCH_TYPES = [FetchType.SystemTemperatureType, FetchType.SystemDiskType]
 
 export default Vue.extend({
   name: 'HealthTrayMenu',
@@ -208,6 +210,7 @@ export default Vue.extend({
     },
   },
   mounted() {
+    system_information.subscribeSystemInformation(FETCH_TYPES)
     mavlink2rest.startListening('HEARTBEAT').setCallback((message) => {
       if (!this.is_vehicle(message?.message.mavtype.type) || message?.header.component_id !== 1) {
         return
@@ -217,6 +220,9 @@ export default Vue.extend({
       autopilot_data.setVehicleArmed(Boolean(message?.message.base_mode.bits & MavModeFlag.MAV_MODE_FLAG_SAFETY_ARMED))
       this.last_heartbeat_date = new Date()
     }).setFrequency(0)
+  },
+  beforeDestroy() {
+    system_information.unsubscribeSystemInformation(FETCH_TYPES)
   },
   methods: {
     heartbeat_age(): number {

--- a/core/frontend/src/components/system-information/SystemCondition.vue
+++ b/core/frontend/src/components/system-information/SystemCondition.vue
@@ -21,15 +21,17 @@ import system_information, { FetchType } from '@/store/system-information'
 import { Disk } from '@/types/system-information/system'
 import { prettifySize } from '@/utils/helper_functions'
 
+const FETCH_TYPES = [
+  FetchType.SystemCpuType,
+  FetchType.SystemMemoryType,
+  FetchType.SystemDiskType,
+  FetchType.SystemTemperatureType,
+]
+
 export default Vue.extend({
   name: 'SystemCondition',
   components: {
     SystemConditionCard,
-  },
-  data() {
-    return {
-      timer: 0,
-    }
   },
   // TODO: move to computeds
   computed: {
@@ -131,15 +133,10 @@ export default Vue.extend({
     },
   },
   mounted() {
-    this.timer = setInterval(() => {
-      system_information.fetchSystemInformation(FetchType.SystemCpuType)
-      system_information.fetchSystemInformation(FetchType.SystemDiskType)
-      system_information.fetchSystemInformation(FetchType.SystemMemoryType)
-      system_information.fetchSystemInformation(FetchType.SystemTemperatureType)
-    }, 2000)
+    system_information.subscribeSystemInformation(FETCH_TYPES)
   },
   beforeDestroy() {
-    clearInterval(this.timer)
+    system_information.unsubscribeSystemInformation(FETCH_TYPES)
   },
 })
 </script>

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -39,6 +39,13 @@ export enum FetchType {
 
 const notifier = new Notifier(system_information_service)
 
+const system_information_subscribers: Partial<Record<FetchType, number>> = {
+  [FetchType.SystemCpuType]: 0,
+  [FetchType.SystemMemoryType]: 0,
+  [FetchType.SystemDiskType]: 0,
+  [FetchType.SystemTemperatureType]: 0,
+}
+
 @Module({
   dynamic: true,
   store,
@@ -66,7 +73,11 @@ class SystemInformationStore extends VuexModule {
   )
 
   fetchSystemNetworkTask = new OneMoreTime(
-    { delay: 1000 },
+    { delay: 2000 },
+  )
+
+  fetchSubscribedSystemInformationTask = new OneMoreTime(
+    { delay: 2000, autostart: false },
   )
 
   @Mutation
@@ -207,6 +218,49 @@ class SystemInformationStore extends VuexModule {
   }
 
   @Action
+  async fetchSubscribedSystemInformation(): Promise<void> {
+    const fetches = (Object.keys(system_information_subscribers) as FetchType[])
+      .filter((type) => (system_information_subscribers[type] ?? 0) > 0)
+      .map((type) => this.fetchSystemInformation(type))
+    if (fetches.length === 0) {
+      return
+    }
+    await Promise.all(fetches)
+  }
+
+  @Action
+  subscribeSystemInformation(types: FetchType[]): void {
+    types.forEach((type) => {
+      if (system_information_subscribers[type] === undefined) {
+        return
+      }
+      system_information_subscribers[type]! += 1
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const task = this.fetchSubscribedSystemInformationTask as any
+    if (task.isPaused) {
+      this.fetchSubscribedSystemInformationTask.resume()
+    } else if (!task.isRunning && !task.timeoutId) {
+      this.fetchSubscribedSystemInformationTask.start()
+    }
+  }
+
+  @Action
+  unsubscribeSystemInformation(types: FetchType[]): void {
+    types.forEach((type) => {
+      if (system_information_subscribers[type] === undefined) {
+        return
+      }
+      system_information_subscribers[type] = Math.max(0, system_information_subscribers[type]! - 1)
+    })
+    const has_subscribers = (Object.keys(system_information_subscribers) as FetchType[])
+      .some((type) => (system_information_subscribers[type] ?? 0) > 0)
+    if (!has_subscribers) {
+      this.fetchSubscribedSystemInformationTask.stop()
+    }
+  }
+
+  @Action
   async fetchSystemInformation(type: FetchType): Promise<void> {
     // Do not fetch system specific information if system is not populate yet
     // system type does not have optional fields, they need to be populate before fetching it
@@ -297,6 +351,7 @@ const system_information: SystemInformationStore = getModule(SystemInformationSt
 system_information.fetchSystem()
 system_information.fetchPlatformTask.setAction(system_information.fetchPlatform)
 system_information.fetchSystemNetworkTask.setAction(system_information.fetchNetworkInformation)
+system_information.fetchSubscribedSystemInformationTask.setAction(system_information.fetchSubscribedSystemInformation)
 
 // It appears that the store is incompatible with websockets or callbacks.
 // Right now the only way to have it working is to have the websocket definition outside the store

--- a/core/frontend/src/widgets/Cpu.vue
+++ b/core/frontend/src/widgets/Cpu.vue
@@ -45,13 +45,10 @@ import Vue from 'vue'
 
 import system_information, { FetchType } from '@/store/system-information'
 
+const FETCH_TYPES = [FetchType.SystemCpuType, FetchType.SystemTemperatureType]
+
 export default Vue.extend({
   name: 'CpuWidget',
-  data() {
-    return {
-      timer: 0,
-    }
-  },
   computed: {
     cpus_usage(): number[] {
       const cpus = system_information.system?.cpu
@@ -97,10 +94,10 @@ export default Vue.extend({
     },
   },
   mounted() {
-    this.timer = setInterval(() => system_information.fetchSystemInformation(FetchType.SystemCpuType), 5000)
+    system_information.subscribeSystemInformation(FETCH_TYPES)
   },
   beforeDestroy() {
-    clearInterval(this.timer)
+    system_information.unsubscribeSystemInformation(FETCH_TYPES)
   },
   methods: {
     getBarColor(usage: number): string {

--- a/core/frontend/src/widgets/Disk.vue
+++ b/core/frontend/src/widgets/Disk.vue
@@ -12,13 +12,10 @@ import Vue from 'vue'
 import system_information, { FetchType } from '@/store/system-information'
 import { Disk } from '@/types/system-information/system'
 
+const FETCH_TYPES = [FetchType.SystemDiskType]
+
 export default Vue.extend({
   name: 'DiskWidget',
-  data() {
-    return {
-      timer: 0,
-    }
-  },
   computed: {
     main_disk(): undefined | Disk {
       const disks = system_information.system?.disk
@@ -30,10 +27,10 @@ export default Vue.extend({
     },
   },
   mounted() {
-    this.timer = setInterval(() => system_information.fetchSystemInformation(FetchType.SystemDiskType), 30000)
+    system_information.subscribeSystemInformation(FETCH_TYPES)
   },
   beforeDestroy() {
-    clearInterval(this.timer)
+    system_information.unsubscribeSystemInformation(FETCH_TYPES)
   },
 })
 </script>


### PR DESCRIPTION
This is a backport of #4027 into 1.4.

---
Supersedes #4034 (recreated from fork `joaoantoniocardoso/BlueOS-docker` instead of same-repo head).