### PR TITLE
core: services: ping: Keep port watcher running after unexpected errors

### DIFF
--- a/core/services/ping/portwatcher.py
+++ b/core/services/ping/portwatcher.py
@@ -78,20 +78,23 @@ class PortWatcher:
         """Start watching for plugged/unplugged serial devices in the system."""
         # TODO: try https://pypi.org/project/inotify/
         while True:
-            ports = serial.tools.list_ports.comports()
-            ports_description = [f"{port.subsystem}:{port.name}" for port in ports]
-            logger.debug(f"Currently detected ports: {ports_description}")
-            found_ports = set()
-            for port in ports:
-                if self.port_should_be_probed(port):
-                    await self.probe_port(port)
-                found_ports.add(port)
+            try:
+                ports = serial.tools.list_ports.comports()
+                ports_description = [f"{port.subsystem}:{port.name}" for port in ports]
+                logger.debug(f"Currently detected ports: {ports_description}")
+                found_ports = set()
+                for port in ports:
+                    if self.port_should_be_probed(port):
+                        await self.probe_port(port)
+                    found_ports.add(port)
 
-            missing = self.known_ports - found_ports
-            for port in missing:
-                logger.info(f"Port lost: {port.hwid}")
-                self.known_ports.remove(port)
-                if self.port_lost_callback is not None:
-                    self.port_lost_callback(port)
-            await self.add_ping360()
+                missing = self.known_ports - found_ports
+                for port in missing:
+                    logger.info(f"Port lost: {port.hwid}")
+                    self.known_ports.remove(port)
+                    if self.port_lost_callback is not None:
+                        self.port_lost_callback(port)
+                await self.add_ping360()
+            except Exception as error:
+                logger.exception(f"Error while watching ports/devices: {error}")
             await asyncio.sleep(1)

--- a/core/services/ping/test_portwatcher.py
+++ b/core/services/ping/test_portwatcher.py
@@ -1,0 +1,27 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from portwatcher import PortWatcher
+
+
+@pytest.mark.asyncio
+async def test_start_watching_continues_after_add_ping360_error() -> None:
+    watcher = PortWatcher(probe_callback=AsyncMock(), found_callback=AsyncMock())
+    calls = {"n": 0}
+
+    async def flaky_add_ping360() -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise KeyError("uap0")
+        raise asyncio.CancelledError()
+
+    with (
+        patch.object(watcher, "add_ping360", side_effect=flaky_add_ping360),
+        patch("portwatcher.serial.tools.list_ports.comports", return_value=[]),
+        patch("portwatcher.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await watcher.start_watching()
+
+    assert calls["n"] == 2


### PR DESCRIPTION
## Summary

- Catch unexpected errors in the Ping `PortWatcher` loop so discovery keeps running.
- Add a regression test that a transient `add_ping360` failure does not stop watching.

Follow-up to #4036: that PR fixes the `list_ips()` KeyError, but any other uncaught exception in the watch loop still permanently kills sensor discovery because `sensor_manager()` is started with a bare `asyncio.create_task`.

## Test plan

- [x] `pytest core/services/ping/test_portwatcher.py`
- [ ] Confirm Ping service continues discovering after SoftAP/`uap0` churn on a vehicle

---
Supersedes #4040 (recreated from fork `joaoantoniocardoso/BlueOS-docker` instead of same-repo head).