### PR TITLE
[1.4] core: libs: commonwealth: settings: Fix temp file race between load and save

### DIFF
--- a/core/libs/commonwealth/commonwealth/settings/bases/pydantic_base.py
+++ b/core/libs/commonwealth/commonwealth/settings/bases/pydantic_base.py
@@ -14,6 +14,7 @@ from commonwealth.settings.exceptions import (
     MigrationFail,
     SettingsFromTheFuture,
 )
+from commonwealth.settings.temp_files import save_lock
 
 
 class PydanticSettings(BaseModel):
@@ -109,18 +110,22 @@ class PydanticSettings(BaseModel):
 
         # Prepare data prior to operation
         logger.debug(f"Saving settings on: {file_path}")
-        json_data = self.dict()
 
-        # Create a temporary file in same directory, write and rename it to the original file
-        temp_file = file_path.with_suffix(".tmp")
-        with open(temp_file, "w", encoding="utf-8") as settings_file:
-            json.dump(json_data, settings_file, indent=4)
-            # Ensure data is written to disk
-            settings_file.flush()
-            os.fsync(settings_file.fileno())
-        # Replace the original file with the temporary file, this operation is atomic if in the same filesystem
-        # https://docs.python.org/3/library/os.html#os.replace
-        temp_file.replace(file_path)
+        # Serialize inside the lock so the write section runs by a single thread at a time. This keeps the
+        # temporary file from colliding and ensures the last writer serializes every mutation made before it.
+        with save_lock:
+            json_data = self.dict()
+
+            # Create a temporary file in same directory, write and rename it to the original file
+            temp_file = file_path.with_suffix(".tmp")
+            with open(temp_file, "w", encoding="utf-8") as settings_file:
+                json.dump(json_data, settings_file, indent=4)
+                # Ensure data is written to disk
+                settings_file.flush()
+                os.fsync(settings_file.fileno())
+            # Replace the original file with the temporary file, this operation is atomic if in the same filesystem
+            # https://docs.python.org/3/library/os.html#os.replace
+            temp_file.replace(file_path)
 
     def reset(self) -> None:
         """Reset internal data to default values"""

--- a/core/libs/commonwealth/commonwealth/settings/bases/pykson_base.py
+++ b/core/libs/commonwealth/commonwealth/settings/bases/pykson_base.py
@@ -14,6 +14,7 @@ from commonwealth.settings.exceptions import (
     MigrationFail,
     SettingsFromTheFuture,
 )
+from commonwealth.settings.temp_files import save_lock
 
 
 class PyksonSettings(pykson.JsonObject):
@@ -93,18 +94,20 @@ class PyksonSettings(pykson.JsonObject):
 
         # Prepare data prior to operation
         logger.debug(f"Saving settings on: {file_path}")
-        json_data = json.dumps(json.loads(Pykson().to_json(self)), indent=4)
 
-        # Create a temporary file in same directory, write and rename it to the original file
-        temp_file = file_path.with_suffix(".tmp")
-        with open(temp_file, "w", encoding="utf-8") as settings_file:
-            settings_file.write(json_data)
-            # Ensure data is written to disk
-            settings_file.flush()
-            os.fsync(settings_file.fileno())
-        # Replace the original file with the temporary file, this operation is atomic if in the same filesystem
-        # https://docs.python.org/3/library/os.html#os.replace
-        temp_file.replace(file_path)
+        with save_lock:
+            json_data = json.dumps(json.loads(Pykson().to_json(self)), indent=4)
+
+            # Create a temporary file in same directory, write and rename it to the original file
+            temp_file = file_path.with_suffix(".tmp")
+            with open(temp_file, "w", encoding="utf-8") as settings_file:
+                settings_file.write(json_data)
+                # Ensure data is written to disk
+                settings_file.flush()
+                os.fsync(settings_file.fileno())
+            # Replace the original file with the temporary file, this operation is atomic if in the same filesystem
+            # https://docs.python.org/3/library/os.html#os.replace
+            temp_file.replace(file_path)
 
     def reset(self) -> None:
         """Reset internal data to default values"""

--- a/core/libs/commonwealth/commonwealth/settings/managers/pydantic_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/managers/pydantic_manager.py
@@ -6,6 +6,7 @@ import appdirs
 from loguru import logger
 
 from commonwealth.settings.bases.pydantic_base import PydanticSettings
+from commonwealth.settings.temp_files import clear_temp_files
 
 
 class PydanticManager:
@@ -116,7 +117,7 @@ class PydanticManager:
         valid_files = [
             possible_file
             for possible_file in self.config_folder.iterdir()
-            if possible_file.name.startswith(PydanticManager.SETTINGS_NAME_PREFIX)
+            if possible_file.name.startswith(PydanticManager.SETTINGS_NAME_PREFIX) and possible_file.suffix == ".json"
         ]
         valid_files.sort(key=get_settings_version_from_filename, reverse=True)
 
