### PR TITLE
vehicle-setup: allow testing all configured ArduSub motors

### DIFF
--- a/core/frontend/src/components/vehiclesetup/PwmSetup.vue
+++ b/core/frontend/src/components/vehiclesetup/PwmSetup.vue
@@ -260,11 +260,15 @@ export default Vue.extend({
       return autopilot.firmware_vehicle_type === FirmwareVehicleType.ArduSub
     },
     available_sub_motors(): MotorTestTarget[] {
-      return this.servo_function_parameters.filter(
-        (parameter) => parameter.value >= SERVO_FUNCTION.MOTOR1 && parameter.value <= SERVO_FUNCTION.MOTOR8,
-      ).map((parameter) => {
+      return this.servo_function_parameters.map((parameter) => {
+        const function_name = SERVO_FUNCTION[parameter.value]
+        const motor_function_match = /^MOTOR(\d+)$/.exec(function_name)
+        if (!motor_function_match) {
+          return undefined
+        }
+
         const servo_number = parseInt(/\d+/g.exec(parameter.name)?.[0] ?? '0', 10)
-        const motor_number = parseInt(/\d+/g.exec(printParam(parameter))?.[0] ?? '0', 10)
+        const motor_number = parseInt(motor_function_match[1], 10)
         const name = this.effective_param_value_map.Submarine?.[parameter.name] ?? `Motor ${motor_number}`
         const direction_parameter = autopilot_data.parameterRegex(`MOT_${motor_number}_DIRECTION`)?.[0]
         const target = motor_number - 1
@@ -273,10 +277,11 @@ export default Vue.extend({
           servo: servo_number,
           motor: motor_number,
           target,
-          direction: direction_parameter.value,
+          direction: direction_parameter?.value ?? 1.0,
           reverse_parameter: direction_parameter,
         }
-      }).sort((a, b) => a.motor - b.motor)
+      }).filter((motor): motor is MotorTestTarget => motor !== undefined)
+        .sort((a, b) => a.motor - b.motor)
     },
     available_motors(): MotorTestTarget[] {
       if (this.is_rover) {


### PR DESCRIPTION
## What changed

- detect configured ArduSub motor functions by their `MOTOR<n>` enum name instead of the numeric `MOTOR1..MOTOR8` range
- include the non-contiguous `MOTOR9..MOTOR12` functions
- default the displayed direction to forward if a firmware does not expose the corresponding direction parameter

## Why

ArduPilot assigns `MOTOR9..MOTOR12` to values 82–85, outside the contiguous 33–40 range used by `MOTOR1..MOTOR8`. The existing numeric range check therefore hides configured motors 9–12 from the PWM motor-test UI.

Matching the enum member name also avoids accidentally treating `MOTORTILT` as a numbered motor and naturally supports future numbered motor functions added to the enum.

Closes #4010.

## Validation

- `bun --cwd core/frontend lint`
- `bun --cwd core/frontend build`
- `git diff --check`

The repository-wide pre-push hook could not run in this environment because Docker is not installed; the frontend-specific checks above passed.
