### PR TITLE
[backport/1.4] Improve frontend: only get Kernel/Journal when needed

### DIFF
--- a/core/frontend/src/components/system-information/Kernel.vue
+++ b/core/frontend/src/components/system-information/Kernel.vue
@@ -41,7 +41,10 @@
 <script lang="ts">
 import Vue from 'vue'
 
-import system_information from '@/store/system-information'
+import system_information, {
+  subscribeKernelMessages,
+  unsubscribeKernelMessages,
+} from '@/store/system-information'
 import { Dictionary } from '@/types/common'
 import { KernelMessage } from '@/types/system-information/kernel'
 
@@ -55,6 +58,12 @@ export default Vue.extend({
     messages() {
       return system_information?.kernel_message
     },
+  },
+  mounted() {
+    subscribeKernelMessages()
+  },
+  beforeDestroy() {
+    unsubscribeKernelMessages()
   },
   methods: {
     getClass(message: KernelMessage): string {

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -21,7 +21,6 @@ import {
 import back_axios, { isBackendOffline } from '@/utils/api'
 
 export enum FetchType {
-    KernelType = 'kernel_buffer',
     ModelType = 'model',
     NetstatType = 'netstat',
     PlatformType = 'platform',
@@ -86,14 +85,15 @@ class SystemInformationStore extends VuexModule {
   }
 
   @Mutation
+  clearKernelMessages(): void {
+    this.kernel_message = []
+  }
+
+  @Mutation
   updateModel(model: Model): void {
     this.model = model
   }
 
-  @Mutation
-  updateKernelMessage(kernel_message: KernelMessage[]): void {
-    this.kernel_message = kernel_message
-  }
 
   @Mutation
   updateNetstat(netstat: Netstat): void {
@@ -182,10 +182,6 @@ class SystemInformationStore extends VuexModule {
     }
   }
 
-  @Action
-  async fetchKernelMessage(): Promise<void> {
-    await this.fetchSystemInformation(FetchType.KernelType)
-  }
 
   @Action
   async fetchModel(): Promise<void> {
@@ -289,9 +285,6 @@ class SystemInformationStore extends VuexModule {
     })
       .then((response) => {
         switch (type) {
-          case FetchType.KernelType:
-            this.updateKernelMessage(response.data)
-            break
           case FetchType.ModelType:
             this.updateModel(response.data)
             break
@@ -353,13 +346,45 @@ system_information.fetchPlatformTask.setAction(system_information.fetchPlatform)
 system_information.fetchSystemNetworkTask.setAction(system_information.fetchNetworkInformation)
 system_information.fetchSubscribedSystemInformationTask.setAction(system_information.fetchSubscribedSystemInformation)
 
-// It appears that the store is incompatible with websockets or callbacks.
-// Right now the only way to have it working is to have the websocket definition outside the store
+// Vuex store modules are a poor fit for WebSocket callbacks; keep sockets outside the store and
+// open them only while a UI consumer is mounted (Kernel tab).
 const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
-const websocketUrl = `${protocol}://${window.location.host}${system_information.API_URL}/ws/kernel_buffer`
-const socket = new WebSocket(websocketUrl)
-socket.onmessage = (message) => {
-  system_information.appendKernelMessage(JSON.parse(message.data))
+
+let kernel_socket: WebSocket | null = null
+let kernel_subscribers = 0
+
+function closeSocket(socket: WebSocket | null): void {
+  if (!socket) {
+    return
+  }
+  socket.onmessage = null
+  socket.onerror = null
+  socket.onclose = null
+  if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+    socket.close()
+  }
+}
+
+export function subscribeKernelMessages(): void {
+  kernel_subscribers += 1
+  if (kernel_socket) {
+    return
+  }
+  const socket = new WebSocket(`${protocol}://${window.location.host}${system_information.API_URL}/ws/kernel_buffer`)
+  socket.onmessage = (message) => {
+    system_information.appendKernelMessage(JSON.parse(message.data))
+  }
+  kernel_socket = socket
+}
+
+export function unsubscribeKernelMessages(): void {
+  kernel_subscribers = Math.max(0, kernel_subscribers - 1)
+  if (kernel_subscribers > 0) {
+    return
+  }
+  closeSocket(kernel_socket)
+  kernel_socket = null
+  system_information.clearKernelMessages()
 }
 
 export default system_information

--- a/core/frontend/src/views/SystemInformationView.vue
+++ b/core/frontend/src/views/SystemInformationView.vue
@@ -19,15 +19,18 @@
     </v-tabs>
     <v-tabs-items v-model="page_selected">
       <v-tab-item
-        v-for="page in pages"
+        v-for="(page, index) in pages"
         :key="page.value"
       >
-        <processes v-if="page.value === 'process'" />
-        <system-condition v-else-if="page.value === 'system_condition'" />
-        <network v-else-if="page.value === 'network'" />
-        <kernel v-else-if="page.value === 'kernel'" />
-        <firmware v-else-if="page.value === 'firmware'" />
-        <about-this-system v-else-if="page.value === 'about'" />
+        <!-- Only mount the active tab so heavy consumers (kernel WS) tear down when leaving -->
+        <template v-if="page_selected === index">
+          <processes v-if="page.value === 'process'" />
+          <system-condition v-else-if="page.value === 'system_condition'" />
+          <network v-else-if="page.value === 'network'" />
+          <kernel v-else-if="page.value === 'kernel'" />
+          <firmware v-else-if="page.value === 'firmware'" />
+          <about-this-system v-else-if="page.value === 'about'" />
+        </template>
       </v-tab-item>
     </v-tabs-items>
   </v-card>
@@ -76,7 +79,7 @@ export default Vue.extend({
         },
         { title: 'About', icon: 'mdi-information', value: 'about' },
       ] as Item[],
-      page_selected: null as string | null,
+      page_selected: 0 as number,
     }
   },
   computed: {


### PR DESCRIPTION
This is a backport of #4025 into 1.4.