### PR TITLE
[1.4] Backport helper service detection retries

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -132,7 +132,7 @@ class ServiceInfo(BaseModel):
     def max_attempts_reached(self) -> bool:
         if self.port not in Helper.attempts_left:
             return False
-        return Helper.attempts_left[self.port] <= 0
+        return bool(Helper.attempts_left[self.port] <= 0)
 
 
 class SpeedtestServer(BaseModel):

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -229,7 +229,7 @@ class Helper:
     PERIODICALLY_RESCAN_3RDPARTY_SERVICES = True
 
     MAX_ATTEMPTS_LEFT = 3
-    attempts_left = {}
+    attempts_left: Dict[int, int] = {}
 
     @staticmethod
     # pylint: disable=too-many-arguments,too-many-branches,too-many-locals

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -129,6 +129,11 @@ class ServiceInfo(BaseModel):
             return self.port == other.port
         return False
 
+    def max_attempts_reached(self) -> bool:
+        if self.port not in Helper.attempts_left:
+            return False
+        return Helper.attempts_left[self.port] <= 0
+
 
 class SpeedtestServer(BaseModel):
     url: str
@@ -222,6 +227,9 @@ class Helper:
     PERIODICALLY_RESCAN_ALL_SERVICES = False
     # Wether or not we should rescan periodically just the 3rdparty services (extensions)
     PERIODICALLY_RESCAN_3RDPARTY_SERVICES = True
+
+    MAX_ATTEMPTS_LEFT = 3
+    attempts_left = {}
 
     @staticmethod
     # pylint: disable=too-many-arguments,too-many-branches,too-many-locals
@@ -320,6 +328,13 @@ class Helper:
             "127.0.0.1", port=port, path="/", timeout=1.0, method="GET", follow_redirects=10
         )
         log_msg = f"Detecting service at port {port}"
+        if response.timeout:
+            service_attempts = Helper.attempts_left.get(port, Helper.MAX_ATTEMPTS_LEFT)
+            Helper.attempts_left[port] = service_attempts - 1
+
+            logger.debug(f"Timed out, attempting to detect service on port: {port}. Attempts left: {service_attempts}")
+
+            return info
         if response.status == http.client.BAD_REQUEST or response.decoded_data is None:
             # If not valid web server, documentation will not be available
             logger.debug(f"{log_msg}: Invalid: {response.status} - {response.decoded_data!r}")
@@ -425,8 +440,10 @@ class Helper:
             Helper.KNOWN_SERVICES = {service for service in Helper.KNOWN_SERVICES if service.port in ports}
 
         # Filter out ports we want to skip, as well as the ports from services we already know, assuming the services don't change,
-        known_ports = {service.port for service in Helper.KNOWN_SERVICES}
-        ports.difference_update(Helper.SKIP_PORTS, known_ports)
+        ignored_ports = {
+            service.port for service in Helper.KNOWN_SERVICES if service.valid or service.max_attempts_reached()
+        }
+        ports.difference_update(Helper.SKIP_PORTS, ignored_ports)
 
         # The detect_services run several of requests sequentially, so we are capping the amount of executors to lower the peaks on the CPU usage
         if get_cpu_type() == CpuType.PI3 or len(ports) == 0:
@@ -438,6 +455,8 @@ class Helper:
             tasks = [executor.submit(Helper.detect_service, port) for port in ports]
             services = {task.result() for task in futures.as_completed(tasks)}
 
+        # Remove the detected services from the known services set so we can add the updated entries
+        Helper.KNOWN_SERVICES = Helper.KNOWN_SERVICES.difference(services)
         # Update our known services cache
         Helper.KNOWN_SERVICES.update(services)
         Helper.update_nginx(services)


### PR DESCRIPTION
## Summary
- Backport of https://github.com/bluerobotics/BlueOS/pull/3454 (`helper: allow 3 attempts when detecting services`) onto `1.4-dev`
- Includes the follow-up typing fixes from master (`max_attempts_reached` bool cast + `attempts_left: Dict[int, int]`)
- Fixes https://github.com/bluerobotics/BlueOS/issues/4132: Available Services could permanently omit healthy BlueOS system services after a failed first probe at boot

## Test plan
- [x] Boot BlueOS 1.4 and force early helper scans before Cable Guy / Commander / Kraken / Beacon / Ping are ready
- [x] Confirm a failed first detect (`Invalid: None - None`) no longer permanently hides the service
- [x] Confirm the service appears in `/helper/latest/web_services` once healthy (without restarting helper)
- [ ] Confirm timeout-heavy non-HTTP listeners still stop being retried after 3 timeout attempts