### PR TITLE
commander: serialize environment variables as a dict

### DIFF
--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 from enum import Enum
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Dict
 
 import appdirs
 from commonwealth.utils.apis import GenericErrorHandlingRoute
@@ -263,8 +263,8 @@ async def check_mavlink_log_folder_size() -> Any:
 
 @app.get("/environment_variables", status_code=status.HTTP_200_OK)
 @version(1, 0)
-async def environment_variables() -> Any:
-    return os.environ
+async def environment_variables() -> Dict[str, Any]:
+    return dict(os.environ)
 
 
 app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)


### PR DESCRIPTION
Without this commander throws a serialization error in the terminal