### PR TITLE
[backport/1.4] kraken: check container exists before streaming logs to return 404

### DIFF
--- a/core/services/kraken/api/v2/routers/container.py
+++ b/core/services/kraken/api/v2/routers/container.py
@@ -56,6 +56,7 @@ async def fetch_log_by_container_name(container_name: str, timeout: Optional[int
     Fetch logs of a given container.
     If timeout is provided, the stream will be closed after no log line is received for the given timeout.
     """
+    await ContainerManager.get_running_container_by_name(container_name)
     stream = ContainerManager.get_container_log_by_name(container_name)
 
     if timeout is not None:


### PR DESCRIPTION
This is a backport of #4186 into 1.4.
