### PR TITLE
Add wifi to venv2 updated deps

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "commonwealth",
   "ardupilot_manager",
   "cable_guy",
-  "wifi",
 ]
 
 [dependency-groups]
@@ -43,7 +42,6 @@ bridges = { workspace = true }
 commonwealth = { workspace = true }
 ardupilot_manager = { workspace = true }
 cable_guy = { workspace = true }
-wifi = { workspace = true }
 
 [tool.uv.workspace]
 members = ["services/*", "libs/*"]
@@ -61,6 +59,7 @@ exclude = [
   "services/recorder_extractor",
   "services/ping",
   "services/pardal",
+  "services/wifi",
 ]
 
 # ------------------ Tooling Configurations ------------------

--- a/core/python-venv2/pyproject.toml
+++ b/core/python-venv2/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "recorder_extractor",
   "pardal",
   "ping",
+  "wifi",
 ]
 
 [dependency-groups]
@@ -66,6 +67,7 @@ nmea_injector = { workspace = true }
 recorder_extractor = { workspace = true }
 pardal = { workspace = true }
 ping = { workspace = true }
+wifi = { workspace = true }
 
 [tool.uv.workspace]
 members = [
@@ -83,4 +85,5 @@ members = [
   "../services/recorder_extractor",
   "../services/pardal",
   "../services/ping",
+  "../services/wifi",
 ]

--- a/core/python-venv2/uv.lock
+++ b/core/python-venv2/uv.lock
@@ -25,6 +25,7 @@ members = [
     "ping",
     "recorder-extractor",
     "versionchooser",
+    "wifi",
 ]
 
 [[package]]
@@ -333,6 +334,7 @@ dependencies = [
     { name = "ping" },
     { name = "recorder-extractor" },
     { name = "versionchooser" },
+    { name = "wifi" },
 ]
 
 [package.dev-dependencies]
@@ -377,6 +379,7 @@ requires-dist = [
     { name = "ping", virtual = "../services/ping" },
     { name = "recorder-extractor", virtual = "../services/recorder_extractor" },
     { name = "versionchooser", virtual = "../services/versionchooser" },
+    { name = "wifi", virtual = "../services/wifi" },
 ]
 
 [package.metadata.requires-dev]
@@ -1512,6 +1515,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyroute2"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "win-inet-pton", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/04/c9060b6cb024d05467e17ea93d3ca4bd2f3b05deb2372b7f79321640e8ad/pyroute2-0.8.1.tar.gz", hash = "sha256:b91f4a1f7abb9824637b1fe67e6e4a0a071d98d4a1a1b47ef792304ff3adad11", size = 435829, upload-time = "2024-12-20T14:41:19.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/cb/0b7a8009a577eba01ea54556c921f3cbf67a52931da17b4dd97472d0e694/pyroute2-0.8.1-py3-none-any.whl", hash = "sha256:f339be8acffc46cd87bca19217b559ea5838810b4b08836301a52cb2cb4c054b", size = 474302, upload-time = "2024-12-20T14:41:15.448Z" },
+]
+
+[[package]]
 name = "pyserial"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1687,6 +1702,29 @@ wheels = [
 ]
 
 [[package]]
