### PR TITLE
vehicle-setup: overview: refer to IMU, not INS

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
@@ -34,8 +34,8 @@
               :key="accelerometer.param"
             >
               <td><b>{{ accelerometer.deviceName ?? 'UNKNOWN' }}</b></td>
-              <td v-tooltip="'Inertial Navigation Sensor'">
-                INS
+              <td v-tooltip="'Inertial Measurement Unit'">
+                IMU
               </td>
               <td>{{ print_bus(accelerometer.busType) }} {{ accelerometer.bus }}</td>
               <td>{{ `0x${accelerometer.address}` }}</td>


### PR DESCRIPTION
An INS is a full [navigation system](https://en.wikipedia.org/wiki/Inertial_navigation_system), not a sensor to calibrate.

Raised by @dgudiel