### PR TITLE
[1.4] core: services: commander: Keep .ssh keys on settings reset (backport #3677 + fix)

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -56,18 +56,42 @@ def get_host_os() -> HostOs:
     return HostOs.Other
 
 
-def delete_everything(path: Path) -> None:
+def delete_everything(path: Path, ignore: list[Path] | None = None) -> None:
+    if ignore is None:
+        ignore = []
+
+    def is_ignored(target: Path) -> bool:
+        for ignored_path in ignore:
+            try:
+                ignored_resolved = ignored_path.resolve()
+                target_resolved = target.resolve()
+                try:
+                    # If relative_to works, target is inside or equal to ignored_resolved
+                    target_resolved.relative_to(ignored_resolved)
+                    return True
+                except ValueError:
+                    # Not relative, so not in ignored path
+                    continue
+            except Exception:
+                continue
+        return False
+
+    if is_ignored(path):
+        return
+
     if path.is_file() and (path.suffix == ".gz" or not file_is_open(path)):
         path.unlink()
         return
 
     for item in path.glob("*"):
+        if is_ignored(item):
+            continue
         try:
             if item.is_file() and not file_is_open(item):
                 item.unlink()
             if item.is_dir() and not item.is_symlink():
                 # Delete folder contents
-                delete_everything(item)
+                delete_everything(item, ignore=ignore)
         except Exception as exception:
             logger.warning(f"Failed to delete: {item}, {exception}")
 

--- a/core/libs/commonwealth/commonwealth/utils/tests/test_general.py
+++ b/core/libs/commonwealth/commonwealth/utils/tests/test_general.py
@@ -1,0 +1,194 @@
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+from .. import general
+from ..general import HostOs
+
+
+@pytest.mark.parametrize(
+    "os_release,expected_host_os",
+    [
+        ('PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"', HostOs.Bookworm),
+        ('PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"', HostOs.Bullseye),
+        ('PRETTY_NAME="Ubuntu 22.04.3 LTS"', HostOs.Other),
+    ],
+)
+def test_get_host_os(os_release: str, expected_host_os: HostOs, monkeypatch: pytest.MonkeyPatch) -> None:
+    general.get_host_os.cache_clear()
+    monkeypatch.setattr(general, "load_file", lambda _: os_release)
+    assert general.get_host_os() == expected_host_os
+    general.get_host_os.cache_clear()
+
+
+def test_blueos_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    general.blueos_version.cache_clear()
+    monkeypatch.setenv("GIT_DESCRIBE_TAGS", "1.5.0-10-gabcdef12")
+    assert general.blueos_version() == "1.5.0-10-gabcdef12"
+    general.blueos_version.cache_clear()
+    monkeypatch.delenv("GIT_DESCRIBE_TAGS")
+    assert general.blueos_version() == "null"
+    general.blueos_version.cache_clear()
+
+
+def test_file_is_open(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("data", encoding="utf-8")
+    assert general.file_is_open(target) is False
+    with open(target, "r", encoding="utf-8"):
+        assert general.file_is_open(target) is True
+
+
+def test_file_is_open_when_lsof_fails_to_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def raise_oserror(*_args: object, **_kwargs: object) -> None:
+        raise OSError("lsof missing")
+
+    monkeypatch.setattr(subprocess, "run", raise_oserror)
+    assert general.file_is_open(tmp_path / "target.txt") is True
+
+
+def test_delete_everything(tmp_path: Path) -> None:
+    root = tmp_path / "data"
+    keep_dir = root / "keep"
+    doomed_dir = root / "doomed"
+    keep_dir.mkdir(parents=True)
+    doomed_dir.mkdir()
+    kept_file = keep_dir / "kept.txt"
+    kept_file.write_text("kept", encoding="utf-8")
+    kept_top_level = root / "kept-top-level.txt"
+    kept_top_level.write_text("kept", encoding="utf-8")
+    (root / "doomed-top-level.txt").write_text("doomed", encoding="utf-8")
+    (doomed_dir / "doomed-nested.txt").write_text("doomed", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_file = outside / "untouchable.txt"
+    outside_file.write_text("untouchable", encoding="utf-8")
+    (root / "link-to-outside").symlink_to(outside)
+
+    general.delete_everything(root, ignore=[keep_dir, kept_top_level])
+
+    assert kept_file.exists()
+    assert kept_top_level.exists()
+    assert not (root / "doomed-top-level.txt").exists()
+    assert not (doomed_dir / "doomed-nested.txt").exists()
+    # Symlinked directories are not followed
+    assert outside_file.exists()
+
+
+def test_delete_everything_single_file(tmp_path: Path) -> None:
+    target = tmp_path / "single.txt"
+    target.write_text("data", encoding="utf-8")
+
+    general.delete_everything(target, ignore=[target])
+    assert target.exists()
+
+    general.delete_everything(target)
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_everything_stream(tmp_path: Path) -> None:
+    root = tmp_path / "logs"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    small = root / "small.txt"
+    small.write_text("12345", encoding="utf-8")
+    nested_file = nested / "inner.txt"
+    nested_file.write_text("abc", encoding="utf-8")
+    rotated_log = root / "rotated.gz"
+    rotated_log.write_text("gz", encoding="utf-8")
+
+    infos = [info async for info in general.delete_everything_stream(root)]
+
+    assert {info["path"] for info in infos} == {str(small), str(nested_file), str(rotated_log)}
+    assert all(info["success"] for info in infos)
+    assert all(info["type"] == "file" for info in infos)
+    sizes = {info["path"]: info["size"] for info in infos}
+    assert sizes[str(small)] == 5
+    assert not small.exists()
+    assert not nested_file.exists()
+    assert not rotated_log.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_everything_stream_single_file(tmp_path: Path) -> None:
+    target = tmp_path / "single.txt"
+    target.write_text("data", encoding="utf-8")
+
+    infos = [info async for info in general.delete_everything_stream(target)]
+
+    assert infos == [{"path": str(target), "size": 4, "type": "file", "success": True}]
+    assert not target.exists()
+
+
+def test_local_unique_identifier_reads_existing(fs: FakeFilesystem) -> None:
+    general.local_unique_identifier.cache_clear()
+    existing = uuid.uuid4().hex
+    fs.create_file("/etc/blueos/uuid", contents=existing)
+    assert general.local_unique_identifier() == existing
+    general.local_unique_identifier.cache_clear()
+
+
+def test_local_unique_identifier_regenerates_invalid(fs: FakeFilesystem) -> None:
+    general.local_unique_identifier.cache_clear()
+    fs.create_file("/etc/blueos/uuid", contents="not-a-uuid")
+    result = general.local_unique_identifier()
+    assert uuid.UUID(result, version=4)
+    assert Path("/etc/blueos/uuid").read_text(encoding="utf-8") == result
+    general.local_unique_identifier.cache_clear()
+
+
+def test_local_unique_identifier_unwritable(fs: FakeFilesystem) -> None:
+    general.local_unique_identifier.cache_clear()
+    # /etc exists but /etc/blueos does not, so both reading and persisting fail
+    fs.create_dir("/etc")
+    assert general.local_unique_identifier() == "00000000000040000000000000000000"
+    general.local_unique_identifier.cache_clear()
+
+
+def test_local_hardware_identifier_reads_existing(fs: FakeFilesystem) -> None:
+    general.local_hardware_identifier.cache_clear()
+    hardware_uuid = str(uuid.uuid4())
+    fs.create_file("/etc/blueos/hardware-uuid", contents=hardware_uuid)
+    assert general.local_hardware_identifier() == hardware_uuid
+    general.local_hardware_identifier.cache_clear()
+
+
+def test_local_hardware_identifier_missing_or_invalid(fs: FakeFilesystem) -> None:
+    general.local_hardware_identifier.cache_clear()
+    fs.create_dir("/etc")
+    assert general.local_hardware_identifier() == "00000000000030000000000000000000"
+    general.local_hardware_identifier.cache_clear()
+    fs.create_file("/etc/blueos/hardware-uuid", contents="garbage")
+    assert general.local_hardware_identifier() == "00000000000030000000000000000000"
+    general.local_hardware_identifier.cache_clear()
+
+
+def test_device_id_from_serial_number(fs: FakeFilesystem) -> None:
+    fs.create_file("/sys/firmware/devicetree/base/serial-number", contents="10000000abcdef01")
+    assert general.device_id() == "10000000abcdef01"
+
+
+def test_device_id_falls_back_to_machine_id(fs: FakeFilesystem) -> None:
+    fs.create_file("/etc/machine-id", contents="abc123def456\n")
+    assert general.device_id() == "abc123def456"
+
+
+def test_device_id_raises_without_sources(fs: FakeFilesystem) -> None:
+    fs.create_dir("/etc")
+    with pytest.raises(ValueError, match="Could not get device id"):
+        general.device_id()
+
+
+def test_is_running_as_root_matches_euid() -> None:
+    assert general.is_running_as_root() == (os.geteuid() == 0)
+
+
+def test_available_disk_space_mb() -> None:
+    space = general.available_disk_space_mb()
+    assert isinstance(space, float)
+    assert space > 0

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -2,7 +2,6 @@
 import json
 import logging
 import os
-import shutil
 import subprocess
 import time
 from enum import Enum
@@ -168,11 +167,13 @@ async def do_eeprom_update(i_know_what_i_am_doing: bool = False) -> Any:
 async def reset_settings(i_know_what_i_am_doing: bool = False) -> Any:
     check_what_i_am_doing(i_know_what_i_am_doing)
     # Be sure to not delete bootstrap to avoid going back to factory image
-    bootstrap_config_path = "/root/.config/bootstrap/startup.json"
-    temporary_location = "/tmp/bootstrap_startup.json"
-    shutil.copy2(bootstrap_config_path, temporary_location)
-    delete_everything(Path(appdirs.user_config_dir()))
-    shutil.copy2(temporary_location, bootstrap_config_path)
+    ignore = [
+        Path("/root/.config/ardupilot-manager"),
+        Path("/root/.config/bag-of-holding"),
+        Path("/root/.config/bootstrap"),
+        Path("/root/.config/kraken"),
+    ]
+    delete_everything(Path(appdirs.user_config_dir()), ignore=ignore)
 
 
 @app.post("/services/remove_log", status_code=status.HTTP_200_OK)

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -167,7 +167,10 @@ async def do_eeprom_update(i_know_what_i_am_doing: bool = False) -> Any:
 async def reset_settings(i_know_what_i_am_doing: bool = False) -> Any:
     check_what_i_am_doing(i_know_what_i_am_doing)
     # Be sure to not delete bootstrap to avoid going back to factory image
+    # .ssh holds the keypair used to run host commands; wiping it forces the
+    # sshpass fallback, which fails whenever the default password was changed
     ignore = [
+        Path("/root/.config/.ssh"),
         Path("/root/.config/ardupilot-manager"),
         Path("/root/.config/bag-of-holding"),
         Path("/root/.config/bootstrap"),


### PR DESCRIPTION
Fixes #3440

Backport of #3677 plus the `.ssh` fix on top.

## Problem

`Reset Settings` deletes everything under `/root/.config`. On 1.4 it only rescues `bootstrap/startup.json` afterwards, so everything else goes, including:

- `/root/.config/.ssh` — the keypair commander uses to run commands on the host. Once it is gone, `run_command()` falls back to `sshpass` with the default password (`SSH_USER`/`SSH_PASSWORD`), so every commander-backed feature breaks on any vehicle where the default password was changed, and a reboot does not recover it.
- `ardupilot-manager`, `bag-of-holding` and `kraken` — which is why a reset followed by a reboot leaves a vehicle with installed extensions in a broken state (see the discussion in #3440).

Master already fixed the second half in #3677, which was never backported.

## Changes

- Cherry-pick 3bdec9b0e: `delete_everything(path, ignore=[...])`, so callers can protect paths that must survive a wipe. Conflict resolution keeps 1.4's `.gz` handling.
- Cherry-pick ee1f27f5b: commander ignores `ardupilot-manager`, `bag-of-holding`, `bootstrap` and `kraken` instead of copying `startup.json` through `/tmp`.
- Cherry-pick eb85a9373: coverage for `commonwealth.utils.general`, which is where the `ignore` behaviour is tested. 1.4 has no `test_general.py`, so the file is created at 1.4's path. Three tests are dropped because they target helpers that only exist on master (`_file_is_open_logic_lsof`, `_file_is_open_command`, `file_is_open_async`), and `test_delete_everything_stream` no longer holds the `.gz` file open, because on 1.4 the `.gz` special case lives in `delete_everything` rather than in `delete_everything_stream`. The `test_get_cpu_type` block is not included: it comes from 1a9bde28a, which also changes Compute Module detection and is unrelated to this PR.
- Add `/root/.config/.ssh` to the ignore list.

After this, 1.4's `reset_settings` is identical to master's apart from the `.ssh` entry, which is the same change proposed in #4122 — so the two branches converge instead of diverging.

Preserving is used instead of regenerating so the key is never absent, and the private key never has to be copied through `/tmp`. The public half in `/home/pi/.ssh/authorized_keys` was never removed by reset anyway, so deleting the private key only ever broke auth while leaving a stale entry behind.

Complements #3898, which adds the recovery path (`setup_ssh()` on startup) — this PR stops the key from being destroyed in the first place.

## Test plan

Verified on a Raspberry Pi running `1.4.4-beta.15`, by running this code in the container:

- [x] Before the fix: `POST /commander/v1.0/settings/reset` leaves `/root/.config/.ssh` empty, and the next host command logs `Failed to run command with SSH key ... trying with sshpass`
- [x] After the fix: the keypair survives with the same fingerprint, and host commands run with `ssh -i /root/.config/.ssh/id_rsa` (no fallback)
- [x] Marker files under `ardupilot-manager`, `bag-of-holding`, `bootstrap` and `kraken` all survive the reset, and `bootstrap/startup.json` is still present
- [x] Reset still resets: a marker file under `/root/.config/beacon` is deleted
- [x] `pytest core/libs/commonwealth/commonwealth/utils/tests/` passes (21 tests)
- [x] `./.hooks/pre-push` reports the exact same 44 pre-existing failures as a pristine `1.4-dev` checkout — no new ones