### PR TITLE
core: frontend: video-manager: VideoThumbnail: Use image icon for continuous thumbnails

### DIFF
--- a/core/frontend/src/components/video-manager/VideoThumbnail.vue
+++ b/core/frontend/src/components/video-manager/VideoThumbnail.vue
@@ -92,7 +92,7 @@
               @click="toggleContinuous"
             >
               <v-icon small>
-                {{ continuous_mode ? 'mdi-pause' : 'mdi-play' }}
+                {{ continuous_mode ? 'mdi-pause' : 'mdi-image-multiple' }}
               </v-icon>
             </v-btn>
           </template>


### PR DESCRIPTION
The continuous-thumbnail toggle used `mdi-play`/`mdi-pause`, making users mistake it for a video stream play button. Replace the idle icon with `mdi-image-multiple` so it reads as an image-fetching control.

Fix #4149