### PR TITLE
[1.4] core: Serve a fresh frontend after a version switch

### DIFF
--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -24,11 +24,11 @@ export default defineConfig(({ command, mode }) => {
     plugins: [
       vue(),
       VitePWA({
+        // Operators use plain HTTP (not a secure context), so Workbox never
+        // installs. registerType still injects registerSW.js so localhost /
+        // tunnel leftovers get this unregistering worker.
         registerType: 'autoUpdate',
-        devOptions: {
-          enabled: true,
-        },
-        includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
+        selfDestroying: true,
       }),
       Components({
         // generate `components.d.ts` global declarations

--- a/core/frontend/vite.config.js
+++ b/core/frontend/vite.config.js
@@ -116,7 +116,14 @@ export default defineConfig(({ command, mode }) => {
         ext: '.gz',
         threshold: 1024,
         deleteOriginFile: true,
-        filter: /\.(js|css|json|svg|txt|xml|wasm|glb)$/i,
+        filter: (file) => {
+          if (!/\.(js|css|json|svg|txt|xml|wasm|glb)$/i.test(file)) {
+            return false
+          }
+          // Keep sw.js as a real file. gzip_static prefers a leftover sw.js.gz from
+          // an incremental build, and try_files (if reintroduced) cannot see .gz.
+          return path.basename(file) !== 'sw.js'
+        },
       }),
       // Parse every shipped script, so a corrupt chunk fails the build instead of only breaking
       // the route that imports it at runtime, like 1.4.4-beta.14 shipped a source map as a chunk.
@@ -133,6 +140,11 @@ export default defineConfig(({ command, mode }) => {
             const { gunzipSync } = require('zlib')
             const { transformSync } = require('esbuild')
             const distPath = path.resolve(__dirname, 'dist')
+            // gzip_static prefers a leftover sw.js.gz over the uncompressed worker
+            const staleSwGz = path.join(distPath, 'sw.js.gz')
+            if (fs.existsSync(staleSwGz)) {
+              fs.unlinkSync(staleSwGz)
+            }
 
             const collectScripts = (dir) => fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
               const fullPath = path.join(dir, entry.name)

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -253,7 +253,6 @@ http {
 
         location / {
             root /home/pi/frontend;
-            try_files $uri $uri/ =404;
             autoindex on;
             # allow frontend to see files using json
             autoindex_format json;

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -205,18 +205,58 @@ http {
             proxy_pass http://127.0.0.1:9110/;
         }
 
+        # Exact locations omit try_files. gzip_static cannot serve a .gz when
+        # try_files looks for the uncompressed name first (workbox-*.js is
+        # gzip-only; /sw.js is kept uncompressed). /index.html and
+        # /manifest.webmanifest exist so the shell is never revalidated.
+        location = / {
+            rewrite ^ /index.html last;
+        }
+
+        location = /index.html {
+            root /home/pi/frontend;
+            etag off;
+            if_modified_since off;
+            add_header Last-Modified "" always;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+            add_header Access-Control-Allow-Origin * always;
+        }
+
+        location = /manifest.webmanifest {
+            root /home/pi/frontend;
+            default_type application/manifest+json;
+            etag off;
+            if_modified_since off;
+            add_header Last-Modified "" always;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+            add_header Access-Control-Allow-Origin * always;
+            error_page 404 = @pwa_not_found;
+        }
+
+        location ~ ^/(sw\.js|registerSW\.js)$ {
+            root /home/pi/frontend;
+            etag off;
+            if_modified_since off;
+            add_header Last-Modified "" always;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+            add_header Access-Control-Allow-Origin * always;
+            error_page 404 = @pwa_not_found;
+        }
+
+        # Content-hashed Workbox runtime; cache like /assets/.
+        location ~ ^/workbox-[^/]+\.js$ {
+            root /home/pi/frontend;
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+            add_header Access-Control-Allow-Origin * always;
+            error_page 404 = @pwa_not_found;
+        }
+
         location / {
             root /home/pi/frontend;
             try_files $uri $uri/ =404;
             autoindex on;
             # allow frontend to see files using json
             autoindex_format json;
-
-            # prevent caching of index.html
-            if ($uri = /index.html) {
-                add_header Last-Modified "";
-                add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
-            }
         }
 
         location /assets/ {
@@ -250,11 +290,21 @@ http {
             add_header Access-Control-Allow-Origin *;
         }
 
-        # Fallback location for Vue.js SPA - serves index.html with 404 status
+        # SPA deep links (404 + index.html). Header validators match /index.html;
+        # add_header needs always because the status is 404.
         location @fallback {
             root /home/pi/frontend;
+            etag off;
+            if_modified_since off;
+            add_header Last-Modified "" always;
             add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+            add_header Access-Control-Allow-Origin * always;
             try_files /index.html =404;
+        }
+
+        location @pwa_not_found {
+            add_header Access-Control-Allow-Origin * always;
+            return 404;
         }
 
         # Helper to redirect services to their port


### PR DESCRIPTION
## Summary

Operators reach BlueOS over plain HTTP (`http://192.168.2.2`, `http://blueos.local`). After updating BlueOS, the UI can still show the old pages until the cache is cleared. We reproduced this in Chromium, and the original report describes the same behavior in Google Chrome.

nginx was already sending `Cache-Control: no-store` on `/` and `/index.html`, but it also sent an `ETag`. The browser then revalidated with `If-None-Match`, nginx answered 304, and the browser kept its old copy of `index.html`.

This PR stops nginx from sending `ETag` and `Last-Modified` on those URLs, on the PWA files, and on the SPA fallback. The fallback is served as a 404, so those headers need nginx `always` or nginx drops them.

It also removes the `try_files` on the frontend root. That directive looks for an uncompressed file before `gzip_static` gets a chance to use the `.gz`, so gzip-only assets 404 and nginx returns the HTML shell instead.

### Uncompressed `sw.js`

This part only matters for local rebuilds. Docker builds the frontend in a fresh container, so `dist/` starts empty, and with `try_files` gone nginx serves `sw.js.gz` on its own. A deployed Docker image does not need an uncompressed `sw.js`.

Vite skips gzipping `sw.js` and deletes any leftover `sw.js.gz` because a second yarn/bun build into the same `dist/` can leave an old `.gz` beside the new file, and `gzip_static always` would serve the stale `.gz`. A deployed image never hits that. The file is also under 1 KiB, so a clean build would not gzip it anyway.

Fixes https://github.com/bluerobotics/BlueOS/issues/4202

Related: https://github.com/bluerobotics/BlueOS/issues/2224

## Test plan

- [x] `GET /index.html` returns `no-store` with no `ETag` and no `Last-Modified`; a later `If-Modified-Since` returns 200, not 304
- [x] Deep link `/tools/version-chooser` returns 404 HTML with the same cache headers and CORS (`add_header ... always`)
- [x] `GET /sw.js` returns JavaScript with `no-store`, not HTML; uncompressed in this tree, though a deployed image does not need that
- [x] A missing hashed script that used to fall through to the SPA is now a plain 404 with no `Location`
- [x] Version Chooser pull and apply of `joaoantoniocardoso/blueos-core:1.4-frontend-cache-across-versions` (`d86cf30c`); reloading without clearing the cache still shows that image as Running