### PR TITLE
core: frontend: video-manager: VideoThumbnail: Use image icon for continuous thumbnails

### DIFF
--- a/core/frontend/src/components/video-manager/VideoThumbnail.vue
+++ b/core/frontend/src/components/video-manager/VideoThumbnail.vue
@@ -92,7 +92,7 @@
               @click="toggleContinuous"
             >
               <v-icon small>
-                {{ continuous_mode ? 'mdi-pause' : 'mdi-play' }}
+                {{ continuous_mode ? 'mdi-pause' : 'mdi-image-multiple' }}
               </v-icon>
             </v-btn>
           </template>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The continuous-thumbnail toggle used `mdi-play`/`mdi-pause`, making users mistake it for a video stream play button. Replace the idle icon with `mdi-image-multiple` so it reads as an image-fetching control.

Fix #4149
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05d103b9-235a-432d-ad19-0057c5036a59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05d103b9-235a-432d-ad19-0057c5036a59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

