### PR TITLE
core: kraken: Fix extension uptime after clock sync

### DIFF
--- a/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/cards/InstalledExtensionCard.vue
@@ -242,7 +242,7 @@ import SpinningLogo from '@/components/common/SpinningLogo.vue'
 import settings from '@/libs/settings'
 import system_information from '@/store/system-information'
 import { JSONValue } from '@/types/common'
-import { ExtensionData, InstalledExtensionData } from '@/types/kraken'
+import { ExtensionData, InstalledExtensionData, RunningContainer } from '@/types/kraken'
 import { Disk } from '@/types/system-information/system'
 import { prettifySize } from '@/utils/helper_functions'
 
@@ -264,9 +264,9 @@ export default Vue.extend({
       required: true,
     },
     container: {
-      type: Object as PropType<{status: string}>,
+      type: Object as PropType<RunningContainer>,
       required: false,
-      default: undefined as {status: string} | undefined,
+      default: undefined as RunningContainer | undefined,
     },
     extensionData: {
       type: Object as PropType<ExtensionData>,
@@ -381,7 +381,29 @@ export default Vue.extend({
       return 100
     },
     getStatus(): string {
-      return this.container?.status ?? 'N/A'
+      if (!this.container) return 'N/A'
+      if (this.container.uptime_seconds == null) return this.container.status
+
+      const suffix_start = this.container.status.indexOf(' (')
+      const suffix = suffix_start >= 0 ? this.container.status.slice(suffix_start) : ''
+      return `Up ${this.humanDuration(this.container.uptime_seconds)}${suffix}`
+    },
+    humanDuration(duration_seconds: number): string {
+      const seconds = Math.floor(duration_seconds)
+      if (seconds < 1) return 'Less than a second'
+      if (seconds === 1) return '1 second'
+      if (seconds < 60) return `${seconds} seconds`
+
+      const minutes = Math.floor(duration_seconds / 60)
+      const hours = Math.floor(duration_seconds / 60 / 60 + 0.5)
+      if (minutes === 1) return 'About a minute'
+      if (minutes < 60) return `${minutes} minutes`
+      if (hours === 1) return 'About an hour'
+      if (hours < 48) return `${hours} hours`
+      if (hours < 24 * 7 * 2) return `${Math.floor(hours / 24)} days`
+      if (hours < 24 * 30 * 2) return `${Math.floor(hours / 24 / 7)} weeks`
+      if (hours < 24 * 365 * 2) return `${Math.floor(hours / 24 / 30)} months`
+      return `${Math.floor(hours / 24 / 365)} years`
     },
   },
 })

