### PR TITLE
helper: Bound internet checks so a DNS hang is not INTERNET_CHECK_FAIL

### DIFF
--- a/core/frontend/src/store/helper.ts
+++ b/core/frontend/src/store/helper.ts
@@ -41,12 +41,14 @@ class PingStore extends VuexModule {
 
   reachable_hosts: string[] = []
 
+  internet_check_failures = 0
+
   checkInternetAccessTask = new OneMoreTime(
     { delay: 20000 },
   )
 
   updateWebServicesTask = new OneMoreTime(
-    { delay: 5000 },
+    { delay: 10000 }, // scan_ports can take several seconds; a 5s delay stacked overlapping polls
   )
 
   @Mutation
@@ -64,6 +66,16 @@ class PingStore extends VuexModule {
     this.services = services
   }
 
+  @Mutation
+  resetInternetCheckFailures(): void {
+    this.internet_check_failures = 0
+  }
+
+  @Mutation
+  incrementInternetCheckFailures(): void {
+    this.internet_check_failures += 1
+  }
+
   @Action
   async checkInternetAccess(): Promise<void> {
     back_axios({
@@ -72,27 +84,34 @@ class PingStore extends VuexModule {
       timeout: 10000,
     })
       .then((response) => {
-        const sites = Object.values(response.data as SiteStatus)
-        const online_sites = sites.filter((item) => item.online)
-        this.setReachableHosts(online_sites.map((item) => item.site.hostname))
+        this.resetInternetCheckFailures()
+        try {
+          const sites = Object.values(response.data as SiteStatus)
+          const online_sites = sites.filter((item) => item.online)
+          this.setReachableHosts(online_sites.map((item) => item.site.hostname))
 
-        // If no sites are reachable, we're offline
-        if (online_sites.length === 0) {
-          this.setHasInternet(InternetConnectionState.OFFLINE)
-          return
+          // A site that did not answer inside Helper's budget carries no verdict.
+          const decided_sites = sites.filter((item) => item.error !== 'timeout')
+          if (decided_sites.length === 0) {
+            return
+          }
+          if (online_sites.length === decided_sites.length) {
+            this.setHasInternet(InternetConnectionState.ONLINE)
+            return
+          }
+          this.setHasInternet(
+            online_sites.length > 0 ? InternetConnectionState.LIMITED : InternetConnectionState.OFFLINE,
+          )
+        } catch {
+          // Helper answered; keep the last verdict if the body is unusable.
         }
-
-        // If all sites are reachable, we're fully online
-        if (online_sites.length === sites.length) {
-          this.setHasInternet(InternetConnectionState.ONLINE)
-          return
-        }
-
-        // If some sites are reachable but not all, we have limited connectivity
-        this.setHasInternet(InternetConnectionState.LIMITED)
       })
       .catch((error) => {
-        // If we can't even reach the backend, we're in an unknown state
+        // One timed-out poll is not a connectivity verdict.
+        this.incrementInternetCheckFailures()
+        if (this.internet_check_failures < 3) {
+          return
+        }
         this.setHasInternet(InternetConnectionState.UNKNOWN)
         this.setReachableHosts([])
         notifier.pushBackError('INTERNET_CHECK_FAIL', error)

--- a/core/libs/commonwealth/src/commonwealth/utils/decorators.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/decorators.py
@@ -20,23 +20,30 @@ def temporary_cache(timeout_seconds: float = 10) -> Callable[[F], F]:
     """
     cache: Dict[Any, Any] = {}
     last_sample_time: Dict[Any, float] = {}
+    # Retained for the process lifetime. Safe here because args are a small set (enums/ports).
+    arg_locks: Dict[Any, Lock] = {}
+    arg_locks_guard = Lock()
 
     def inner_function(function: F) -> F:
         @wraps(function)
         def wrapper(*args: Any) -> Any:
             nonlocal last_sample_time
-            current_time = time.time()
-            cache_is_valid = args in last_sample_time and current_time - last_sample_time[args] < timeout_seconds
+            with arg_locks_guard:
+                arg_lock = arg_locks.setdefault(args, Lock())
 
-            # The cache is still valid and we can return the value if exists
-            if cache_is_valid and args in cache:
-                return cache[args]
+            with arg_lock:
+                current_time = time.time()
+                cache_is_valid = args in last_sample_time and current_time - last_sample_time[args] < timeout_seconds
 
-            # The cache is invalid or argument does not exist in cache, update it!
-            last_sample_time[args] = current_time
-            function_return = function(*args)
-            cache[args] = function_return
-            return function_return
+                # The cache is still valid and we can return the value if exists
+                if cache_is_valid and args in cache:
+                    return cache[args]
+
+                # The cache is invalid or argument does not exist in cache, update it!
+                last_sample_time[args] = current_time
+                function_return = function(*args)
+                cache[args] = function_return
+                return function_return
 
         def invalidate() -> None:
             cache.clear()

--- a/core/libs/commonwealth/src/commonwealth/utils/tests/test_decorators.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/tests/test_decorators.py
@@ -1,4 +1,5 @@
 import time
+from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import datetime
 
 from .. import decorators
@@ -37,3 +38,21 @@ def test_temporary_cache_invalidate() -> None:
     cached_function.invalidate()  # type: ignore[attr-defined]
 
     assert all(original_output[key] != cached_function(key) for key in inputs)
+
+
+def test_temporary_cache_coalesces_in_flight() -> None:
+    calls = []
+
+    @decorators.temporary_cache(timeout_seconds=1.0)
+    def slow(_entry: str) -> int:
+        calls.append(1)
+        time.sleep(0.5)
+        return len(calls)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(slow, "same") for _ in range(4)]
+        wait(futures)
+        results = [future.result() for future in futures]
+
+    assert len(calls) == 1
+    assert results == [1, 1, 1, 1]

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -170,6 +170,8 @@ class Helper:
         5201,  # Iperf
         6021,  # Mavlink Camera Manager's WebRTC signaller
         7000,  # Major Tom does not have a public API yet
+        7117,  # Zenoh REST
+        7447,  # Zenoh scout
         8554,  # Mavlink Camera Manager's RTSP server
         5777,  # ardupilot-manager's Mavlink TCP Server
         5555,  # DGB server

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -42,6 +42,12 @@ from uvicorn import Config, Server
 
 SERVICE_NAME = "helper"
 
+# Stay below the frontend's 10s Axios timeout. Cache covers overlapping UI polls (20s).
+# Website cache must outlive INTERNET_CHECK_CACHE_S so a late probe is still valid next poll.
+INTERNET_CHECK_DEADLINE_S = 4
+INTERNET_CHECK_CACHE_S = 25
+WEBSITE_CHECK_CACHE_S = 30
+
 logging.basicConfig(handlers=[InterceptHandler()], level=logging.DEBUG)
 try:
     init_logger(SERVICE_NAME)
@@ -188,6 +194,9 @@ class Helper:
 
     MAX_ATTEMPTS_LEFT = 3
     attempts_left: Dict[int, int] = {}
+    website_executor = futures.ThreadPoolExecutor(max_workers=10)
+    # Reused so a hung DNS lookup cannot queue a second worker for the same site.
+    website_in_flight: Dict[Website, "futures.Future[WebsiteStatus]"] = {}
 
     mavlink2rest = MavlinkMessenger()
 
@@ -244,7 +253,8 @@ class Helper:
 
             # Decode the data
             request_response.status = response.status
-            if response.status == http.client.OK:
+            # HEAD has no body; gzip-decoding an empty 200 would raise and mark the site offline.
+            if method != "HEAD" and response.status == http.client.OK:
                 encoding = response.headers.get_content_charset() or "utf-8"
                 if response.getheader("Content-Encoding") == "gzip":
                     buffer = BytesIO(response.read())
@@ -431,13 +441,13 @@ class Helper:
         return [service for service in Helper.KNOWN_SERVICES if service.valid]
 
     @staticmethod
-    @temporary_cache(timeout_seconds=1)
+    @temporary_cache(timeout_seconds=WEBSITE_CHECK_CACHE_S)
     def check_website(site: Website) -> WebsiteStatus:
         hostname = str(site.value["hostname"])
         port = int(str(site.value["port"]))
         path = str(site.value["path"])
 
-        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=5, method="GET")
+        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=5, method="HEAD")
         website_status = WebsiteStatus(site=site, online=False)
 
         log_msg = f"Running check_website for '{hostname}:{port}'"
@@ -468,13 +478,26 @@ class Helper:
             Helper.reload_nginx()
 
     @staticmethod
-    @temporary_cache(timeout_seconds=5)
+    @temporary_cache(timeout_seconds=INTERNET_CHECK_CACHE_S)
     def check_internet_access() -> Dict[str, WebsiteStatus]:
-        # 10 concurrent executors is fine here because its a very short/light task
-        with futures.ThreadPoolExecutor(max_workers=10) as executor:
-            tasks = [executor.submit(Helper.check_website, site) for site in Website]
-            status_list = [task.result() for task in futures.as_completed(tasks)]
+        # Hard deadline below the frontend's 10s Axios timeout. DNS is not covered by the per-socket timeout.
+        # Pending futures keep running on website_executor after wait() returns; do not drop max_workers to
+        # len(Website), and do not submit a second task for a site that is still in flight.
+        future_to_site: Dict["futures.Future[WebsiteStatus]", Website] = {}
+        for site in Website:
+            existing = Helper.website_in_flight.get(site)
+            if existing is not None and not existing.done():
+                future_to_site[existing] = site
+                continue
+            future = Helper.website_executor.submit(Helper.check_website, site)
+            Helper.website_in_flight[site] = future
+            future_to_site[future] = site
 
+        done, pending = futures.wait(future_to_site.keys(), timeout=INTERNET_CHECK_DEADLINE_S)
+        status_list = [future.result() for future in done]
+        status_list.extend(
+            WebsiteStatus(site=future_to_site[future], online=False, error="timeout") for future in pending
+        )
         return {status.site.name: status for status in status_list}
 
     @staticmethod
@@ -509,7 +532,9 @@ class Helper:
     @staticmethod
     async def check_and_notify_factory_mode() -> None:
         try:
-            response = requests.get("http://localhost/version-chooser/v1.0/version/current", timeout=10)
+            response = await asyncio.to_thread(
+                requests.get, "http://localhost/version-chooser/v1.0/version/current", timeout=10
+            )
             if response.status_code == 200 and response.json()["tag"] == "factory":
                 mav_message = Helper.mavlink2rest.command_statustext_message("BlueOS is in factory mode")
                 await Helper.mavlink2rest.send_mavlink_message(mav_message)
@@ -597,7 +622,6 @@ async def ping(host: str, interface_addr: Optional[str] = None) -> bool:
 async def periodic() -> None:
     while True:
         await asyncio.sleep(60)
-        Helper.check_internet_access()
 
         await Helper.check_and_notify_factory_mode()
 
@@ -640,9 +664,9 @@ async def main() -> None:
     config = Config(app=app, host="0.0.0.0", port=Helper.PORT, log_config=None)
     server = Server(config)
 
-    asyncio.create_task(periodic())
-
+    periodic_task = asyncio.create_task(periodic())
     await server.serve()
+    periodic_task.cancel()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Helper's internet check waited for every website probe, including DNS lookups that ignore the 5s socket timeout. A lost UDP query to `8.8.8.8` costs glibc ~10s, which matches the frontend's 10s Axios deadline, so the UI showed `INTERNET_CHECK_FAIL` while ICMP still worked.

- `check_internet_access` now returns within 4s. Sites still resolving are `online: false, error: "timeout"` — not a failed network. In-flight probes are reused so a hung DNS lookup cannot queue a second worker.
- Website probes use HEAD. Per-site results cache for 20s; the overall check caches for 25s to cover overlapping UI polls (20s).
- Service scans skip Zenoh REST/scout (7117/7447). In-flight `temporary_cache` calls coalesce per args.
- The unused periodic internet check is gone. Factory-mode HTTP still runs off the event loop.
- The UI keeps the last verdict until three polls in a row fail, and does not treat Helper budget timeouts as offline. `web_services` polling is 10s so scans no longer stack every 5s.

Fixes #4176

## Test plan

- [x] Open BlueOS with working internet: globe is online, notifications stay empty
- [x] `GET /helper/latest/check_internet_access` returns in well under 10s (Pi retest: 200 in ~19ms, all five sites online; cached/concurrent polls 12–25ms)
- [x] Helper logs no 1s timeouts on Zenoh 7447/7117 after restart
- [x] A single timed-out Axios poll does not clear `has_internet` or raise `INTERNET_CHECK_FAIL`
- [x] All-timeout Helper responses do not flip the UI to OFFLINE