### PR TITLE
core: commonwealth: Preserve response models in OpenAPI

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/utils/apis.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/apis.py
@@ -3,12 +3,12 @@ from typing import Any, Callable, Coroutine, Dict, Optional
 
 from commonwealth.utils.logs import stack_trace_message
 from fastapi import HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from loguru import logger
-from starlette.responses import Response as StarletteResponse
 
 
-class PrettyJSONResponse(StarletteResponse):
+class PrettyJSONResponse(JSONResponse):
     media_type = "application/json"
 
     def render(self, content: Any) -> bytes:

--- a/core/libs/commonwealth/src/commonwealth/utils/tests/test_apis.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/tests/test_apis.py
@@ -1,0 +1,21 @@
+from commonwealth.utils.apis import PrettyJSONResponse
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+class Payload(BaseModel):
+    value: str
+
+
+def test_pretty_json_response_uses_response_model_in_openapi_schema() -> None:
+    app = FastAPI(default_response_class=PrettyJSONResponse)
+
+    @app.get("/payload", response_model=Payload)
+    def get_payload() -> Payload:
+        return Payload(value="test")
+
+    response_schema = app.openapi()["paths"]["/payload"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+
+    assert response_schema == {"$ref": "#/components/schemas/Payload"}


### PR DESCRIPTION
`PrettyJSONResponse` inherits directly from Starlette's base `Response`. FastAPI therefore treats it as an arbitrary response when generating OpenAPI and describes successful responses as strings, even when a path operation explicitly declares a structured `response_model`. The runtime response remains valid JSON, leaving the published contract out of sync with the service.

This changes `PrettyJSONResponse` to inherit from `JSONResponse` while retaining its existing pretty-printing behaviour. FastAPI can now emit each path operation's declared response model in the generated OpenAPI schema. A regression test covers that contract.
