### PR TITLE
[backport/1.4] vehicle-setup: overview: refer to IMU, not INS

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/OnboardSensors.vue
@@ -31,8 +31,8 @@
               :key="accelerometer.param"
             >
               <td><b>{{ accelerometer.deviceName ?? 'UNKNOWN' }}</b></td>
-              <td v-tooltip="'Inertial Navigation Sensor'">
-                INS
+              <td v-tooltip="'Inertial Measurement Unit'">
+                IMU
               </td>
               <td>{{ print_bus(accelerometer.busType) }} {{ accelerometer.bus }}</td>
               <td>{{ `0x${accelerometer.address}` }}</td>


### PR DESCRIPTION
This is a backport of #4193 into 1.4.
