### PR TITLE
Use frozen frontend dependencies in CI

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -60,7 +60,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Bun install
-        run: bun install --cwd ./core/frontend
+        run: bun install --frozen-lockfile --cwd ./core/frontend
 
       - name: Bun lint
         run: bun --cwd ./core/frontend lint

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -21,7 +21,7 @@ COPY frontend /home/pi/frontend
 RUN <<-EOF
 set -e
 
-    bun install --cwd /home/pi/frontend
+    bun install --frozen-lockfile --cwd /home/pi/frontend
     NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd /home/pi/frontend build
 
 EOF

--- a/core/frontend/.gitignore
+++ b/core/frontend/.gitignore
@@ -4,4 +4,3 @@ dist/
 yarn.lock
 dev-dist/
 components.d.ts
-bun.lockb


### PR DESCRIPTION
fix #4083

I'd play with the frontend before merging, just in case