### PR TITLE
[backport/1.4] core: Use ISO 8601 UTC timestamps for logs

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/commonwealth/utils/logs.py
@@ -8,8 +8,12 @@ from typing import Any, Optional, TextIO, Union
 
 from loguru import logger
 
-# ISO 8601 UTC (e.g. 2026-08-11T19:15:00.123Z)
-ISO8601_LOG_FORMAT = "{time:YYYY-MM-DDTHH:mm:ss.SSS!UTC}Z | {level:<8} | {name}:{function}:{line} - {message}"
+# ISO 8601 UTC (e.g. 2026-08-11T19:15:00.123Z), with loguru's default colors.
+# Tags are stripped automatically when the sink is not a terminal.
+ISO8601_LOG_FORMAT = (
+    "<green>{time:YYYY-MM-DDTHH:mm:ss.SSS!UTC}Z</green> | <level>{level:<8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
+)
 
 
 class LogRotator:

--- a/core/libs/commonwealth/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/commonwealth/utils/logs.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from datetime import datetime, timezone
 from logging import LogRecord
 from pathlib import Path
@@ -6,6 +7,9 @@ from types import FrameType
 from typing import Any, Optional, TextIO, Union
 
 from loguru import logger
+
+# ISO 8601 UTC (e.g. 2026-08-11T19:15:00.123Z)
+ISO8601_LOG_FORMAT = "{time:YYYY-MM-DDTHH:mm:ss.SSS!UTC}Z | {level:<8} | {name}:{function}:{line} - {message}"
 
 
 class LogRotator:
@@ -61,7 +65,9 @@ def get_new_log_path(service_name: str) -> Path:
 
 def init_logger(service_name: str) -> None:
     try:
-        logger.add(get_new_log_path(service_name), rotation="10 MB")
+        logger.remove()
+        logger.add(sys.stderr, format=ISO8601_LOG_FORMAT)
+        logger.add(get_new_log_path(service_name), rotation="10 MB", format=ISO8601_LOG_FORMAT)
     except Exception as e:
         print(f"Error: unable to set logging path: {e}")
 

--- a/core/libs/commonwealth/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/commonwealth/utils/logs.py
@@ -59,7 +59,8 @@ def get_new_log_path(service_name: str) -> Path:
     service_log_folder.mkdir(parents=True, exist_ok=True)
 
     # Returned log path are service-specific and store datetime information
-    datetime_now = datetime.now().strftime("%Y%m%d_%H%M%S")
+    # ISO 8601 basic format, since the extended one is not filename friendly
+    datetime_now = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     return service_log_folder.joinpath(f"logfile_{datetime_now}.log")
 
 

--- a/core/run-service.sh
+++ b/core/run-service.sh
@@ -65,7 +65,7 @@ start_service() {
 while true; do
   echo "Starting service: $service_command with memory limit: $memory_limit_bytes bytes "
   if ! start_service; then
-    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     echo "$timestamp: Service ($service_command) exceeded memory limit or stopped. Restarting..." | tee -a "$LOG_FILE"
   else
     echo "Service ($service_command) completed successfully."

--- a/core/services/log_zipper/main.py
+++ b/core/services/log_zipper/main.py
@@ -88,7 +88,7 @@ def main() -> None:
             if not local_files:
                 continue
             folder_name = os.path.basename(folder)
-            timestamp = time.strftime("%Y%m%d-%H%M%S")
+            timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
             zipped_file = f"{folder}/{folder_name}-{timestamp}.{zip_extension}"
             zip_files(local_files, zipped_file)
             logger.info(f"Created zip archive {zipped_file} with {len(local_files)} files.")


### PR DESCRIPTION
Backport of #4124 (c1e2190) into 1.4 + log filename fix for consistency.

- [x] tested.