### PR TITLE
core: frontend: ServoFunctionRangeEditor: Fix slider click target

### DIFF
--- a/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
@@ -283,6 +283,10 @@ export default Vue.extend({
       const container = this.$refs.sliderContainer as HTMLElement
       if (!container) return
 
+      const rect = container.getBoundingClientRect()
+      const trackY = rect.top + rect.height / 2
+      if (Math.abs(event.clientY - trackY) > 16) return
+
       const { value } = this.calculateValueFromEvent(event, container)
       const closestThumb = this.findClosestThumb(value)
 
@@ -442,7 +446,7 @@ export default Vue.extend({
 .servo-slider {
   position: relative;
   height: 80px;
-  cursor: pointer;
+  cursor: default;
   padding: 0 10px;
   margin: 20px 0;
 }
@@ -455,6 +459,7 @@ export default Vue.extend({
   height: 4px;
   background-color: rgba(128, 128, 128, 0.2);
   border-radius: 2px;
+  cursor: pointer;
 }
 
 .slider-fill {
@@ -465,6 +470,7 @@ export default Vue.extend({
   background-color: var(--v-primary-base);
   border-radius: 2px;
   opacity: 0.8;
+  cursor: pointer;
 }
 
 .slider-thumb {

--- a/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
@@ -511,7 +511,6 @@ export default Vue.extend({
   white-space: nowrap;
   user-select: none;
   text-align: center;
-  pointer-events: none;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 

--- a/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
@@ -22,9 +22,6 @@
           ref="sliderContainer"
           class="servo-slider"
           @mousedown="onSliderMouseDown"
-          @mousemove="onSliderMouseMove"
-          @mouseup="onSliderMouseUp"
-          @mouseleave="onSliderMouseUp"
           @touchstart="onTouchStart"
           @touchmove="onTouchMove"
           @touchend="onTouchEnd"
@@ -42,7 +39,7 @@
             class="slider-thumb"
             :class="{ active: activeThumb === index }"
             :style="{ left: `${getThumbPosition(index)}%` }"
-            @mousedown.stop="startDragging(index)"
+            @mousedown.stop.prevent="startDragging(index)"
           >
             <div class="thumb-label">
               {{ thumbType }}: {{ getThumbValue(index) }}
@@ -224,6 +221,10 @@ export default Vue.extend({
       this.updateParamValue('max', newValue)
     },
   },
+  beforeDestroy() {
+    window.removeEventListener('mousemove', this.onSliderMouseMove)
+    window.removeEventListener('mouseup', this.onSliderMouseUp)
+  },
   methods: {
     getParamByType(type: string): Parameter | undefined {
       if (!this.param?.name) return undefined
@@ -278,6 +279,8 @@ export default Vue.extend({
     startDragging(index: number): void {
       this.activeThumb = index
       this.isDragging = true
+      window.addEventListener('mousemove', this.onSliderMouseMove)
+      window.addEventListener('mouseup', this.onSliderMouseUp)
     },
     onSliderMouseDown(event: MouseEvent): void {
       const container = this.$refs.sliderContainer as HTMLElement
@@ -340,6 +343,8 @@ export default Vue.extend({
 
       this.isDragging = false
       this.activeThumb = -1
+      window.removeEventListener('mousemove', this.onSliderMouseMove)
+      window.removeEventListener('mouseup', this.onSliderMouseUp)
     },
     updateThumbValue(event: MouseEvent | Touch): void {
       if (!this.isDragging) return

--- a/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ServoFunctionRangeEditor.vue
@@ -37,7 +37,7 @@
           />
           <div
             v-for="(thumbType, index) in ['min', 'trim', 'max']"
-            v-show="thumbType !== 'trim' || trimParam"
+            v-show="thumbType !== 'trim' || resolvedTrimParam"
             :key="thumbType"
             class="slider-thumb"
             :class="{ active: activeThumb === index }"


### PR DESCRIPTION
Clicking the empty area around the servo range was changing trim instead of requiring a click on the track.