### PR TITLE
frontend: Use image icons for video thumbnail stills

### DIFF
--- a/core/frontend/src/components/video-manager/VideoThumbnail.vue
+++ b/core/frontend/src/components/video-manager/VideoThumbnail.vue
@@ -40,7 +40,7 @@
         class="thumbnail-overlay text-caption"
       >
         <template v-if="continuous_mode">
-          LIVE
+          1 Hz
           <template v-if="last_fetch_ms !== null">
             {{ last_fetch_ms }}ms
           </template>
@@ -74,7 +74,7 @@
               @click="fetchSingleThumbnail"
             >
               <v-icon small>
-                mdi-camera
+                mdi-image
               </v-icon>
             </v-btn>
           </template>
@@ -87,12 +87,13 @@
               text
               dark
               class="control-btn"
+              :class="{ 'control-btn--active': continuous_mode }"
               v-bind="attrs"
               v-on="on"
               @click="toggleContinuous"
             >
               <v-icon small>
-                {{ continuous_mode ? 'mdi-pause' : 'mdi-play' }}
+                mdi-image-sync
               </v-icon>
             </v-btn>
           </template>
@@ -269,6 +270,10 @@ export default Vue.extend({
   border-radius: 0 !important;
   margin: 0 !important;
   letter-spacing: normal !important;
+}
+
+.control-btn--active {
+  background-color: rgba(255, 255, 255, 0.18) !important;
 }
 
 .control-separator {


### PR DESCRIPTION
https://github.com/user-attachments/assets/47d9da21-5500-4aca-ae39-5f09a364b160

## Summary
- Replace the camera / play-pause thumbnail controls with `mdi-image` (single still) and `mdi-image-sync` (1 Hz refresh) so the play button is no longer mistaken for a live video stream.
- Latch the sync button while continuous fetch is on, and show `1 Hz` instead of `LIVE` in pirate mode.

Fixes https://github.com/bluerobotics/BlueOS/issues/4149

## Test plan
- [ ] Open Video, confirm the thumbnail bar shows an image icon and an image-sync icon (not camera / play).
- [ ] Fetch a single thumbnail; confirm one still appears and continuous fetch does not start.
- [ ] Start continuous thumbnails; confirm the sync button stays visually latched and frames update about once per second.
- [ ] Stop continuous thumbnails; confirm fetching stops and the latch clears.
- [ ] In pirate mode, confirm the overlay says `1 Hz` rather than `LIVE`.
