### PR TITLE
[1.4] core: services: log_zipper: Keep all inputs in one gzip stream

### DIFF
--- a/core/services/log_zipper/main.py
+++ b/core/services/log_zipper/main.py
@@ -18,10 +18,11 @@ SERVICE_NAME = "log-zipper"
 
 
 def zip_files(files: List[str], output_path: str) -> None:
-    for file in files:
-        logger.debug(f"Zipping {file}...")
-        with open(file, "rb") as f_in, gzip.open(output_path, "wb") as f_out:
-            f_out.writelines(f_in)
+    with gzip.open(output_path, "wb") as f_out:
+        for file in files:
+            logger.debug(f"Zipping {file}...")
+            with open(file, "rb") as f_in:
+                f_out.writelines(f_in)
 
     for file in files:
         try:

--- a/core/services/log_zipper/test_zip_files.py
+++ b/core/services/log_zipper/test_zip_files.py
@@ -1,0 +1,25 @@
+import gzip
+import importlib.util
+import sys
+from pathlib import Path
+
+_SERVICE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SERVICE_DIR.parents[1] / "libs" / "commonwealth"))
+
+_SPEC = importlib.util.spec_from_file_location("log_zipper_main", _SERVICE_DIR / "main.py")
+assert _SPEC is not None and _SPEC.loader is not None
+_LOG_ZIPPER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_LOG_ZIPPER)
+
+
+def test_zip_files_archives_every_input(tmp_path: Path) -> None:
+    first = tmp_path / "a.log"
+    second = tmp_path / "b.log"
+    first.write_bytes(b"alpha\n")
+    second.write_bytes(b"bravo\n")
+    archive = tmp_path / "bundle.gz"
+
+    _LOG_ZIPPER.zip_files([str(first), str(second)], str(archive))
+
+    with gzip.open(archive, "rb") as compressed:
+        assert compressed.read() == b"alpha\nbravo\n"


### PR DESCRIPTION
## Summary
- `zip_files` reopened the same `.gz` with `"wb"` for every input, so only the last log survived and then every original was deleted.
- Open the gzip once and write all files into that stream, matching the original `ZipFile` loop.
- Regression test: two inputs must both appear in the archive.

Fixes https://github.com/bluerobotics/BlueOS/issues/4181

## Test plan
- [x] Deploy this branch's docker image on a Pi
- [x] Leave more than one aged `.log` per service (short sessions that skip zipper, or copy extras into a service folder with old mtimes)
- [x] After log-zipper runs, `gunzip -c` a multi-file `{service}-{timestamp}.gz` and confirm it contains every original, not only the last file
- [x] Download System Logs from Settings and confirm the unzipped tree matches the size chip once zipper has finished