+name = "sdbus"
+version = "0.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/0f/0cf6b2fb0338fb3ab564cb8a8d68aa1c6de767851f5f9de9a3c83dbabeab/sdbus-0.14.2.tar.gz", hash = "sha256:4f5d13b196e1e1de35311ebb2563a32de791451a30f5b9a4894528ba98766412", size = 89923, upload-time = "2025-12-21T20:22:32.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/e0/43d2c3e0cc6f6c345df5f3230e2a9c62bd8ae8608d401f582ccf943da14d/sdbus-0.14.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbed8db91668ad537089c42a71d30e2472faa2e6616a461441ab0d51344a461c", size = 769099, upload-time = "2025-12-21T20:22:27.773Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/0b/043869e8e53fe267b0fc9a98688f8ec9131ae2761a1665ee7c553b67ba69/sdbus-0.14.2-cp39-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:019871c00d9c2eeb5b40c3f3c94ff1d6579a49e245d6ecaf3bd9e245c4b248bc", size = 698023, upload-time = "2025-12-21T20:22:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f8/416467419d3345763372aaa51ef389fc95d0bd210679561edb63daa49933/sdbus-0.14.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a64bbb6280104efeb24a9632a9ebd5504e9c9c1349594142bbe50e734f16c83", size = 742236, upload-time = "2025-12-21T20:22:31.207Z" },
+]
+
+[[package]]
+name = "sdbus-networkmanager"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sdbus" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/ab/e864c6c2eb778c194cfb56cd9d98b5594dc00573210fdf6b44904745a0bf/sdbus-networkmanager-2.0.0.tar.gz", hash = "sha256:3572ac3a8189c683ec0416acb148761773a8f0881ad3d78b6d6f6864eff9c50b", size = 165071, upload-time = "2023-06-04T10:50:16.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/0c/6a67ebd967f3816022d04ab93db5f3d998a55d79c138af11feb1f59a6f10/sdbus_networkmanager-2.0.0-py3-none-any.whl", hash = "sha256:710a5ccfb1c3267016c990023ca76ad6210b13ab63aa5dad3a20e590b291b08f", size = 248349, upload-time = "2023-06-04T10:50:13.355Z" },
+]
+
+[[package]]
 name = "semver"
 version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1746,6 +1784,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]
@@ -1901,6 +1948,46 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "python-multipart", specifier = "==0.0.21" },
     { name = "uvicorn", specifier = "==0.38.0" },
+]
+
+[[package]]
+name = "wifi"
+version = "0.1.0"
+source = { virtual = "../services/wifi" }
+dependencies = [
+    { name = "commonwealth" },
+    { name = "fastapi" },
+    { name = "fastapi-versioning" },
+    { name = "loguru" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyroute2" },
+    { name = "sdbus-networkmanager" },
+    { name = "tabulate" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "commonwealth", specifier = "==0.1.0" },
+    { name = "fastapi", specifier = "==0.125.0" },
+    { name = "fastapi-versioning", specifier = "==0.10.0" },
+    { name = "loguru", specifier = "==0.7.3" },
+    { name = "psutil", specifier = "==7.1.3" },
+    { name = "pydantic", specifier = "==2.12.5" },
+    { name = "pyroute2", specifier = "==0.8.1" },
+    { name = "sdbus-networkmanager", specifier = "==2.0.0" },
+    { name = "tabulate", specifier = "==0.10.0" },
+    { name = "uvicorn", specifier = "==0.38.0" },
+]
+
+[[package]]
+name = "win-inet-pton"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/da/0b1487b5835497dea00b00d87c2aca168bb9ca2e2096981690239e23760a/win_inet_pton-1.1.0.tar.gz", hash = "sha256:dd03d942c0d3e2b1cf8bab511844546dfa5f74cb61b241699fa379ad707dea4f", size = 2949, upload-time = "2019-02-19T17:46:23.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/31/ff772a44aa56319df8afbb0b34f1a856f66f05b9d5f1fed917849e47fdae/win_inet_pton-1.1.0-py2.py3-none-any.whl", hash = "sha256:eaf0193cbe7152ac313598a0da7313fb479f769343c0c16c5308f64887dc885b", size = 4848, upload-time = "2019-02-19T17:46:22.182Z" },
 ]
 
 [[package]]

--- a/core/services/wifi/pyproject.toml
+++ b/core/services/wifi/pyproject.toml
@@ -5,19 +5,16 @@ description = "Wifi manager."
 requires-python = ">=3.11"
 dependencies = [
     "commonwealth==0.1.0",
-    "fastapi==0.105.0",
-    "fastapi-versioning==0.9.1",
-    "loguru==0.5.3",
-    "psutil==5.7.2",
-    "pydantic==1.10.12",
+    "fastapi==0.125.0",
+    "fastapi-versioning==0.10.0",
+    "loguru==0.7.3",
+    "psutil==7.1.3",
+    "pydantic==2.12.5",
     "pyroute2==0.8.1",
     "sdbus-networkmanager==2.0.0",
-    "tabulate==0.8.9",
-    "uvicorn==0.18.0",
+    "tabulate==0.10.0",
+    "uvicorn==0.38.0",
 ]
 
 [tool.uv]
 package = false
