### PR TITLE
[backport/1.4] Frontend: add BlueBoat power modules to drop-down

### DIFF
--- a/core/frontend/src/components/vehiclesetup/configuration/power/BatteryCard.vue
+++ b/core/frontend/src/components/vehiclesetup/configuration/power/BatteryCard.vue
@@ -323,6 +323,22 @@ const SENSOR_PRESETS: SensorPreset[] = [
     ampOffset: 0.330,
   },
   {
+    text: 'BlueBoat120 Power Module v2',
+    voltPin: 5,
+    currPin: 4,
+    voltMult: 11.000,
+    ampPerVolt: 37.8788,
+    ampOffset: 0.330,
+  },
+  {
+    text: 'BlueBoat120 Power Module v1',
+    voltPin: 5,
+    currPin: 4,
+    voltMult: 11.3,
+    ampPerVolt: 100.0,
+    ampOffset: 1.638,
+  },
+  {
     text: 'Navigator w/ Blue Robotics Power Sense Module',
     voltPin: 5,
     currPin: 4,


### PR DESCRIPTION
This is a backport of #4148 into 1.4.

(btw, I thought this was already in 1.4)