@@ -136,8 +137,4 @@ class PydanticManager:
 
     def _clear_temp_files(self) -> None:
         """Clear temporary files"""
-        for temp_file in self.config_folder.glob("*.tmp"):
-            try:
-                temp_file.unlink()
-            except Exception as exception:
-                logger.debug(f"Failed to clear temporary file {temp_file}: {exception}")
+        clear_temp_files(self.config_folder)

--- a/core/libs/commonwealth/commonwealth/settings/managers/pykson_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/managers/pykson_manager.py
@@ -6,6 +6,7 @@ import appdirs
 from loguru import logger
 
 from commonwealth.settings.bases.pykson_base import PyksonSettings
+from commonwealth.settings.temp_files import clear_temp_files
 
 
 class PyksonManager:
@@ -112,7 +113,7 @@ class PyksonManager:
         valid_files = [
             possible_file
             for possible_file in self.config_folder.iterdir()
-            if possible_file.name.startswith(PyksonManager.SETTINGS_NAME_PREFIX)
+            if possible_file.name.startswith(PyksonManager.SETTINGS_NAME_PREFIX) and possible_file.suffix == ".json"
         ]
         valid_files.sort(key=get_settings_version_from_filename, reverse=True)
 
@@ -132,8 +133,4 @@ class PyksonManager:
 
     def _clear_temp_files(self) -> None:
         """Clear temporary files"""
-        for temp_file in self.config_folder.glob("*.tmp"):
-            try:
-                temp_file.unlink()
-            except Exception as exception:
-                logger.debug(f"Failed to clear temporary file {temp_file}: {exception}")
+        clear_temp_files(self.config_folder)

--- a/core/libs/commonwealth/commonwealth/settings/temp_files.py
+++ b/core/libs/commonwealth/commonwealth/settings/temp_files.py
@@ -1,0 +1,17 @@
+import pathlib
+import threading
+
+from loguru import logger
+
+save_lock = threading.Lock()
+
+
+def clear_temp_files(folder: pathlib.Path) -> None:
+    # Must use the same non-reentrant lock as settings save() so we never unlink a .tmp file while
+    # save() is still writing and about to os.replace() it.
+    with save_lock:
+        for temp_file in folder.glob("*.tmp"):
+            try:
+                temp_file.unlink()
+            except Exception as exception:
+                logger.debug(f"Failed to clear temporary file {temp_file}: {exception}")

--- a/core/libs/commonwealth/commonwealth/settings/tests/test_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/tests/test_manager.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import tempfile
+import threading
 from typing import Any, Dict
 
 import pykson  # type: ignore
@@ -272,3 +273,41 @@ def test_invalid_json_fallback_to_defaults_v2_from_invalid_v2_and_v1() -> None:
     assert settings_manager.settings.VERSION == 2
     assert settings_manager.settings.version_1_variable == 42
     assert settings_manager.settings.version_2_variable == 66
+
+
+def test_concurrent_saves_preserve_all_updates() -> None:
+    # Regression test for https://github.com/bluerobotics/BlueOS/issues/3998: two requests mutating and saving
+    # the same settings object at once must not crash on the temporary file and must both end up persisted.
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+
+    settings_manager = manager.Manager("ManagerTest", SettingsV2, config_path)
+
+    errors: list[Exception] = []
+    start = threading.Barrier(2)
+
+    def mutate_and_save(variable: str, value: int) -> None:
+        try:
+            start.wait()
+            for _ in range(100):
+                setattr(settings_manager.settings, variable, value)
+                settings_manager.save()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    threads = [
+        threading.Thread(target=mutate_and_save, args=("version_1_variable", 111)),
+        threading.Thread(target=mutate_and_save, args=("version_2_variable", 222)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, f"Concurrent saves raised: {errors}"
+
+    # Both updates must survive, and only the versioned settings file should remain (no leftover temp files).
+    reloaded = manager.Manager("ManagerTest", SettingsV2, config_path)
+    assert reloaded.settings.version_1_variable == 111
+    assert reloaded.settings.version_2_variable == 222
+    assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]

--- a/core/libs/commonwealth/commonwealth/settings/tests/test_manager.py
+++ b/core/libs/commonwealth/commonwealth/settings/tests/test_manager.py
@@ -311,3 +311,45 @@ def test_concurrent_saves_preserve_all_updates() -> None:
     assert reloaded.settings.version_1_variable == 111
     assert reloaded.settings.version_2_variable == 222
     assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]
