### PR TITLE
stop sensor getters from burning CPU on every HEARTBEAT

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -34,6 +34,7 @@
       mdi-lightning-bolt
     </v-icon>
     <v-menu
+      v-model="menu_open"
       :close-on-content-click="false"
       nudge-left="150"
       nudge-bottom="25"
@@ -49,7 +50,7 @@
         >
           <v-icon
             v-if="heartbeat_age() < time_limit_heartbeat"
-            v-tooltip="heartbeat_message()"
+            v-tooltip="heartbeat_message"
             class="px-1"
             :color="heartbeat_color()"
           >
@@ -85,7 +86,7 @@
                 <td>Current:</td>
                 <td> {{ battery_current }} A</td>
               </tr>
-              <tr v-for="(calibrated, sensor_name,) in ardupilot_sensors.sensors" :key="sensor_name">
+              <tr v-for="(calibrated, sensor_name) in sensor_status" :key="sensor_name">
                 <td class="sensor-type">
                   {{ sensor_name }}:
                 </td>
@@ -117,11 +118,12 @@ import { convertHexToRgbd } from '@/cosmos'
 import mavlink2rest from '@/libs/MAVLink2Rest'
 import Listener from '@/libs/MAVLink2Rest/Listener'
 import { MavModeFlag, MavType } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
-import ardupilot_sensors, { ArdupilotSensorsStore } from '@/store/ardupilot_sensors'
+import ardupilot_sensors from '@/store/ardupilot_sensors'
 import autopilot_data from '@/store/autopilot'
 import mavlink from '@/store/mavlink'
 import system_information, { FetchType } from '@/store/system-information'
 import * as DEFAULT_COLORS from '@/style/colors/default'
+import { Dictionary } from '@/types/common'
 import { RaspberryEventType } from '@/types/system-information/platform'
 import { Disk } from '@/types/system-information/system'
 import mavlink_store_get from '@/utils/mavlink'
