### PR TITLE
[backport/1.4] ardupilot-manager: return empty list on non-Linux flight controllers

### DIFF
--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -265,7 +265,8 @@ class AutoPilotManager(metaclass=Singleton):
         # The first column comes from https://ardupilot.org/dev/docs/sitl-serial-mapping.html
 
         if "serials" not in self.configuration:
-            assert isinstance(self._current_board, LinuxFlightController)
+            if not isinstance(self._current_board, LinuxFlightController):
+                return []
             return self._current_board.get_serials()
         serials = []
         for entry in self.configuration["serials"]:


### PR DESCRIPTION
This is a backport of #4184 into 1.4.