-
-[tool.uv.sources]
-commonwealth = { workspace = true }

--- a/core/services/wifi/typedefs.py
+++ b/core/services/wifi/typedefs.py
@@ -10,27 +10,27 @@ class HotspotStatus(BaseModel):
 
 
 class WifiStatus(BaseModel):
-    bssid: Optional[str]
-    freq: Optional[str]
-    ssid: Optional[str]
-    id: Optional[str]
-    mode: Optional[str]
-    wifi_generation: Optional[str]
-    pairwise_cipher: Optional[str]
-    group_cipher: Optional[str]
-    key_mgmt: Optional[str]
-    wpa_state: Optional[str]
-    ip_address: Optional[str]
-    p2p_device_address: Optional[str]
-    address: Optional[str]
-    uuid: Optional[str]
-    ieee80211ac: Optional[str]
-    state: Optional[str]
-    disabled: Optional[str]
+    bssid: Optional[str] = None
+    freq: Optional[str] = None
+    ssid: Optional[str] = None
+    id: Optional[str] = None
+    mode: Optional[str] = None
+    wifi_generation: Optional[str] = None
+    pairwise_cipher: Optional[str] = None
+    group_cipher: Optional[str] = None
+    key_mgmt: Optional[str] = None
+    wpa_state: Optional[str] = None
+    ip_address: Optional[str] = None
+    p2p_device_address: Optional[str] = None
+    address: Optional[str] = None
+    uuid: Optional[str] = None
+    ieee80211ac: Optional[str] = None
+    state: Optional[str] = None
+    disabled: Optional[str] = None
 
 
 class ScannedWifiNetwork(BaseModel):
-    ssid: Optional[str]
+    ssid: Optional[str] = None
     bssid: str
     flags: str
     frequency: int
@@ -40,10 +40,10 @@ class ScannedWifiNetwork(BaseModel):
 class SavedWifiNetwork(BaseModel):
     networkid: int
     ssid: str
-    bssid: Optional[str]
-    flags: Optional[str]
-    nm_id: Optional[str]
-    nm_uuid: Optional[str]
+    bssid: Optional[str] = None
+    flags: Optional[str] = None
+    nm_id: Optional[str] = None
+    nm_uuid: Optional[str] = None
 
 
 class WifiCredentials(BaseModel):

--- a/core/services/wifi/wifi_handlers/wpa_supplicant/Hotspot.py
+++ b/core/services/wifi/wifi_handlers/wpa_supplicant/Hotspot.py
@@ -125,6 +125,10 @@ class HotspotManager:
     def desired_channel_frequency(self) -> int:
         return self.base_interface_channel_frequency()
 
+    def _ap_interface_flags(self) -> List[str]:
+        stats = psutil.net_if_stats().get(self._ap_interface_name)
+        return str(stats.flags).split(",") if stats else []
+
     def _create_virtual_interface(self) -> None:
         logger.debug("Deleting virtual access point interface (if exists).")
         wireless_interfaces = self.iw.get_interfaces_dict()
