### PR TITLE
kraken: raise ExtensionNotFound when restarting uninstalled extension

### DIFF
--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -389,6 +389,8 @@ class Extension:
     @classmethod
     async def from_running(cls, identifier: str) -> "Extension":
         installed: List[Extension] = cast(List[Extension], await cls.from_settings(identifier))
+        if not installed:
+            raise ExtensionNotFound(f"Extension {identifier} not found")
 
         enabled = [ext for ext in installed if ext.source.enabled]
         if not enabled:


### PR DESCRIPTION
## Description
Fixes #4160

`POST /kraken/v2.0/extension/{identifier}/restart` for an extension identifier that was never installed previously returned HTTP 400 (`Extension {identifier} have no running versions`) instead of HTTP 404 (`Extension {identifier} not found`).

This PR updates `Extension.from_running(identifier)` to raise `ExtensionNotFound` (HTTP 404) when the `installed` list is empty, while preserving `ExtensionNotRunning` (HTTP 400) when the extension is installed but disabled.
