### PR TITLE
Fix CI: update bun

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.1
+          bun-version: 1.3.14
 
       - name: Bun install
         run: bun install --cwd ./core/frontend

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -2,7 +2,7 @@
 ARG BASE_IMAGE=bluerobotics/blueos-base:0.2.6
 
 # Build frontend
-FROM --platform=$BUILDPLATFORM oven/bun:1.0.3-slim AS frontend-builder
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.14-slim AS frontend-builder
 
 ARG VITE_APP_GIT_DESCRIBE
 ENV VITE_APP_GIT_DESCRIBE=${VITE_APP_GIT_DESCRIBE:-none/none-0-g00000000}


### PR DESCRIPTION
CI is failing since we updated the lock file, which contains the version supported by `bun`. The current version requires at least `1.3.x`, so we are moving to the latest.