--- a/core/frontend/src/types/kraken.ts
+++ b/core/frontend/src/types/kraken.ts
@@ -80,6 +80,7 @@ export interface RunningContainer {
     image: string
     imageId: string
     status: string
+    uptime_seconds?: number | null
 }
 
 export interface ManifestSource {

--- a/core/services/kraken/harbor/container.py
+++ b/core/services/kraken/harbor/container.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import AsyncGenerator, Dict, List
+import time
+from typing import Any, AsyncGenerator, Dict, List
 
 import psutil
 from aiodocker import Docker
@@ -13,6 +14,62 @@ from loguru import logger
 
 
 class ContainerManager:
+    @staticmethod
+    def _human_duration(duration_seconds: float) -> str:
+        seconds = int(duration_seconds)
+        if seconds < 1:
+            human_duration = "Less than a second"
+        elif seconds == 1:
+            human_duration = "1 second"
+        elif seconds < 60:
+            human_duration = f"{seconds} seconds"
+        else:
+            minutes = int(duration_seconds / 60)
+            hours = int(duration_seconds / 60 / 60 + 0.5)
+            if minutes == 1:
+                human_duration = "About a minute"
+            elif minutes < 60:
+                human_duration = f"{minutes} minutes"
+            elif hours == 1:
+                human_duration = "About an hour"
+            elif hours < 48:
+                human_duration = f"{hours} hours"
+            elif hours < 24 * 7 * 2:
+                human_duration = f"{hours // 24} days"
+            elif hours < 24 * 30 * 2:
+                human_duration = f"{hours // 24 // 7} weeks"
+            elif hours < 24 * 365 * 2:
+                human_duration = f"{hours // 24 // 30} months"
+            else:
+                human_duration = f"{int(duration_seconds / 60 / 60) // 24 // 365} years"
+
+        return human_duration
+
+    @classmethod
+    def _status_with_monotonic_uptime(cls, status_text: str, pid: int) -> str:
+        if not status_text.startswith("Up ") or pid <= 0:
+            return status_text
+
+        try:
+            process_start_since_boot = psutil.Process(pid).create_time() - psutil.boot_time()
+            uptime_seconds = max(0.0, time.monotonic() - process_start_since_boot)
+        except psutil.Error:
+            return status_text
+
+        suffix_start = status_text.find(" (")
+        suffix = status_text[suffix_start:] if suffix_start >= 0 else ""
+        return f"Up {cls._human_duration(uptime_seconds)}{suffix}"
+
+    @classmethod
+    def _container_model(cls, container: DockerContainer, details: Dict[str, Any]) -> ContainerModel:
+        pid = details.get("State", {}).get("Pid", 0)
+        return ContainerModel(
+            name=container["Names"][0],
+            image=container["Image"],
+            image_id=container["ImageID"],
+            status=cls._status_with_monotonic_uptime(container["Status"], pid),
+        )
+
     @staticmethod
     async def get_raw_container_by_name(client: Docker, container_name: str) -> DockerContainer:
         containers = await client.containers.list(filters={"name": {container_name: True}})  # type: ignore
@@ -84,32 +141,21 @@ class ContainerManager:
 
         return result
 
-    @staticmethod
-    async def get_running_containers() -> List[ContainerModel]:
+    @classmethod
+    async def get_running_containers(cls) -> List[ContainerModel]:
         async with DockerCtx() as client:
             containers = await client.containers.list(filters={"status": ["running"]})  # type: ignore
+            details = await asyncio.gather(*(container.show() for container in containers))
 
-            return [
-                ContainerModel(
-                    name=container["Names"][0],
-                    image=container["Image"],
-                    image_id=container["ImageID"],
-                    status=container["Status"],
-                )
-                for container in containers
-            ]
+            return [cls._container_model(container, detail) for container, detail in zip(containers, details)]
 
     @classmethod
     async def get_running_container_by_name(cls, container_name: str) -> ContainerModel:
         async with DockerCtx() as client:
             container = await cls.get_raw_container_by_name(client, container_name)
+            details = await container.show()
 
-            return ContainerModel(
-                name=container["Names"][0],
-                image=container["Image"],
-                image_id=container["ImageID"],
-                status=container["Status"],
-            )
+            return cls._container_model(container, details)
 
     @classmethod
     async def get_container_log_by_name(cls, container_name: str) -> AsyncGenerator[str, None]:

--- a/core/services/kraken/harbor/container.py
+++ b/core/services/kraken/harbor/container.py
@@ -15,50 +15,15 @@ from loguru import logger
 
 class ContainerManager:
     @staticmethod
-    def _human_duration(duration_seconds: float) -> str:
-        seconds = int(duration_seconds)
-        if seconds < 1:
-            human_duration = "Less than a second"
-        elif seconds == 1:
-            human_duration = "1 second"
-        elif seconds < 60:
-            human_duration = f"{seconds} seconds"
-        else:
-            minutes = int(duration_seconds / 60)
-            hours = int(duration_seconds / 60 / 60 + 0.5)
-            if minutes == 1:
-                human_duration = "About a minute"
-            elif minutes < 60:
-                human_duration = f"{minutes} minutes"
-            elif hours == 1:
-                human_duration = "About an hour"
-            elif hours < 48:
-                human_duration = f"{hours} hours"
-            elif hours < 24 * 7 * 2:
-                human_duration = f"{hours // 24} days"
-            elif hours < 24 * 30 * 2:
-                human_duration = f"{hours // 24 // 7} weeks"
-            elif hours < 24 * 365 * 2:
-                human_duration = f"{hours // 24 // 30} months"
-            else:
-                human_duration = f"{int(duration_seconds / 60 / 60) // 24 // 365} years"
-
-        return human_duration
-
-    @classmethod
-    def _status_with_monotonic_uptime(cls, status_text: str, pid: int) -> str:
-        if not status_text.startswith("Up ") or pid <= 0:
-            return status_text
+    def _monotonic_uptime(pid: int) -> float | None:
+        if pid <= 0:
+            return None
 
         try:
             process_start_since_boot = psutil.Process(pid).create_time() - psutil.boot_time()
-            uptime_seconds = max(0.0, time.monotonic() - process_start_since_boot)
+            return float(max(0.0, time.monotonic() - process_start_since_boot))
         except psutil.Error:
-            return status_text
-
-        suffix_start = status_text.find(" (")
-        suffix = status_text[suffix_start:] if suffix_start >= 0 else ""
-        return f"Up {cls._human_duration(uptime_seconds)}{suffix}"
+            return None
 
     @classmethod
     def _container_model(cls, container: DockerContainer, details: Dict[str, Any]) -> ContainerModel:
@@ -67,7 +32,8 @@ class ContainerManager:
             name=container["Names"][0],
             image=container["Image"],
             image_id=container["ImageID"],
-            status=cls._status_with_monotonic_uptime(container["Status"], pid),
+            status=container["Status"],
+            uptime_seconds=cls._monotonic_uptime(pid),
         )
 
     @staticmethod
