### PR TITLE
core: frontend: mavlink: Skip SET_MESSAGE_INTERVAL when rate is 0

### DIFF
--- a/core/frontend/src/libs/MAVLink2Rest/index.ts
+++ b/core/frontend/src/libs/MAVLink2Rest/index.ts
@@ -203,6 +203,11 @@ class Mavlink2RestManager {
       console.warn(`Requested invalid message rate for ${message}: ${rate}`)
       return
     }
+    // ~0 Hz means listen only (e.g. HEARTBEAT). Do not POST SET_MESSAGE_INTERVAL:
+    // 1000000 / 0 is Infinity, JSON-serialized as null, and mavlink2rest returns 404.
+    if (rate < 0.01) {
+      return
+    }
     if (!Object.keys(messageId).includes(message)) {
       console.warn(
         `Requesting for an unmapped message (${message})! Please add it to mavlink2rest/MessageID.ts`,


### PR DESCRIPTION
## Summary
- `MavlinkUpdater` registers `HEARTBEAT` with `refreshRate: 0` (listen-only).
- `requestMessageRate` still POSTed `MAV_CMD_SET_MESSAGE_INTERVAL` with `param2 = 1000000 / 0` → `Infinity` → JSON `null`.
- mavlink2rest rejects that as an invalid MAVLink message and returns **404** on every page load (`unable to send message...`).
- Skip the POST when `rate === 0`; websocket listening is unchanged.

## Test plan
- [ ] Load BlueOS UI; Network tab should show **no** failing `POST /mavlink2rest/mavlink` with `param2: null` for HEARTBEAT.
- [ ] Confirm HEARTBEAT / vehicle connected state still updates in the tray.
- [ ] Open a page that requests a non-zero rate (e.g. Vehicle Setup PWM / compass) and confirm `SET_MESSAGE_INTERVAL` POSTs still return 200.
