### PR TITLE
[master] core: libs: commonwealth: settings: Fix temp file race between load and save

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/settings/managers/pydantic_manager.py
+++ b/core/libs/commonwealth/src/commonwealth/settings/managers/pydantic_manager.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, Optional, Type
 
 import appdirs
-from commonwealth.settings.bases.pydantic_base import PydanticSettings
+from commonwealth.settings.bases.pydantic_base import PydanticSettings, _save_lock
 from loguru import logger
 
 
@@ -115,7 +115,7 @@ class PydanticManager:
         valid_files = [
             possible_file
             for possible_file in self.config_folder.iterdir()
-            if possible_file.name.startswith(PydanticManager.SETTINGS_NAME_PREFIX)
+            if possible_file.name.startswith(PydanticManager.SETTINGS_NAME_PREFIX) and possible_file.suffix == ".json"
         ]
         valid_files.sort(key=get_settings_version_from_filename, reverse=True)
 
@@ -135,8 +135,11 @@ class PydanticManager:
 
     def _clear_temp_files(self) -> None:
         """Clear temporary files"""
-        for temp_file in self.config_folder.glob("*.tmp"):
-            try:
-                temp_file.unlink()
-            except Exception as exception:
-                logger.debug(f"Failed to clear temporary file {temp_file}: {exception}")
+        # Must use the same non-reentrant lock as PydanticSettings.save() so we never unlink a .tmp
+        # file while save() is still writing and about to os.replace() it.
+        with _save_lock:
+            for temp_file in self.config_folder.glob("*.tmp"):
+                try:
+                    temp_file.unlink()
+                except Exception as exception:
+                    logger.debug(f"Failed to clear temporary file {temp_file}: {exception}")

--- a/core/libs/commonwealth/src/commonwealth/settings/tests/test_manager_pydantic.py
+++ b/core/libs/commonwealth/src/commonwealth/settings/tests/test_manager_pydantic.py
@@ -286,3 +286,45 @@ def test_concurrent_saves_preserve_all_updates() -> None:
     assert reloaded.settings.version_1_variable == 111
     assert reloaded.settings.version_2_variable == 222
     assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]
+
+
+def test_concurrent_load_and_save_do_not_crash() -> None:
+    # Regression test for https://github.com/bluerobotics/BlueOS/issues/4106 load() clearing *.tmp
+    # while save() is writing must not raise FileNotFoundError on replace.
+    temporary_folder = tempfile.mkdtemp()
+    config_path = pathlib.Path(temporary_folder)
+
+    settings_manager = PydanticManager("ManagerTest", SettingsV2, config_path)
+    settings_manager.settings.version_1_variable = 1
+    settings_manager.save()
+
+    errors: list[Exception] = []
+    stop = threading.Event()
+
+    def save_loop() -> None:
+        try:
+            for i in range(200):
+                settings_manager.settings.version_1_variable = i
+                settings_manager.save()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    def load_loop() -> None:
+        try:
+            while not stop.is_set():
+                settings_manager.load()
+        except Exception as error:  # noqa: BLE001 - collect to assert on the main thread
+            errors.append(error)
+
+    save_thread = threading.Thread(target=save_loop)
+    load_thread = threading.Thread(target=load_loop)
+    save_thread.start()
+    load_thread.start()
+    save_thread.join(timeout=30)
+    stop.set()
+    load_thread.join(timeout=30)
+
+    assert not save_thread.is_alive(), "save thread did not finish"
+    assert not load_thread.is_alive(), "load thread did not finish"
+    assert not errors, f"Concurrent load and save raised: {errors}"
+    assert os.listdir(config_path.joinpath("managertest")) == ["settings-2.json"]

--- a/core/libs/commonwealth/src/commonwealth/settings/tests/test_manager_pydantic.py
+++ b/core/libs/commonwealth/src/commonwealth/settings/tests/test_manager_pydantic.py
@@ -251,7 +251,7 @@ def test_invalid_json_fallback_to_defaults_v2_from_invalid_v2_and_v1() -> None:
 
 
 def test_concurrent_saves_preserve_all_updates() -> None:
-    # Regression test for https://github.com/bluerobotics/BlueOS/issues/3998: two requests mutating and saving
+    # Regression test for https://github.com/bluerobotics/BlueOS/issues/3998 two requests mutating and saving
     # the same settings object at once must not crash on the temporary file and must both end up persisted.
     temporary_folder = tempfile.mkdtemp()
     config_path = pathlib.Path(temporary_folder)


### PR DESCRIPTION
Closes #4106 for master.

Brings the missing piece from #4116 to master.

Clear temp files under the same lock as save() so load() cannot delete a .tmp file while save() is replacing it.