### PR TITLE
frontend: show custom extension actions on every tab

### DIFF
--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -323,62 +323,62 @@
           <spinning-logo size="20%" subtitle="Fetching installed extensions" />
         </template>
       </template>
-      <v-fab-transition>
-        <v-speed-dial
-          :key="'create_button'"
-          v-model="fab_menu"
-          fixed
-          bottom
-          right
-          direction="top"
-          transition="slide-y-reverse-transition"
-        >
-          <template #activator>
-            <v-btn
-              v-model="fab_menu"
-              color="primary"
-              fab
-              large
-              dark
-            >
-              <v-icon v-if="fab_menu">
-                mdi-close
-              </v-icon>
-              <v-icon v-else>
-                mdi-plus
-              </v-icon>
-            </v-btn>
-          </template>
-          <v-btn
-            v-tooltip="'Install from file'"
-            fab
-            dark
-            small
-            color="primary"
-            @click="openInstallFromFileDialog"
-          >
-            <v-icon>mdi-file-upload-outline</v-icon>
-          </v-btn>
-          <v-btn
-            v-tooltip="'Create from scratch'"
-            fab
-            dark
-            small
-            color="green"
-            @click="openCreationDialog"
-          >
-            <v-icon>mdi-code-braces</v-icon>
-          </v-btn>
-        </v-speed-dial>
-      </v-fab-transition>
-      <ExtensionCreationModal
-        v-if="edited_extension"
-        :extension="edited_extension"
-        :temp-tag="upload_temp_tag"
-        @extensionChange="createOrUpdateExtension"
-        @closed="clearEditedExtension"
-      />
     </v-card>
+    <v-fab-transition>
+      <v-speed-dial
+        :key="'create_button'"
+        v-model="fab_menu"
+        fixed
+        bottom
+        right
+        direction="top"
+        transition="slide-y-reverse-transition"
+      >
+        <template #activator>
+          <v-btn
+            v-model="fab_menu"
+            color="primary"
+            fab
+            large
+            dark
+          >
+            <v-icon v-if="fab_menu">
+              mdi-close
+            </v-icon>
+            <v-icon v-else>
+              mdi-plus
+            </v-icon>
+          </v-btn>
+        </template>
+        <v-btn
+          v-tooltip="'Install from file'"
+          fab
+          dark
+          small
+          color="primary"
+          @click="openInstallFromFileDialog"
+        >
+          <v-icon>mdi-file-upload-outline</v-icon>
+        </v-btn>
+        <v-btn
+          v-tooltip="'Create from scratch'"
+          fab
+          dark
+          small
+          color="green"
+          @click="openCreationDialog"
+        >
+          <v-icon>mdi-code-braces</v-icon>
+        </v-btn>
+      </v-speed-dial>
+    </v-fab-transition>
+    <ExtensionCreationModal
+      v-if="edited_extension"
+      :extension="edited_extension"
+      :temp-tag="upload_temp_tag"
+      @extensionChange="createOrUpdateExtension"
+      @closed="clearEditedExtension"
+    />
   </v-container>
 </template>
 


### PR DESCRIPTION
## What changed

Moved the custom-extension action menu and `ExtensionCreationModal` out of the Installed-only card and into the page-level extension manager container.

The existing **Install from file** and **Create from scratch** actions are now available while the Store, Bazaar, or Installed tab is selected.

## Why

Previously the controls were rendered only inside `v-if="is_installed_tab"`. Users looking to install a new custom extension had to discover that the entry point was hidden under the Installed tab, and moving only the floating button would still leave the creation modal unavailable outside that conditional subtree.

Closes #4016.

## Impact

This changes only where the existing action controls and modal are mounted. Installation, upload, and creation behavior is unchanged.

## Validation

- `bun --cwd core/frontend lint`
- `bun --cwd core/frontend build`
- `git diff --check`
