### PR TITLE
[1.4] frontend: vehiclesetup: accelerometer: Give GenericViewer an explicit height

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/accelerometer/FullAccelerometerCalibration.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/accelerometer/FullAccelerometerCalibration.vue
@@ -38,6 +38,7 @@
         :transparent="false"
         :cameracontrols="false"
         :orientation="current_state_3D"
+        :style="{ height: '320px' }"
       />
       <v-card-actions class="justify-center">
         <v-btn v-if="show_start_button" :loading="start_button_loading" class="primary" @click="startCalibration">


### PR DESCRIPTION
Fixes https://github.com/bluerobotics/BlueOS/issues/4190

## Summary

- Full accelerometer calibration shows an empty rectangle instead of the 3D pose because `GenericViewer` / `model-viewer` is `height: 100%` with no parent height, so the canvas collapses to 0px.
- Frame selector and vehicle body already set an explicit height; this dialog did not. Give the viewer `320px` so the model is visible.

## Test plan

- [x] Vehicle Setup → Accelerometer → Start Full Calibration
- [x] Confirm the 3D vehicle model is visible (not an empty rectangle)
- [x] Confirm the model orientation still updates as you step through each side
- [x] Confirm Frame selector / vehicle body 3D viewers are unchanged
