### PR TITLE
[backport/1.4] helper: Bound internet checks so a DNS hang is not INTERNET_CHECK_FAIL

### DIFF
--- a/core/frontend/src/store/helper.ts
+++ b/core/frontend/src/store/helper.ts
@@ -41,12 +41,14 @@ class PingStore extends VuexModule {
 
   reachable_hosts: string[] = []
 
+  internet_check_failures = 0
+
   checkInternetAccessTask = new OneMoreTime(
     { delay: 20000 },
   )
 
   updateWebServicesTask = new OneMoreTime(
-    { delay: 5000 },
+    { delay: 10000 }, // scan_ports can take several seconds; a 5s delay stacked overlapping polls
   )
 
   @Mutation
@@ -64,6 +66,16 @@ class PingStore extends VuexModule {
     this.services = services
   }
 
+  @Mutation
+  resetInternetCheckFailures(): void {
+    this.internet_check_failures = 0
+  }
+
+  @Mutation
+  incrementInternetCheckFailures(): void {
+    this.internet_check_failures += 1
+  }
+
   @Action
   async checkInternetAccess(): Promise<void> {
     back_axios({
@@ -72,27 +84,34 @@ class PingStore extends VuexModule {
       timeout: 10000,
     })
       .then((response) => {
-        const sites = Object.values(response.data as SiteStatus)
-        const online_sites = sites.filter((item) => item.online)
-        this.setReachableHosts(online_sites.map((item) => item.site.hostname))
+        this.resetInternetCheckFailures()
+        try {
+          const sites = Object.values(response.data as SiteStatus)
+          const online_sites = sites.filter((item) => item.online)
+          this.setReachableHosts(online_sites.map((item) => item.site.hostname))
 
-        // If no sites are reachable, we're offline
-        if (online_sites.length === 0) {
-          this.setHasInternet(InternetConnectionState.OFFLINE)
-          return
+          // A site that did not answer inside Helper's budget carries no verdict.
+          const decided_sites = sites.filter((item) => item.error !== 'timeout')
+          if (decided_sites.length === 0) {
+            return
+          }
+          if (online_sites.length === decided_sites.length) {
+            this.setHasInternet(InternetConnectionState.ONLINE)
+            return
+          }
+          this.setHasInternet(
+            online_sites.length > 0 ? InternetConnectionState.LIMITED : InternetConnectionState.OFFLINE,
+          )
+        } catch {
+          // Helper answered; keep the last verdict if the body is unusable.
         }
-
-        // If all sites are reachable, we're fully online
-        if (online_sites.length === sites.length) {
-          this.setHasInternet(InternetConnectionState.ONLINE)
-          return
-        }
-
-        // If some sites are reachable but not all, we have limited connectivity
-        this.setHasInternet(InternetConnectionState.LIMITED)
       })
       .catch((error) => {
-        // If we can't even reach the backend, we're in an unknown state
+        // One timed-out poll is not a connectivity verdict.
+        this.incrementInternetCheckFailures()
+        if (this.internet_check_failures < 3) {
+          return
+        }
         this.setHasInternet(InternetConnectionState.UNKNOWN)
         this.setReachableHosts([])
         notifier.pushBackError('INTERNET_CHECK_FAIL', error)

--- a/core/libs/commonwealth/commonwealth/utils/decorators.py
+++ b/core/libs/commonwealth/commonwealth/utils/decorators.py
@@ -15,23 +15,30 @@ def temporary_cache(timeout_seconds: float = 10) -> Callable[[Callable[[Any], An
     """
     cache: Dict[Any, Any] = {}
     last_sample_time: Dict[Any, float] = {}
+    # Retained for the process lifetime. Safe here because args are a small set (enums/ports).
+    arg_locks: Dict[Any, Lock] = {}
+    arg_locks_guard = Lock()
 
     def inner_function(function: Callable[[Any], Any]) -> Any:
         @wraps(function)
         def wrapper(*args: Any) -> Any:
             nonlocal last_sample_time
-            current_time = time.time()
-            cache_is_valid = args in last_sample_time and current_time - last_sample_time[args] < timeout_seconds
+            with arg_locks_guard:
+                arg_lock = arg_locks.setdefault(args, Lock())
 
-            # The cache is still valid and we can return the value if exists
-            if cache_is_valid and args in cache:
-                return cache[args]
+            with arg_lock:
+                current_time = time.time()
+                cache_is_valid = args in last_sample_time and current_time - last_sample_time[args] < timeout_seconds
 
-            # The cache is invalid or argument does not exist in cache, update it!
-            last_sample_time[args] = current_time
-            function_return = function(*args)
-            cache[args] = function_return
-            return function_return
+                # The cache is still valid and we can return the value if exists
+                if cache_is_valid and args in cache:
+                    return cache[args]
+
+                # The cache is invalid or argument does not exist in cache, update it!
+                last_sample_time[args] = current_time
+                function_return = function(*args)
+                cache[args] = function_return
+                return function_return
 
         return wrapper
 

--- a/core/libs/commonwealth/commonwealth/utils/tests/test_decorators.py
+++ b/core/libs/commonwealth/commonwealth/utils/tests/test_decorators.py
@@ -1,4 +1,5 @@
 import time
+from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import datetime
 
 from .. import decorators
@@ -24,3 +25,21 @@ def test_nested_settings_save_load() -> None:
 
     # Check if all cache values are invalid after waiting for a long time
     assert all(original_output[key] != cached_function(key) for key in inputs)
+
+
+def test_temporary_cache_coalesces_in_flight() -> None:
+    calls = []
+
+    @decorators.temporary_cache(timeout_seconds=1.0)
+    def slow(_entry: str) -> int:
+        calls.append(1)
+        time.sleep(0.5)
+        return len(calls)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(slow, "same") for _ in range(4)]
+        wait(futures)
+        results = [future.result() for future in futures]
+
+    assert len(calls) == 1
+    assert results == [1, 1, 1, 1]

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -43,6 +43,12 @@ from nginx_parser import parse_nginx_file
 SERVICE_NAME = "helper"
 SPEED_TEST: Optional[Speedtest] = None
 
+# Stay below the frontend's 10s Axios timeout. Cache covers overlapping UI polls (20s).
+# Website cache must outlive INTERNET_CHECK_CACHE_S so a late probe is still valid next poll.
+INTERNET_CHECK_DEADLINE_S = 4
+INTERNET_CHECK_CACHE_S = 25
+WEBSITE_CHECK_CACHE_S = 30
+
 logging.basicConfig(handlers=[InterceptHandler()], level=logging.DEBUG)
 try:
     init_logger(SERVICE_NAME)
@@ -232,6 +238,9 @@ class Helper:
 
     MAX_ATTEMPTS_LEFT = 3
     attempts_left: Dict[int, int] = {}
+    website_executor = futures.ThreadPoolExecutor(max_workers=10)
+    # Reused so a hung DNS lookup cannot queue a second worker for the same site.
+    website_in_flight: Dict[Website, "futures.Future[WebsiteStatus]"] = {}
 
     @staticmethod
     # pylint: disable=too-many-arguments,too-many-branches,too-many-locals
@@ -286,7 +295,8 @@ class Helper:
 
             # Decode the data
             request_response.status = response.status
-            if response.status == http.client.OK:
+            # HEAD has no body; gzip-decoding an empty 200 would raise and mark the site offline.
+            if method != "HEAD" and response.status == http.client.OK:
                 encoding = response.headers.get_content_charset() or "utf-8"
                 if response.getheader("Content-Encoding") == "gzip":
                     buffer = BytesIO(response.read())
@@ -465,13 +475,13 @@ class Helper:
         return [service for service in Helper.KNOWN_SERVICES if service.valid]
 
     @staticmethod
-    @temporary_cache(timeout_seconds=1)
+    @temporary_cache(timeout_seconds=WEBSITE_CHECK_CACHE_S)
     def check_website(site: Website) -> WebsiteStatus:
         hostname = str(site.value["hostname"])
         port = int(str(site.value["port"]))
         path = str(site.value["path"])
 
-        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=5, method="GET")
+        response = Helper.simple_http_request(hostname, port=port, path=path, timeout=5, method="HEAD")
         website_status = WebsiteStatus(site=site, online=False)
 
         log_msg = f"Running check_website for '{hostname}:{port}'"
@@ -502,13 +512,26 @@ class Helper:
             Helper.reload_nginx()
 
     @staticmethod
-    @temporary_cache(timeout_seconds=5)
+    @temporary_cache(timeout_seconds=INTERNET_CHECK_CACHE_S)
     def check_internet_access() -> Dict[str, WebsiteStatus]:
-        # 10 concurrent executors is fine here because its a very short/light task
-        with futures.ThreadPoolExecutor(max_workers=10) as executor:
-            tasks = [executor.submit(Helper.check_website, site) for site in Website]
-            status_list = [task.result() for task in futures.as_completed(tasks)]
+        # Hard deadline below the frontend's 10s Axios timeout. DNS is not covered by the per-socket timeout.
+        # Pending futures keep running on website_executor after wait() returns; do not drop max_workers to
+        # len(Website), and do not submit a second task for a site that is still in flight.
+        future_to_site: Dict["futures.Future[WebsiteStatus]", Website] = {}
+        for site in Website:
+            existing = Helper.website_in_flight.get(site)
+            if existing is not None and not existing.done():
+                future_to_site[existing] = site
+                continue
+            future = Helper.website_executor.submit(Helper.check_website, site)
+            Helper.website_in_flight[site] = future
+            future_to_site[future] = site
 
+        done, pending = futures.wait(future_to_site.keys(), timeout=INTERNET_CHECK_DEADLINE_S)
+        status_list = [future.result() for future in done]
+        status_list.extend(
+            WebsiteStatus(site=future_to_site[future], online=False, error="timeout") for future in pending
+        )
         return {status.site.name: status for status in status_list}
 
     @staticmethod
@@ -674,7 +697,6 @@ async def ping(host: str, interface_addr: Optional[str] = None) -> bool:
 async def periodic() -> None:
     while True:
         await asyncio.sleep(60)
-        Helper.check_internet_access()
 
         # Clear the known ports cache and re-scan it
         if Helper.PERIODICALLY_RESCAN_ALL_SERVICES:
@@ -715,5 +737,6 @@ if __name__ == "__main__":
     config = Config(app=app, loop=loop, host="0.0.0.0", port=Helper.PORT, log_config=None)
     server = Server(config)
 
-    loop.create_task(periodic())
+    periodic_task = loop.create_task(periodic())
     loop.run_until_complete(server.serve())
+    periodic_task.cancel()

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -214,6 +214,8 @@ class Helper:
         5201,  # Iperf
         6021,  # Mavlink Camera Manager's WebRTC signaller
         7000,  # Major Tom does not have a public API yet
+        7117,  # Zenoh REST
+        7447,  # Zenoh scout
         8554,  # Mavlink Camera Manager's RTSP server
         5777,  # ardupilot-manager's Mavlink TCP Server
         5555,  # DGB server


### PR DESCRIPTION
This is a backport of #4178 into 1.4.

Helper on 1.4 still ran `check_internet_access` on the asyncio event loop. That call is removed here, matching #4178.