+
+
+def test_concurrent_load_and_save_do_not_crash() -> None:
+    # Regression test for https://github.com/bluerobotics/BlueOS/issues/4106: load() clearing *.tmp
+    # while save() is writing must not raise FileNotFoundError on replace.
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+
+    settings_manager = manager.Manager("ManagerTest", SettingsV2, config_path)
+    settings_manager.settings.version_1_variable = 1
+    settings_manager.save()
+
+    errors: list[Exception] = []
+    stop = threading.Event()
+
+    def save_loop() -> None:
+        try:
+            for i in range(200):
+                settings_manager.settings.version_1_variable = i
+                settings_manager.save()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    def load_loop() -> None:
+        try:
+            while not stop.is_set():
+                settings_manager.load()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    save_thread = threading.Thread(target=save_loop)
+    load_thread = threading.Thread(target=load_loop)
+    save_thread.start()
+    load_thread.start()
+    save_thread.join(timeout=30)
+    stop.set()
+    load_thread.join(timeout=30)
+
+    assert not save_thread.is_alive(), "save thread did not finish"
+    assert not load_thread.is_alive(), "load thread did not finish"
+    assert not errors, f"Concurrent load and save raised: {errors}"
+    assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]

--- a/core/libs/commonwealth/commonwealth/settings/tests/test_manager_pydantic.py
+++ b/core/libs/commonwealth/commonwealth/settings/tests/test_manager_pydantic.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import tempfile
+import threading
 from typing import Any, Dict
 
 from ..bases.pydantic_base import PydanticSettings
@@ -247,3 +248,41 @@ def test_invalid_json_fallback_to_defaults_v2_from_invalid_v2_and_v1() -> None:
     assert settings_manager.settings.VERSION == 2
     assert settings_manager.settings.version_1_variable == 42
     assert settings_manager.settings.version_2_variable == 66
+
+
+def test_concurrent_saves_preserve_all_updates() -> None:
+    # Regression test for https://github.com/bluerobotics/BlueOS/issues/3998: two requests mutating and saving
+    # the same settings object at once must not crash on the temporary file and must both end up persisted.
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+
+    settings_manager = PydanticManager("ManagerTest", SettingsV2, config_path)
+
+    errors: list[Exception] = []
+    start = threading.Barrier(2)
+
+    def mutate_and_save(variable: str, value: int) -> None:
+        try:
+            start.wait()
+            for _ in range(100):
+                setattr(settings_manager.settings, variable, value)
+                settings_manager.save()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    threads = [
+        threading.Thread(target=mutate_and_save, args=("version_1_variable", 111)),
+        threading.Thread(target=mutate_and_save, args=("version_2_variable", 222)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, f"Concurrent saves raised: {errors}"
+
+    # Both updates must survive, and only the versioned settings file should remain (no leftover temp files).
+    reloaded = PydanticManager("ManagerTest", SettingsV2, config_path)
+    assert reloaded.settings.version_1_variable == 111
+    assert reloaded.settings.version_2_variable == 222
+    assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]

--- a/core/libs/commonwealth/commonwealth/settings/tests/test_manager_pydantic.py
+++ b/core/libs/commonwealth/commonwealth/settings/tests/test_manager_pydantic.py
@@ -286,3 +286,45 @@ def test_concurrent_saves_preserve_all_updates() -> None:
     assert reloaded.settings.version_1_variable == 111
     assert reloaded.settings.version_2_variable == 222
     assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]
+
+
+def test_concurrent_load_and_save_do_not_crash() -> None:
+    # Regression test for https://github.com/bluerobotics/BlueOS/issues/4106: load() clearing *.tmp
+    # while save() is writing must not raise FileNotFoundError on replace.
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+
+    settings_manager = PydanticManager("ManagerTest", SettingsV2, config_path)
+    settings_manager.settings.version_1_variable = 1
+    settings_manager.save()
+
+    errors: list[Exception] = []
+    stop = threading.Event()
+
+    def save_loop() -> None:
+        try:
+            for i in range(200):
+                settings_manager.settings.version_1_variable = i
+                settings_manager.save()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    def load_loop() -> None:
+        try:
+            while not stop.is_set():
+                settings_manager.load()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    save_thread = threading.Thread(target=save_loop)
+    load_thread = threading.Thread(target=load_loop)
+    save_thread.start()
+    load_thread.start()
+    save_thread.join(timeout=30)
+    stop.set()
+    load_thread.join(timeout=30)
+
+    assert not save_thread.is_alive(), "save thread did not finish"
+    assert not load_thread.is_alive(), "load thread did not finish"
+    assert not errors, f"Concurrent load and save raised: {errors}"
+    assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]


### PR DESCRIPTION
Closes #4106 for 1.4.

We are backporting #4001 to 1.4 and adapting it to cover Pykson as well.

How? Beacon’s periodic `load()` can no longer delete `*.tmp` while another thread is mid-`save()`. An unchanged hostname still triggers a save (frontend behavior unchanged), but it won't crash.