### PR TITLE
core: tools: linux2rest: Update to 0.6.4

### DIFF
--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="v0.6.2"
+VERSION="v0.6.4"
 REPOSITORY_ORG="patrickelectric"
 REPOSITORY_NAME="linux2rest"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
This fixes the wrong CPU% when we open the PROCESSES tab from the System Information page.