### PR TITLE
[1.4] core: tools: mavlink-camera-manager: Update to t3.26.3

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-VERSION="t3.26.1"
+VERSION="t3.26.3"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink-camera-manager"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
This reduces the MCM CPU use for our 4K Cam by almost half.

(backports #4174)

Changelogs: 
* https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.26.2
* https://github.com/mavlink/mavlink-camera-manager/releases/tag/t3.26.3
