### PR TITLE
core: services: ping: Use nonlocal counter in portwatcher test

### DIFF
--- a/core/services/ping/test_portwatcher.py
+++ b/core/services/ping/test_portwatcher.py
@@ -8,11 +8,12 @@ from portwatcher import PortWatcher
 @pytest.mark.asyncio
 async def test_start_watching_continues_after_add_ping360_error() -> None:
     watcher = PortWatcher(probe_callback=AsyncMock(), found_callback=AsyncMock())
-    calls = {"n": 0}
+    calls = 0
 
     async def flaky_add_ping360() -> None:
-        calls["n"] += 1
-        if calls["n"] == 1:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
             raise KeyError("uap0")
         raise asyncio.CancelledError()
 
@@ -24,4 +25,4 @@ async def test_start_watching_continues_after_add_ping360_error() -> None:
         with pytest.raises(asyncio.CancelledError):
             await watcher.start_watching()
 
-    assert calls["n"] == 2
+    assert calls == 2


### PR DESCRIPTION
## Summary
- Replace the single-key `calls = {"n": 0}` dict in `test_portwatcher.py` with a plain `int` + `nonlocal` (same cleanup as on the 1.4 backport).

## Test plan
- [ ] `pytest core/services/ping/test_portwatcher.py`