### PR TITLE
kraken: check container exists before streaming logs to return 404

### DIFF
--- a/core/services/kraken/api/v2/routers/container.py
+++ b/core/services/kraken/api/v2/routers/container.py
@@ -55,6 +55,7 @@ async def fetch_log_by_container_name(container_name: str, timeout: Optional[int
     Fetch logs of a given container.
     If timeout is provided, the stream will be closed after no log line is received for the given timeout.
     """
+    await ContainerManager.get_running_container_by_name(container_name)
     stream = ContainerManager.get_container_log_by_name(container_name)
 
     if timeout is not None:


### PR DESCRIPTION
## Description
Fixes #4161

`GET /kraken/v2.0/container/{container_name}/log` previously constructed and returned a `StreamingResponse` without first checking if the container existed. As a result, requests for non-existent containers returned HTTP 200 OK headers followed by an empty stream or heartbeat fragments.

This PR awaits `ContainerManager.get_running_container_by_name(container_name)` before returning `StreamingResponse`, properly raising `ContainerNotFound` and returning HTTP 404 when the container does not exist.
