### PR TITLE
ardupilot-manager: return empty list on non-Linux flight controllers

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -302,7 +302,8 @@ class AutoPilotManager(metaclass=Singleton):
         # The first column comes from https://ardupilot.org/dev/docs/sitl-serial-mapping.html
 
         if "serials" not in self.configuration:
-            assert isinstance(self._current_board, LinuxFlightController)
+            if not isinstance(self._current_board, LinuxFlightController):
+                return []
             return self._current_board.get_serials()
         serials = []
         for entry in self.configuration["serials"]:


### PR DESCRIPTION
## Description
Fixes #4168

`GET /ardupilot-manager/v1.0/serials` previously asserted that `self._current_board` was an instance of `LinuxFlightController`, which caused an HTTP 500 error when connected to non-Linux flight controllers (e.g. Pixhawk).

This PR checks if `self._current_board` is a `LinuxFlightController` and returns an empty list `[]` if it is not, allowing clients and the UI to handle non-Linux flight controllers gracefully.
