### PR TITLE
Core: recover shiny loguru terminal colors

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/logs.py
@@ -13,8 +13,12 @@ from loguru import logger
 if TYPE_CHECKING:
     from loguru import Message
 
-# ISO 8601 UTC (e.g. 2026-08-11T19:15:00.123Z)
-ISO8601_LOG_FORMAT = "{time:YYYY-MM-DDTHH:mm:ss.SSS!UTC}Z | {level:<8} | {name}:{function}:{line} - {message}"
+# ISO 8601 UTC (e.g. 2026-08-11T19:15:00.123Z), with loguru's default colors.
+# Tags are stripped automatically when the sink is not a terminal.
+ISO8601_LOG_FORMAT = (
+    "<green>{time:YYYY-MM-DDTHH:mm:ss.SSS!UTC}Z</green> | <level>{level:<8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
+)
 
 LOG_PUBLISHER_OPTIONS: dict[str, Any] = {
     "encoding": zenoh.Encoding.APPLICATION_JSON.with_schema("foxglove.Log"),


### PR DESCRIPTION
needs testing:
 - [x] Colors appear on terminal
 - [x] No tags on zenoh