### PR TITLE
[1.4] Stream MAVLink log removal and stop asking lsof file by file

### DIFF
--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -127,7 +127,7 @@
             <v-btn
               v-tooltip="'Frees up space on the SD card deleting MAVLink logs'"
               class="ma-2"
-              :disabled="disable_remove_mavlink"
+              :disabled="disable_remove_mavlink || deletion_in_progress"
               @click="remove_mavlink_log_files"
             >
               <v-icon left>
@@ -378,24 +378,53 @@ export default Vue.extend({
       this.get_log_folder_size()
     },
     async remove_mavlink_log_files(): Promise<void> {
-      this.prepare_operation('Removing MAVLink log files...')
+      this.deletion_log_abort_controller = axios.CancelToken.source()
+      this.deletion_in_progress = true
+      this.current_deletion_path = '...'
+      this.current_deletion_size = 0
+      this.current_deletion_total_size = 0
+      this.current_deletion_status = 'Starting deletion...'
 
-      await back_axios({
-        url: `${commander.API_URL}/services/remove_mavlink_log`,
-        method: 'post',
-        params: {
-          i_know_what_i_am_doing: true,
-        },
-        timeout: 20000,
-      })
-        .then(() => {
-          this.get_mavlink_log_folder_size()
+      try {
+        await back_axios({
+          url: `${commander.API_URL}/services/remove_mavlink_log_stream`,
+          method: 'post',
+          params: {
+            i_know_what_i_am_doing: true,
+          },
+          responseType: 'text',
+          onDownloadProgress: (progressEvent) => {
+            let result = parseStreamingResponse(progressEvent.currentTarget.response)
+            result = result.filter((fragment) => fragment.fragment !== -1)
+            const last_fragment = result.last()
+            const total_deleted = result
+              .reduce((acc, fragment) => acc + (JSON.parse(fragment?.data ?? '{}')?.size ?? 0), 0)
+
+            if (last_fragment?.data) {
+              try {
+                const info = JSON.parse(last_fragment.data)
+                this.current_deletion_path = info.path.length > 30 ? `...${info.path.slice(-20)}` : info.path
+                this.current_deletion_size = info.size
+                this.current_deletion_total_size = total_deleted
+                this.current_deletion_status = info.success ? 'Deleting..' : 'Failed to delete file..'
+              } catch (e) {
+                console.error('Error parsing deletion info:', e)
+              }
+            }
+          },
+          cancelToken: this.deletion_log_abort_controller?.token,
         })
-        .catch((error) => {
-          this.operation_error = String(error)
-          notifier.pushBackError('REMOVE_MAVLINK_LOG_FAIL', error)
-        })
-      this.operation_in_progress = false
+      } catch (error) {
+        this.operation_error = String(error)
+        notifier.pushBackError('REMOVE_MAVLINK_LOG_FAIL', error)
+      } finally {
+        this.deletion_in_progress = false
+        this.current_deletion_path = ''
+        this.current_deletion_size = 0
+        this.current_deletion_status = ''
+      }
+
+      this.get_mavlink_log_folder_size()
     },
     async enable_wizard(): Promise<void> {
       const payload = { version: 0 }

--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -56,7 +56,7 @@ def get_host_os() -> HostOs:
     return HostOs.Other
 
 
-def delete_everything(path: Path, ignore: list[Path] | None = None) -> None:
+def delete_everything(path: Path, ignore: list[Path] | None = None, open_files: set[Path] | None = None) -> None:
     if ignore is None:
         ignore = []
 
@@ -83,17 +83,32 @@ def delete_everything(path: Path, ignore: list[Path] | None = None) -> None:
         path.unlink()
         return
 
+    if open_files is None and path.is_dir():
+        open_files = open_files_under(path)
+
     for item in path.glob("*"):
         if is_ignored(item):
             continue
         try:
-            if item.is_file() and not file_is_open(item):
+            if item.is_file() and not _file_is_open_in(item, open_files):
                 item.unlink()
             if item.is_dir() and not item.is_symlink():
                 # Delete folder contents
-                delete_everything(item, ignore=ignore)
+                delete_everything(item, ignore=ignore, open_files=open_files)
         except Exception as exception:
             logger.warning(f"Failed to delete: {item}, {exception}")
+
+
+def _file_is_open_in(path: Path, open_files: set[Path] | None) -> bool:
+    if open_files is None:
+        return file_is_open(path)
+    return path.resolve() in open_files
+
+
+async def _file_is_open_in_async(path: Path, open_files: set[Path] | None) -> bool:
+    if open_files is None:
+        return await asyncio.to_thread(file_is_open, path)
+    return path.resolve() in open_files
 
 
 @dataclass
@@ -107,11 +122,15 @@ class DeletionInfo:
         return asdict(self)
 
 
-async def delete_everything_stream(path: Path) -> AsyncGenerator[dict[str, Any], None]:
+async def delete_everything_stream(
+    path: Path, open_files: set[Path] | None = None
+) -> AsyncGenerator[dict[str, Any], None]:
     """Delete everything in a path and yield information about each file being deleted.
 
     Args:
         path: Path to delete
+        open_files: Files to keep, from a single lsof pass over the folder. Computed on the first call and
+            reused while recursing. None means lsof failed and each file has to be checked on its own.
 
     Yields:
         Dictionary containing information about each file being deleted:
@@ -147,11 +166,14 @@ async def delete_everything_stream(path: Path) -> AsyncGenerator[dict[str, Any],
             # fmt: on
         return
 
+    if open_files is None and path.is_dir():
+        open_files = await asyncio.to_thread(open_files_under, path)
+
     items = await asyncio.to_thread(lambda: list(path.glob("*")))
 
     for item in items:
         try:
-            if item.is_file() and not file_is_open(item):
+            if item.is_file() and not await _file_is_open_in_async(item, open_files):
                 size = item.stat().st_size
                 await asyncio.to_thread(item.unlink)
                 # fmt: off
@@ -164,7 +186,7 @@ async def delete_everything_stream(path: Path) -> AsyncGenerator[dict[str, Any],
                 # fmt: on
             if item.is_dir() and not item.is_symlink():
                 # Delete folder contents
-                async for info in delete_everything_stream(item):
+                async for info in delete_everything_stream(item, open_files):
                     yield info
         except Exception as exception:
             logger.warning(f"Failed to delete: {item}, {exception}")
@@ -176,6 +198,38 @@ async def delete_everything_stream(path: Path) -> AsyncGenerator[dict[str, Any],
                 success=False
             ).to_dict()
             # fmt: on
+
+
+def open_files_under(path: Path) -> set[Path] | None:
+    """List every open file under a folder, resolved, using a single lsof call.
+
+    Each lsof call rescans every process in the system, so asking file by file costs a process spawn per file
+    and dominates deletion time: on a Raspberry Pi 4, 300 log files take 42s one by one against 0.2s here.
+    Returns None when lsof fails, so callers can fall back to checking each file.
+    """
+    try:
+        kernel_functions_timeout = str(2)
+        result = subprocess.run(
+            # -w drops warnings about file systems lsof cannot stat, -F n asks for file names only
+            # and +D searches the whole folder tree with a single call
+            ["lsof", "-w", "-n", "-P", "-S", kernel_functions_timeout, "-F", "n", "+D", path.resolve()],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except Exception as error:
+        logger.error(f"Failed to list open files under {path}, {error}")
+        return None
+
+    # Searching a folder exits with 1 both when nothing is open and when files were found, so the only
+    # reliable failure signal is output on stderr
+    if result.stderr.strip() or result.returncode not in (0, 1):
+        logger.error(f"lsof error listing open files under {path}, {result.stderr.strip()}")
+        return None
+
+    return {Path(line[1:]) for line in result.stdout.splitlines() if line.startswith("n")}
 
 
 def file_is_open(path: Path) -> bool:

--- a/core/libs/commonwealth/commonwealth/utils/tests/test_general.py
+++ b/core/libs/commonwealth/commonwealth/utils/tests/test_general.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import uuid
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -51,6 +52,36 @@ def test_file_is_open_when_lsof_fails_to_run(monkeypatch: pytest.MonkeyPatch, tm
     assert general.file_is_open(tmp_path / "target.txt") is True
 
 
+def test_open_files_under_reports_open_file(tmp_path: Path) -> None:
+    held = tmp_path / "in-use.txt"
+    held.write_text("in use", encoding="utf-8")
+    closed = tmp_path / "closed.txt"
+    closed.write_text("closed", encoding="utf-8")
+
+    with open(held, "r", encoding="utf-8"):
+        open_files = general.open_files_under(tmp_path)
+
+    assert open_files is not None
+    assert held.resolve() in open_files
+    assert closed.resolve() not in open_files
+
+
+def test_open_files_under_when_lsof_fails_to_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def raise_oserror(*_args: object, **_kwargs: object) -> None:
+        raise OSError("lsof missing")
+
+    monkeypatch.setattr(subprocess, "run", raise_oserror)
+    assert general.open_files_under(tmp_path) is None
+
+
+def test_open_files_under_when_lsof_reports_an_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def failing_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="lsof: status error")
+
+    monkeypatch.setattr(subprocess, "run", failing_run)
+    assert general.open_files_under(tmp_path) is None
+
+
 def test_delete_everything(tmp_path: Path) -> None:
     root = tmp_path / "data"
     keep_dir = root / "keep"
@@ -90,6 +121,76 @@ def test_delete_everything_single_file(tmp_path: Path) -> None:
     assert not target.exists()
 
 
+def test_delete_everything_keeps_open_files_with_one_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "data"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    for index in range(10):
+        (root / f"file-{index}.txt").write_text("data", encoding="utf-8")
+        (nested / f"file-{index}.txt").write_text("data", encoding="utf-8")
+    held = root / "in-use.txt"
+    held.write_text("in use", encoding="utf-8")
+
+    spawns = 0
+    original = subprocess.run
+
+    def counting_run(*args: Any, **kwargs: Any) -> Any:
+        nonlocal spawns
+        spawns += 1
+        return original(*args, **kwargs)  # pylint: disable=subprocess-run-check
+
+    monkeypatch.setattr(subprocess, "run", counting_run)
+
+    with open(held, "r", encoding="utf-8"):
+        general.delete_everything(root)
+
+    assert held.exists()
+    assert not (root / "file-0.txt").exists()
+    assert not (nested / "file-0.txt").exists()
+    # A single lsof pass covers the whole tree, spawning one process per file is what makes deletion time out
+    assert spawns == 1
+
+
+def test_delete_everything_on_open_file_keeps_it_quietly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "service.log"
+    target.write_text("data", encoding="utf-8")
+
+    spawns = 0
+    original = subprocess.run
+
+    def counting_run(*args: Any, **kwargs: Any) -> Any:
+        nonlocal spawns
+        spawns += 1
+        return original(*args, **kwargs)  # pylint: disable=subprocess-run-check
+
+    monkeypatch.setattr(subprocess, "run", counting_run)
+
+    with open(target, "r", encoding="utf-8"):
+        general.delete_everything(target)
+
+    assert target.exists()
+    # lsof cannot search a single file, and log_zipper deletes file by file: only the open check may run
+    assert spawns == 1
+
+
+def test_delete_everything_through_symlinked_folder(tmp_path: Path) -> None:
+    # /shortcuts/ardupilot_logs/logs is a symlink to the folder ArduPilot writes to
+    real = tmp_path / "ardupilot-manager" / "logs"
+    real.mkdir(parents=True)
+    held = real / "00000042.BIN"
+    held.write_text("being written", encoding="utf-8")
+    doomed = real / "00000041.BIN"
+    doomed.write_text("old", encoding="utf-8")
+    shortcut = tmp_path / "ardupilot_logs"
+    shortcut.symlink_to(real)
+
+    with open(held, "r", encoding="utf-8"):
+        general.delete_everything(shortcut)
+
+    assert held.exists()
+    assert not doomed.exists()
+
+
 @pytest.mark.asyncio
 async def test_delete_everything_stream(tmp_path: Path) -> None:
     root = tmp_path / "logs"
@@ -123,6 +224,72 @@ async def test_delete_everything_stream_single_file(tmp_path: Path) -> None:
 
     assert infos == [{"path": str(target), "size": 4, "type": "file", "success": True}]
     assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_everything_stream_keeps_open_files(tmp_path: Path) -> None:
+    root = tmp_path / "logs"
+    root.mkdir()
+    held = root / "in-use.txt"
+    held.write_text("in use", encoding="utf-8")
+    doomed = root / "doomed.txt"
+    doomed.write_text("doomed", encoding="utf-8")
+
+    with open(held, "r", encoding="utf-8"):
+        infos = [info async for info in general.delete_everything_stream(root)]
+
+    assert {info["path"] for info in infos} == {str(doomed)}
+    assert held.exists()
+    assert not doomed.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_everything_stream_checks_open_files_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "logs"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    for index in range(10):
+        (root / f"file-{index}.txt").write_text("data", encoding="utf-8")
+        (nested / f"file-{index}.txt").write_text("data", encoding="utf-8")
+
+    spawns = 0
+    original = subprocess.run
+
+    def counting_run(*args: Any, **kwargs: Any) -> Any:
+        nonlocal spawns
+        spawns += 1
+        return original(*args, **kwargs)  # pylint: disable=subprocess-run-check
+
+    monkeypatch.setattr(subprocess, "run", counting_run)
+    infos = [info async for info in general.delete_everything_stream(root)]
+
+    assert len(infos) == 20
+    # A single lsof pass covers the whole tree, spawning one process per file is what makes deletion time out
+    assert spawns == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_everything_stream_falls_back_when_lsof_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "logs"
+    root.mkdir()
+    held = root / "in-use.txt"
+    held.write_text("in use", encoding="utf-8")
+    doomed = root / "doomed.txt"
+    doomed.write_text("doomed", encoding="utf-8")
+
+    def failed_snapshot(_path: Path) -> None:
+        return None
+
+    monkeypatch.setattr(general, "open_files_under", failed_snapshot)
+
+    with open(held, "r", encoding="utf-8"):
+        infos = [info async for info in general.delete_everything_stream(root)]
+
+    assert {info["path"] for info in infos} == {str(doomed)}
+    assert held.exists()
+    assert not doomed.exists()
 
 
 def test_local_unique_identifier_reads_existing(fs: FakeFilesystem) -> None:

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -55,6 +55,27 @@ def check_what_i_am_doing(i_know_what_i_am_doing: bool = False) -> None:
         )
 
 
+def deletion_stream_response(path: Path) -> StreamingResponse:
+    async def generate() -> AsyncGenerator[str, None]:
+        try:
+            async for info in delete_everything_stream(path):
+                yield json.dumps(info)
+        except Exception as error:
+            logger.error(f"Error during deletion stream of {path}: {error}")
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+
+    return StreamingResponse(
+        streamer(generate(), heartbeats=1.0),
+        media_type="application/x-ndjson",
+        headers={
+            "Content-Type": "application/x-ndjson",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable buffering for nginx
+        },
+    )
+
+
 @app.post("/command/host", status_code=status.HTTP_200_OK)
 @version(1, 0)
 async def command_host(command: str, i_know_what_i_am_doing: bool = False) -> Any:
@@ -191,25 +212,7 @@ async def remove_log_services(i_know_what_i_am_doing: bool = False) -> Any:
 async def remove_log_services_stream(i_know_what_i_am_doing: bool = False) -> StreamingResponse:
     """Stream the deletion of log files, providing real-time updates about each file being deleted."""
     check_what_i_am_doing(i_know_what_i_am_doing)
-
-    async def generate() -> AsyncGenerator[str, None]:
-        try:
-            async for info in delete_everything_stream(Path(LOG_FOLDER_PATH)):
-                yield json.dumps(info)
-        except Exception as error:
-            logger.error(f"Error during log deletion stream: {error}")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
-
-    return StreamingResponse(
-        streamer(generate(), heartbeats=1.0),
-        media_type="application/x-ndjson",
-        headers={
-            "Content-Type": "application/x-ndjson",
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",  # Disable buffering for nginx
-        },
-    )
+    return deletion_stream_response(Path(LOG_FOLDER_PATH))
 
 
 @app.post("/services/remove_mavlink_log", status_code=status.HTTP_200_OK)

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -222,6 +222,14 @@ async def remove_mavlink_log_services(i_know_what_i_am_doing: bool = False) -> A
     delete_everything(Path(MAVLINK_LOG_FOLDER_PATH))
 
 
+@app.post("/services/remove_mavlink_log_stream", status_code=status.HTTP_200_OK)
+@version(1, 0)
+async def remove_mavlink_log_services_stream(i_know_what_i_am_doing: bool = False) -> StreamingResponse:
+    """Stream the deletion of MAVLink log files, providing real-time updates about each file being deleted."""
+    check_what_i_am_doing(i_know_what_i_am_doing)
+    return deletion_stream_response(Path(MAVLINK_LOG_FOLDER_PATH))
+
+
 @app.get("/services/check_log_folder_size", status_code=status.HTTP_200_OK)
 @version(1, 0)
 async def check_log_folder_size() -> Any:


### PR DESCRIPTION
Fixes #4105 for 1.4

## After:

https://github.com/user-attachments/assets/6cb1bea2-b459-4007-bc64-6e487fef39f9

## Problem

Clearing ~1GB of MAVLink logs failed with `Error: timeout of 20000ms exceeded` and no progress feedback, while the deletion kept running on the vehicle. System logs already stream their deletion (#3250, backported in #3806), but the MAVLink path was never migrated.

Digging into why deletion is slow at all turned up a second, larger problem. Every file is passed to its own `lsof` call to check whether something still has it open, and each `lsof` invocation rescans every process in the system. Deletion therefore costs one process spawn per file and scales with file count, not with bytes removed.

Measured on a Raspberry Pi 4 with 300 files (900 MiB), one file deliberately held open:

| strategy | time | detected the open file |
| --- | --- | --- |
| `lsof` per file (before) | 41.8 s | yes |
| one `lsof` call with all paths | 0.33 s | yes |
| one `lsof -w +D` on the folder | 0.19 s | yes |
| the actual `unlink()` calls | 0.006 s | — |

At 3000 files the single `+D` call still takes 0.245 s, where per-file would take about seven minutes. This is also why `/var/logs/blueos` (123 files) sat right at the 20 s limit in #3179.

## Changes

- `commonwealth.utils.general`: take one `lsof -w -n -P -S 2 -F n +D <folder>` snapshot of open files per deletion and reuse it while recursing, in both `delete_everything` and `delete_everything_stream`. When `lsof` fails the snapshot is `None` and each file falls back to the previous individual check, so the "when in doubt, keep the file" behaviour is unchanged.
- `commander`: add `/services/remove_mavlink_log_stream`, mirroring `remove_log_stream`. The old endpoint stays for API compatibility.
- `SettingsMenu`: consume the stream with no timeout and show the existing progress UI, which now sits next to the MAVLink logs rather than under the service logs.

Two details worth flagging for review: searching a folder makes `lsof` exit with `1` whether or not it found open files, so the result is parsed from stdout and failure is detected from stderr; and `-w` silences warnings about file systems `lsof` cannot stat, which are emitted on any Docker host and would otherwise look like failures.

## Testing

New tests in `commonwealth/utils/tests/test_general.py` cover open files surviving deletion, exactly one process being spawned for a 20-file tree (sync and streaming), the fallback path when `lsof` is unavailable, and `open_files_under` itself.

On hardware (Raspberry Pi 4, 1.4 image), 973 MB across 302 MAVLink log files:

- before: 40.4 s on the blocking endpoint, past the 20 s frontend timeout
- streaming alone: 41.4 s total, first byte in 5 ms, 338 progress updates, no timeout
- streaming with the single `lsof` pass: **0.74 s**, 300 progress updates

Commander stayed responsive throughout: latency for concurrent requests during deletion went from 201 ms median (495 ms worst) to 15 ms. A file held open by another process, standing in for the log ArduPilot is actively writing, was preserved and never reported as deleted. The UI was exercised end to end against a vehicle: progress renders under MAVLink Logs, the folder size drops, and no error is raised.

## Notes

Targets `1.4-dev`. The equivalent change for `master` is ready and will follow as a separate PR.