@@ -156,7 +160,8 @@ class HotspotManager:
         # virtual_interface_index = int(self.ipr.link_lookup(ifname=self._ap_interface_name)[0])
         # self.ipr.link("set", index=virtual_interface_index, state="up")
         self._reach_condition_or_timeout(
-            lambda self: self._ap_interface_name in psutil.net_if_stats() and psutil.net_if_stats()[self._ap_interface_name][0],  # fmt: skip
+            # psutil's isup means IFF_RUNNING, which uap0 only gets once hostapd beacons on it.
+            lambda self: "up" in self._ap_interface_flags(),
             "Could not start virtual interface. Timeout exceeded.",
         )
 

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -129,7 +129,7 @@ PRIORITY_SERVICES=(
 SERVICES=(
     # This services are not prioritized because they are not fundamental for the vehicle to work
     'kraken',0,0,0,0,"nice -19 $BLUEOS_PYTHON_BIN_SECONDARY $SERVICES_PATH/kraken/main.py"
-    'wifi',0,0,0,0,"nice -19 $SERVICES_PATH/wifi/main.py --socket wlan0"
+    'wifi',0,0,0,0,"nice -19 $BLUEOS_PYTHON_BIN_SECONDARY $SERVICES_PATH/wifi/main.py --socket wlan0"
     # This services are not as important as the others
     'beacon',250,0,0,0,"$BLUEOS_PYTHON_BIN_SECONDARY $SERVICES_PATH/beacon/main.py"
     'bridget',0,0,0,0,"nice -19 $RUN_AS_REGULAR_USER_BEGIN $BLUEOS_PYTHON_BIN_SECONDARY $SERVICES_PATH/bridget/main.py $RUN_AS_REGULAR_USER_END"

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -14,7 +14,6 @@ members = [
     "cable-guy",
     "commonwealth",
     "filebrowser",
-    "wifi",
 ]
 
 [[package]]
@@ -154,7 +153,6 @@ dependencies = [
     { name = "bridges" },
     { name = "cable-guy" },
     { name = "commonwealth" },
-    { name = "wifi" },
 ]
 
 [package.dev-dependencies]
@@ -187,7 +185,6 @@ requires-dist = [
     { name = "bridges", editable = "libs/bridges" },
     { name = "cable-guy", virtual = "services/cable_guy" },
     { name = "commonwealth", editable = "libs/commonwealth" },
-    { name = "wifi", virtual = "services/wifi" },
 ]
 
 [package.metadata.requires-dev]
@@ -1093,15 +1090,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tabulate"
-version = "0.8.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3d/9d7576d94007eaf3bb685acbaaec66ff4cdeb0b18f1bf1f17edbeebffb0a/tabulate-0.8.9.tar.gz", hash = "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7", size = 53482, upload-time = "2021-02-22T07:34:14.585Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/80/7c0cad11bd99985cfe7c09427ee0b4f9bd6b048bd13d4ffb32c6db237dfb/tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4", size = 25123, upload-time = "2021-02-22T07:34:12.229Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1227,37 +1215,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/1a/4e4c12982b093796c1ceaff49cbc5998fb3a7866da755f8e7a1a40b8fda4/validators-0.18.2.tar.gz", hash = "sha256:37cd9a9213278538ad09b5b9f9134266e7c226ab1fede1d500e29e0a8fbb9ea6", size = 30299, upload-time = "2020-12-18T10:27:30.059Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/2f/7fed3ee94ad665ad2c1de87f858f10a7785251ff75b4fd47987888d07ef1/validators-0.18.2-py3-none-any.whl", hash = "sha256:0143dcca8a386498edaf5780cbd5960da1a4c85e0719f3ee5c9b41249c4fefbd", size = 19419, upload-time = "2020-12-18T10:27:27.933Z" },
-]
-
-[[package]]
-name = "wifi"
-version = "0.1.0"
-source = { virtual = "services/wifi" }
-dependencies = [
-    { name = "commonwealth" },
-    { name = "fastapi" },
-    { name = "fastapi-versioning" },
-    { name = "loguru" },
-    { name = "psutil" },
-    { name = "pydantic" },
-    { name = "pyroute2" },
-    { name = "sdbus-networkmanager" },
-    { name = "tabulate" },
-    { name = "uvicorn" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "commonwealth", editable = "libs/commonwealth" },
-    { name = "fastapi", specifier = "==0.105.0" },
-    { name = "fastapi-versioning", specifier = "==0.9.1" },
-    { name = "loguru", specifier = "==0.5.3" },
-    { name = "psutil", specifier = "==5.7.2" },
-    { name = "pydantic", specifier = "==1.10.12" },
-    { name = "pyroute2", specifier = "==0.8.1" },
-    { name = "sdbus-networkmanager", specifier = "==2.0.0" },
-    { name = "tabulate", specifier = "==0.8.9" },
-    { name = "uvicorn", specifier = "==0.18.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
the `_ap_interface_flags` change it's required by the `psutil` bump. isup now means IFF_RUNNING and uap0 has no carrier until hostapd beacons.

I did not update `pyroute2` so that we have an easier time bumping cable-guy.

bumping pyroute2 from 0.8.1 to 0.9.6 would require some changes in the Hostpot file because pyroute2 had an asyncio/architecture change. It's manageable for wifi, but it would involve a lot more of files for cable guy. I believe it would make reviewing easier if we handle these changes in a separate PR