@@ -137,6 +139,9 @@ export default Vue.extend({
   data() {
     return {
       time_limit_heartbeat: 3000,
+      menu_open: false,
+      heartbeat_now: Date.now(),
+      heartbeat_timer: undefined as ReturnType<typeof setInterval> | undefined,
       heartbeat_listener: undefined as Listener | undefined,
     }
   },
@@ -185,30 +190,65 @@ export default Vue.extend({
     disk_usage_high(): boolean {
       return this.disk_usage_percent > 85
     },
-    ardupilot_sensors(): ArdupilotSensorsStore {
-      return ardupilot_sensors
+    all_sensors_calibrated(): boolean {
+      return ardupilot_sensors.all_sensors_calibrated
+    },
+    // Avoid evaluating the full sensors tree while the menu is closed.
+    sensor_status(): Dictionary<boolean> {
+      return this.menu_open ? ardupilot_sensors.sensors : {}
+    },
+    heartbeat_message(): string {
+      if (this.all_sensors_calibrated) {
+        return 'MAVLink heartbeats arriving as expected'
+      }
+      return 'One or more sensors are not calibrated'
     },
   },
   mounted() {
     system_information.subscribeSystemInformation(FETCH_TYPES)
+    this.heartbeat_timer = setInterval(() => {
+      this.heartbeat_now = Date.now()
+    }, 1000)
     // markRaw: Listener → Endpoint.latestData must not be deep-observed per HEARTBEAT.
     this.heartbeat_listener = markRaw(mavlink2rest.startListening('HEARTBEAT').setCallback((message) => {
       if (!this.is_vehicle(message?.message.mavtype.type) || message?.header.component_id !== 1) {
         return
       }
-      autopilot_data.setSystemId(message?.header.system_id)
-      autopilot_data.setAutopilotType(message?.message.autopilot.type)
-      autopilot_data.setVehicleArmed(Boolean(message?.message.base_mode.bits & MavModeFlag.MAV_MODE_FLAG_SAFETY_ARMED))
+      const system_id = message?.header.system_id
+      const autopilot_type = message?.message.autopilot.type
+      const armed = Boolean(message?.message.base_mode.bits & MavModeFlag.MAV_MODE_FLAG_SAFETY_ARMED)
+      if (autopilot_data.system_id !== system_id) {
+        autopilot_data.setSystemId(system_id)
+      }
+      if (autopilot_data.autopilot_type !== autopilot_type) {
+        autopilot_data.setAutopilotType(autopilot_type)
+      }
+      if (autopilot_data.verhicle_armed !== armed) {
+        autopilot_data.setVehicleArmed(armed)
+      }
+      this.heartbeat_now = Date.now()
       autopilot_data.setLastHeartbeatDate(new Date())
     }).setFrequency(0))
   },
   beforeDestroy() {
     system_information.unsubscribeSystemInformation(FETCH_TYPES)
+    if (this.heartbeat_timer !== undefined) {
+      clearInterval(this.heartbeat_timer)
+    }
     this.heartbeat_listener?.discard()
   },
   methods: {
+    // Method (not computed): age must follow wall clock, not a cached Date.now() snapshot.
     heartbeat_age(): number {
-      return new Date().valueOf() - autopilot_data.last_heartbeat_date.getTime()
+      return this.heartbeat_now - autopilot_data.last_heartbeat_date.getTime()
+    },
+    heartbeat_color(): string {
+      const selected_color = this.all_sensors_calibrated
+        ? DEFAULT_COLORS.SHEET_LIGHT_BG : DEFAULT_COLORS.WARNING
+      const [r, g, b] = convertHexToRgbd(selected_color)
+      const opacity = Math.max(0.4, 1.4 - this.heartbeat_age() / 1000)
+
+      return `rgba(${r}, ${g}, ${b}, ${opacity})`
     },
     is_vehicle(type: string) {
       return [
@@ -231,20 +271,6 @@ export default Vue.extend({
         'MAV_TYPE_VTOL_FIXEDROTOR',
         'MAV_TYPE_VTOL_TAILSITTER',
       ].includes(type)
-    },
-    heartbeat_color() : string {
-      const selected_color = ardupilot_sensors.all_sensors_calibrated
-        ? DEFAULT_COLORS.SHEET_LIGHT_BG : DEFAULT_COLORS.WARNING
-      const [r, g, b] = convertHexToRgbd(selected_color)
-      const opacity = Math.max(0.4, 1.4 - this.heartbeat_age() / 1000)
-
-      return `rgba(${r}, ${g}, ${b}, ${opacity})`
-    },
-    heartbeat_message() : string {
-      if (ardupilot_sensors.all_sensors_calibrated) {
-        return 'MAVLink heartbeats arriving as expected'
-      }
-      return 'One or more sensors are not calibrated'
     },
   },
 })

--- a/core/frontend/src/store/ardupilot_sensors.ts
+++ b/core/frontend/src/store/ardupilot_sensors.ts
@@ -1,15 +1,27 @@
+import { vec3 } from 'gl-matrix'
+import { every } from 'lodash'
 import {
-    getModule,
+  getModule,
   Module, VuexModule,
 } from 'vuex-module-decorators'
 
 import store from '@/store'
-import autopilot_data from "./autopilot"
-import { Dictionary } from "@/types/common"
+import Parameter from '@/types/autopilot/parameter'
+import { Dictionary } from '@/types/common'
 import decode, { deviceId } from '@/utils/deviceid_decoder'
 
-import { vec3 } from 'gl-matrix'
-import { every } from 'lodash'
+import autopilot_data from './autopilot'
+
+// avoid parameterRegex full-table scans on every sensors getter eval.
+const ACCEL_ID_PARAMS = ['INS_ACC_ID', 'INS_ACC2_ID', 'INS_ACC3_ID']
+const COMPASS_ID_PARAMS = ['COMPASS_DEV_ID', 'COMPASS_DEV_ID2', 'COMPASS_DEV_ID3']
+const BARO_ID_PARAMS = ['BARO_DEVID', 'BARO2_DEVID', 'BARO3_DEVID']
+
+function params_by_names(names: string[]): Parameter[] {
+  return names
+    .map((name) => autopilot_data.parameter(name))
+    .filter((param): param is Parameter => param !== undefined && param.value !== 0)
+}
 
 @Module({
     dynamic: true,
@@ -20,20 +32,17 @@ import { every } from 'lodash'
 class ArdupilotSensorsStore extends VuexModule {
 
     get accelerometers(): deviceId[]  {
-        return autopilot_data.parameterRegex('^INS_ACC.*_ID')
-        .filter((param) => param.value !== 0)
+        return params_by_names(ACCEL_ID_PARAMS)
         .map((parameter) => decode(parameter.name, parameter.value))
       }
     
       get compasses(): deviceId[] {
-        return autopilot_data.parameterRegex('^COMPASS_DEV_ID.*')
-          .filter((param) => param.value !== 0)
+        return params_by_names(COMPASS_ID_PARAMS)
           .map((parameter) => decode(parameter.name, parameter.value))
       }
     
       get baros(): deviceId[] {
-        return autopilot_data.parameterRegex('^BARO.*_DEVID')
-          .filter((param) => param.value !== 0)
+        return params_by_names(BARO_ID_PARAMS)
           .map((parameter) => decode(parameter.name, parameter.value))
       }
     

--- a/core/frontend/src/store/autopilot.ts
+++ b/core/frontend/src/store/autopilot.ts
@@ -2,6 +2,7 @@ import {
   getModule, Module, Mutation, VuexModule,
 } from 'vuex-module-decorators'
 
+import { vehicle_folder } from '@/components/vehiclesetup/viewers/modelHelper'
 import { MavAutopilot, MavType } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
 import { Message as M2R } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-message'
 import store from '@/store'
@@ -21,10 +22,7 @@ import {
 
 import autopilot_manager from './autopilot_manager'
 
-import { vehicle_folder } from '@/components/vehiclesetup/viewers/modelHelper'
-
 const models: Record<string, string> = import.meta.glob('/public/assets/vehicles/models/**', { eager: true })
-
 
 const parameterFetcher = new ParameterFetcher()
 
@@ -36,6 +34,8 @@ const parameterFetcher = new ParameterFetcher()
 
 class AutopilotStore extends VuexModule {
   parameters: Parameter[] = []
+
+  parameters_by_name: Record<string, Parameter> = {}
 
   parameters_loaded = 0
 
@@ -58,7 +58,7 @@ class AutopilotStore extends VuexModule {
   last_heartbeat_date: Date = new Date()
 
   get parameter() {
-    return (name: string): Parameter | undefined => this.parameters.find((parameter) => parameter.name === name)
+    return (name: string): Parameter | undefined => this.parameters_by_name[name]
   }
 
   get parameterRegex() {
@@ -75,7 +75,7 @@ class AutopilotStore extends VuexModule {
   }
 
   get frame_type(): number | undefined {
-    const mav_type = 'MAV_TYPE_' + autopilot_manager.vehicle_type?.toUpperCase().replace(' ', '_')
+    const mav_type = `MAV_TYPE_${autopilot_manager.vehicle_type?.toUpperCase().replace(' ', '_')}`
     switch (mav_type) {
       case MavType.MAV_TYPE_SUBMARINE:
         return this.parameter('FRAME_CONFIG')?.value
@@ -94,12 +94,11 @@ class AutopilotStore extends VuexModule {
       case 'Surface Boat':
         // we already know it is a boat, so check only TYPE and ignore CLASS (rover/boat/balancebot)
         return Object.entries(ROVER_FRAME_CLASS).find((key, value) => value === this.frame_type)?.[1] as string
-     default:
+      default:
         break
     }
     return undefined
   }
-
 
   get vehicle_model() {
     const frame = this.frame_type
@@ -121,6 +120,7 @@ class AutopilotStore extends VuexModule {
   @Mutation
   reset(): void {
     this.parameters = []
+    this.parameters_by_name = {}
     parameterFetcher.reset()
     this.finished_loading = false
     this.metadata_loaded = false
@@ -131,6 +131,11 @@ class AutopilotStore extends VuexModule {
   @Mutation
   setParameters(parameters: Parameter[]): void {
     this.parameters = parameters
+    const by_name: Record<string, Parameter> = {}
+    for (const parameter of parameters) {
+      by_name[parameter.name] = parameter
+    }
+    this.parameters_by_name = by_name
   }
 
   @Mutation


### PR DESCRIPTION
- `autopilot.ts` uses a map for the parameters and its search is now O(1)
- `ardupilot_sensors.ts` uses fixed param names to avoid full-table scans
- `HealthTrayMenu.vue` moved the sensor/heartbeat to the computed property; sensor status only updates if the menu is open and heartbeat mutations are only fired if they change the current value of `system_id`/ `autopilot_type` / `armed`

fix: #3465 