@@ -88,7 +54,9 @@ class ContainerManager:
 
     @staticmethod
     # pylint: disable=too-many-locals
-    async def _get_stats_from_containers(containers: List[DockerContainer]) -> Dict[str, ContainerUsageModel]:
+    async def _get_stats_from_containers(
+        containers: List[DockerContainer],
+    ) -> Dict[str, ContainerUsageModel]:
         result: Dict[str, ContainerUsageModel] = {}
 
         # Create separate lists of coroutine objects for stats and show

--- a/core/services/kraken/harbor/models.py
+++ b/core/services/kraken/harbor/models.py
@@ -6,6 +6,7 @@ class ContainerModel(BaseModel):
     image: str
     image_id: str
     status: str
+    uptime_seconds: float | None = None
 
 
 class ContainerUsageModel(BaseModel):

--- a/core/services/kraken/harbor/test_container.py
+++ b/core/services/kraken/harbor/test_container.py
@@ -5,24 +5,9 @@ import pytest
 from harbor.container import ContainerManager
 
 
-@pytest.mark.parametrize(
-    ("duration_seconds", "expected"),
-    [
-        (0.5, "Less than a second"),
-        (1, "1 second"),
-        (59, "59 seconds"),
-        (60, "About a minute"),
-        (59 * 60, "59 minutes"),
-        (60 * 60, "About an hour"),
-        (4 * 60 * 60, "4 hours"),
-        (3 * 24 * 60 * 60, "3 days"),
-    ],
-)
-def test_human_duration(duration_seconds: float, expected: str) -> None:
-    assert ContainerManager._human_duration(duration_seconds) == expected
-
-
-def test_status_uses_process_uptime_and_preserves_health(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_uptime_uses_process_start_relative_to_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class FakeProcess:
         @staticmethod
         def create_time() -> float:
@@ -32,17 +17,34 @@ def test_status_uses_process_uptime_and_preserves_health(monkeypatch: pytest.Mon
     monkeypatch.setattr(psutil, "boot_time", lambda: 1_000.0)
     monkeypatch.setattr(time, "monotonic", lambda: 10_800.0)
 
-    status = ContainerManager._status_with_monotonic_uptime("Up 17 hours (healthy)", 42)
+    uptime = ContainerManager._monotonic_uptime(42)
 
-    assert status == "Up 2 hours (healthy)"
+    assert uptime == 7_200.0
 
 
-def test_status_falls_back_when_process_is_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_uptime_is_unavailable_when_process_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def missing_process(pid: int) -> None:
         raise psutil.NoSuchProcess(pid)
 
     monkeypatch.setattr(psutil, "Process", missing_process)
 
-    status = ContainerManager._status_with_monotonic_uptime("Up 17 hours", 42)
+    assert ContainerManager._monotonic_uptime(42) is None
 
-    assert status == "Up 17 hours"
+
+def test_container_model_keeps_status_and_exposes_uptime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ContainerManager, "_monotonic_uptime", lambda _pid: 7_200.0)
+    container = {
+        "Names": ["/example"],
+        "Image": "example/image:latest",
+        "ImageID": "sha256:123",
+        "Status": "Up 17 hours (healthy)",
+    }
+
+    model = ContainerManager._container_model(container, {"State": {"Pid": 42}})  # type: ignore[arg-type]
+
+    assert model.status == "Up 17 hours (healthy)"
+    assert model.uptime_seconds == 7_200.0

--- a/core/services/kraken/harbor/test_container.py
+++ b/core/services/kraken/harbor/test_container.py
@@ -1,0 +1,48 @@
+import time
+
+import psutil
+import pytest
+from harbor.container import ContainerManager
+
+
+@pytest.mark.parametrize(
+    ("duration_seconds", "expected"),
+    [
+        (0.5, "Less than a second"),
+        (1, "1 second"),
+        (59, "59 seconds"),
+        (60, "About a minute"),
+        (59 * 60, "59 minutes"),
+        (60 * 60, "About an hour"),
+        (4 * 60 * 60, "4 hours"),
+        (3 * 24 * 60 * 60, "3 days"),
+    ],
+)
+def test_human_duration(duration_seconds: float, expected: str) -> None:
+    assert ContainerManager._human_duration(duration_seconds) == expected
+
+
+def test_status_uses_process_uptime_and_preserves_health(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeProcess:
+        @staticmethod
+        def create_time() -> float:
+            return 4_600.0
+
+    monkeypatch.setattr(psutil, "Process", lambda _pid: FakeProcess())
+    monkeypatch.setattr(psutil, "boot_time", lambda: 1_000.0)
+    monkeypatch.setattr(time, "monotonic", lambda: 10_800.0)
+
+    status = ContainerManager._status_with_monotonic_uptime("Up 17 hours (healthy)", 42)
+
+    assert status == "Up 2 hours (healthy)"
+
+
+def test_status_falls_back_when_process_is_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing_process(pid: int) -> None:
+        raise psutil.NoSuchProcess(pid)
+
+    monkeypatch.setattr(psutil, "Process", missing_process)
+
+    status = ContainerManager._status_with_monotonic_uptime("Up 17 hours", 42)
+
+    assert status == "Up 17 hours"


### PR DESCRIPTION
Closes #3416

## What changed

- derive running-container uptime from the host process's monotonic start time instead of Docker's wall-clock duration
- expose that raw duration as `uptime_seconds` in the Kraken API
- keep human-readable duration formatting in the frontend, where presentation belongs
- preserve Docker status suffixes such as `(healthy)`
- fall back to Docker's original status if process uptime cannot be read
- cover monotonic calculation, fallback behavior, and API model output with regression tests

## Root cause

Docker builds the human-readable `Status` field by subtracting `StartedAt` from the current wall clock. BlueOS can start extensions before the Raspberry Pi synchronizes its clock, so a later NTP correction makes long-running extensions appear older than the host.

BlueOS Core runs in the host PID namespace. Kraken can therefore derive each container process's start offset from boot and compare it with `time.monotonic()`, which is unaffected by wall-clock corrections.

## Architecture

Kraken returns the raw monotonic uptime as data. The extension card formats that duration for display and combines it with Docker's health suffix. This keeps presentation out of the backend while retaining the existing UI.

## Validation

- `pytest -q core/services/kraken/harbor/test_container.py` (3 passed)
- targeted ESLint and Stylelint on the frontend changes
- production frontend build (2,584 modules transformed; existing Sentry-auth warning only)
- Ruff 0.0.288, Black 22.3.0, isort 5.8, and mypy 1.4.1 on the changed backend files
