### PR TITLE
frontend: version-chooser: use notifier instead of alert for error messages

### DIFF
--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -669,7 +669,13 @@ export default Vue.extend({
           (element) => element.repository !== repository || element.tag !== tag,
         )
       })
-        .catch((error) => { alert(error.response?.data ?? error.message) })
+        .catch((error) => {
+          notifier.pushError(
+            'VERSION_CHOOSER_DELETE_FAIL',
+            error.response?.data?.error ?? error.message,
+            true,
+          )
+        })
         .finally(() => { this.deleting = '' })
     },
     imageIsAvailableLocally(sha: string) : boolean {


### PR DESCRIPTION
fix: #3858 

This should fix the error, but I hasn't able to reproduce it to confirm