### PR TITLE
[1.4] core: services: ardupilot_manager: Prevent i2c file descriptor leak (backport #3878)

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/linux/linux_boards.py
@@ -24,8 +24,8 @@ class LinuxFlightController(FlightController):
 
     def check_for_i2c_device(self, bus_number: int, address: int) -> bool:
         try:
-            bus = SMBus(bus_number)
-            bus.read_byte_data(address, 0)
+            with SMBus(bus_number) as bus:
+                bus.read_byte_data(address, 0)
             return True
         except OSError:
             return False


### PR DESCRIPTION
While working on #4121, I found the same problem already fixed on master.

Backport of #3878 (`e6c97dc4a`) to `1.4-dev`.

`check_for_i2c_device` opens an `SMBus` and never closes it. Every failed probe leaks one `/dev/i2c-*` file descriptor, so on a vehicle whose Navigator is missing or unresponsive, `ardupilot-manager` walks the whole detector list on every `available_boards` call and steadily burns through the 1024 FD soft limit.

### Reproduced on hardware

Raspberry Pi 4 with the Navigator removed, running current `1.4-dev`:

- Board detection correctly finds no Navigator, `available_boards` returns SITL only.
- Within ~4 minutes the ardupilot-manager process holds 1024/1024 FDs, 1015 of them `/dev/i2c-1`.
- Its HTTP server then dies with `OSError: [Errno 24] Too many open files` on `socket.accept()`; `GET /v1.0/board` and `/v1.0/available_boards` stop responding entirely.
- Every rejected connection dumps a loguru backtrace, growing the ardupilot-manager log directory by roughly 20 MB/min (189 MB in 15 minutes, rotating 10 MB files every ~30 s).

A Raspberry Pi 5 with its Navigator attached, same image, stays flat at 15 FDs total (5 i2c) and under 1 MB of logs, which matches the leak being on the `OSError` path.

### Change

Use the context manager so the bus is closed on both the success and failure paths:

```python
with SMBus(bus_number) as bus:
    bus.read_byte_data(address, 0)
```

### Test plan

- [x] Reproduced FD exhaustion and API death on a Pi 4 without the Navigator on unpatched `1.4-dev`
- [x] With the patch applied on the same board (still no Navigator), 200 `available_boards` requests driving ~1770 detection sweeps left the FD count flat at 8 with zero open `/dev/i2c-*` handles, no `Errno 24`, API still answering 200, and the log file at 1.2 MB after several minutes