### PR TITLE
frontend: store: Divide disk write rate by linux2rest sample window

### DIFF
--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -20,7 +20,7 @@ import {
   CPU, Disk, Info, Memory, Network, Process, System, Temperature,
 } from '@/types/system-information/system'
 import back_axios, { isBackendOffline } from '@/utils/api'
-import { networkProbeRateBps } from '@/utils/networking'
+import { linux2restProbeRateBps } from '@/utils/linux2rest'
 
 export enum FetchType {
     ModelType = 'model',
@@ -218,8 +218,8 @@ class SystemInformationStore extends VuexModule {
       // frontend re-diff of total_*. Those deltas are already saturating and match the
       // Sampler window (LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S).
       for (const network of networks) {
-        network.download_speed = networkProbeRateBps(network.received_B)
-        network.upload_speed = networkProbeRateBps(network.transmitted_B)
+        network.download_speed = linux2restProbeRateBps(network.received_B)
+        network.upload_speed = linux2restProbeRateBps(network.transmitted_B)
       }
       this.system.network = networks
       const names = nextNetworkInterfaceNames(this.network_interface_names, networks)

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -171,25 +171,27 @@ class SystemInformationStore extends VuexModule {
   @Mutation
   updateSystemDisk(disk: [Disk]): void {
     if (this.system) {
-      const now = Date.now()
-
       for (const currentDisk of disk) {
-        const previousDisk = this.system.disk?.find(d => d.name === currentDisk.name)
+        const previousDisk = this.system.disk?.find(
+          (d) => d.mount_point === currentDisk.mount_point,
+        )
 
+        // write_rate_Bps is frontend-only; linux2rest does not send it. Keep the last
+        // computed rate while the capacity snapshot is unchanged (zero delta).
         if (currentDisk.write_rate_Bps === undefined) {
           currentDisk.write_rate_Bps = previousDisk?.write_rate_Bps ?? 0
         }
 
-        currentDisk.last_update = now
-
-        if (previousDisk && previousDisk.last_update) {
-          const timeDelta = (now - previousDisk.last_update) / 1000
+        if (previousDisk) {
           const currentUsed = currentDisk.total_space_B - currentDisk.available_space_B
           const previousUsed = previousDisk.total_space_B - previousDisk.available_space_B
           const disk_delta = currentUsed - previousUsed
-
           if (disk_delta !== 0) {
-            currentDisk.write_rate_Bps = disk_delta / timeDelta
+            // available_space_B only changes on linux2rest Sampler ticks (5s), not on
+            // the 2s frontend poll. Dividing by poll dt inflates the rate by 5/2 and a
+            // later zero delta freezes that value on screen.
+            // Used-space can drop (deletes); clamp to 0 because this widget is a write rate.
+            currentDisk.write_rate_Bps = linux2restProbeRateBps(disk_delta)
           }
         }
       }

--- a/core/frontend/src/types/system-information/system.ts
+++ b/core/frontend/src/types/system-information/system.ts
@@ -23,7 +23,6 @@ export interface Disk {
      * @param name - Name that is used to identify the disk, E.g: /dev/root, /dev/sda1
      * @param total_space_B - Size of the disk in bytes
      * @param type - E.g: SSD, HD
-     * @param last_update - Timestamp of last update for rate calculation
      * @param write_rate_Bps - Disk write rate in bytes per second
     * */
     available_space_B: number,
@@ -32,7 +31,6 @@ export interface Disk {
     name: string,
     total_space_B: number,
     type: string,
-    last_update?: number,
     write_rate_Bps?: number
 }
 

--- a/core/frontend/src/utils/linux2rest.ts
+++ b/core/frontend/src/utils/linux2rest.ts
@@ -1,0 +1,8 @@
+// Must match linux2rest Sampler interval (src/main.rs: Duration::from_secs(5)).
+// TODO: prefer a probed interval if/when linux2rest exposes it (rates silently drift if Sampler cadence changes).
+export const LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S = 5
+
+/** Convert a linux2rest per-sample byte delta into a bytes-per-second rate. Negative deltas are clamped to zero. */
+export function linux2restProbeRateBps(bytesSinceLastProbe: number): number {
+  return Math.max(0, bytesSinceLastProbe) / LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S
+}

--- a/core/frontend/src/utils/networking.ts
+++ b/core/frontend/src/utils/networking.ts
@@ -1,12 +1,3 @@
-// Must match linux2rest Sampler interval (src/main.rs: Duration::from_secs(5)).
-// TODO: prefer a probed interval if/when linux2rest exposes it (Mbps silently drift if Sampler cadence changes).
-export const LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S = 5
-
-/** Convert a linux2rest per-sample byte delta into a bytes-per-second rate. Negative deltas are clamped to zero. */
-export function networkProbeRateBps(bytesSinceLastProbe: number): number {
-  return Math.max(0, bytesSinceLastProbe) / LINUX2REST_SYSTEM_SAMPLE_INTERVAL_S
-}
-
 export function formatBandwidth(bytesPerSecond: number): string {
   const mbps = (8 * bytesPerSecond / 1024 / 1024)
   const decimal_places = mbps < 10 ? 2 : mbps < 100 ? 1 : 0


### PR DESCRIPTION
## Summary
- The tray disk widget (`W: … MB/s`) treated each `available_space_B` jump as happening over the **2 s** frontend poll. linux2rest only refreshes that snapshot every **5 s**, so a ~2.1 MB/s recording showed as **~5.0–5.1 MB/s**, then stuck there because a later zero delta kept the inflated rate.
- Divide capacity deltas by the same 5 s Sampler window already used for network (`linux2restProbeRateBps`). Match disks by `mount_point` (many bind mounts share `name: /dev/root`). Drop unused `Disk.last_update`.
- No linux2rest API change. Self-hosted frontend against a vehicle writing ~2 MB/s showed **W: 2.0 MB/s**.

Helps https://github.com/bluerobotics/BlueOS/issues/4172: this PR doesn't solve it, but at least we get a correct reading from the widget
Related (not required for this PR): https://github.com/patrickelectric/linux2rest/issues/38

## Test plan
- [x] Self-host `core/frontend` with `BLUEOS_ADDRESS=http://<vehicle>/ yarn dev`
- [x] With a sustained ~16 Mbps recording (or any ~2 MB/s writer), tray shows **~2 MB/s**, not ~5 MB/s, and holds there across several 2 s polls
- [x] After stopping the writer, rate drops toward zero on the next non-zero capacity change
- [x] Disk fill still updates (`xx/yyGB (zz%)`)
- [x] Network tray rates still look sane (this PR reuses their helper, does not change that path)