### PR TITLE
[master] core: services: commander: Keep .ssh keys on settings reset

### DIFF
--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -168,7 +168,10 @@ async def do_eeprom_update(i_know_what_i_am_doing: bool = False) -> Any:
 async def reset_settings(i_know_what_i_am_doing: bool = False) -> Any:
     check_what_i_am_doing(i_know_what_i_am_doing)
     # Be sure to not delete bootstrap to avoid going back to factory image
+    # .ssh holds the keypair used to run host commands; wiping it forces the
+    # sshpass fallback, which fails whenever the default password was changed
     ignore = [
+        Path("/root/.config/.ssh"),
         Path("/root/.config/ardupilot-manager"),
         Path("/root/.config/bag-of-holding"),
         Path("/root/.config/bootstrap"),


### PR DESCRIPTION
Fixes #3440 for master

Master counterpart of #4120. Master already has #3677, so the only missing piece here is the `.ssh` entry.

## Problem

`Reset Settings` deletes everything under `/root/.config`, including `/root/.config/.ssh` — the keypair commander uses to run commands on the host. Once it is gone, `run_command()` falls back to `sshpass` with the default password (`SSH_USER`/`SSH_PASSWORD`), so every commander-backed feature breaks on any vehicle where the default password was changed, and a reboot does not recover it.

The reset already protects `ardupilot-manager`, `bag-of-holding`, `bootstrap` and `kraken` for the same reason (#3677); `.ssh` was simply never added to that list.

## Changes

- Add `/root/.config/.ssh` to the `reset_settings` ignore list.

Preserving is used instead of regenerating so the key is never absent, and the private key never has to be copied through `/tmp`. The public half in `/home/pi/.ssh/authorized_keys` was never removed by reset anyway, so deleting the private key only ever broke auth while leaving a stale entry behind.

Complements #3898, which adds the recovery path (`setup_ssh()` on startup) — this PR stops the key from being destroyed in the first place.

## Test plan

The `ignore` mechanism is already covered by `test_delete_everything` and `test_delete_everything_single_file`, so this change adds no tests.

Behaviour was verified on a Raspberry Pi running `1.4.4-beta.15` via #4120, whose `reset_settings` is identical to this one after the backport:

- [x] Before the fix: `POST /commander/v1.0/settings/reset` leaves `/root/.config/.ssh` empty, and the next host command logs `Failed to run command with SSH key ... trying with sshpass`
- [x] After the fix: the keypair survives with the same fingerprint, and host commands run with `ssh -i /root/.config/.ssh/id_rsa` (no fallback)
- [x] Reset still resets: a marker file under `/root/.config/beacon` is deleted, while markers under the ignored directories survive
- [x] `./.hooks/pre-push` passes
