### PR TITLE
core: libs: commonwealth: Cover remaining apis helpers

### DIFF
--- a/core/libs/commonwealth/src/commonwealth/utils/tests/test_apis.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/tests/test_apis.py
@@ -1,5 +1,10 @@
-from commonwealth.utils.apis import PrettyJSONResponse
-from fastapi import FastAPI
+from commonwealth.utils.apis import (
+    GenericErrorHandlingRoute,
+    PrettyJSONResponse,
+    StackedHTTPException,
+)
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 
@@ -19,3 +24,53 @@ def test_pretty_json_response_uses_response_model_in_openapi_schema() -> None:
     ]
 
     assert response_schema == {"$ref": "#/components/schemas/Payload"}
+
+
+def test_pretty_json_response_render_indents_body() -> None:
+    body = PrettyJSONResponse({"a": 1, "b": 2}).body
+    assert body == b'{\n  "a": 1, \n  "b": 2\n}'
+
+
+def test_generic_error_handling_route_reraises_http_400() -> None:
+    app = FastAPI()
+    app.router.route_class = GenericErrorHandlingRoute
+
+    @app.get("/bad-request")
+    def bad_request() -> None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="bad")
+
+    response = TestClient(app).get("/bad-request")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "bad"
+
+
+def test_generic_error_handling_route_keeps_http_500() -> None:
+    app = FastAPI()
+    app.router.route_class = GenericErrorHandlingRoute
+
+    @app.get("/server-error")
+    def server_error() -> None:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="boom")
+
+    response = TestClient(app).get("/server-error")
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json()["detail"] == "boom"
+
+
+def test_generic_error_handling_route_wraps_unhandled_exception() -> None:
+    app = FastAPI()
+    app.router.route_class = GenericErrorHandlingRoute
+
+    @app.get("/unhandled")
+    def unhandled() -> None:
+        raise RuntimeError("unexpected")
+
+    response = TestClient(app).get("/unhandled")
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert "unexpected" in response.json()["detail"]
+
+
+def test_stacked_http_exception_includes_cause_message() -> None:
+    exception = StackedHTTPException(status_code=status.HTTP_404_NOT_FOUND, error=RuntimeError("missing"))
+    assert exception.status_code == status.HTTP_404_NOT_FOUND
+    assert "missing" in exception.detail

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "coverage==7.5.1",
+  "httpx==0.28.1",
   "nmeasim==1.1.1.0",
   "pytest==7.4.2",
   "pytest-cov==4.1.0",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -385,6 +385,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "httpx" },
     { name = "nmeasim" },
     { name = "pyelftools" },
     { name = "pyfakefs" },
@@ -432,6 +433,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = "==7.5.1" },
+    { name = "httpx", specifier = "==0.28.1" },
     { name = "nmeasim", specifier = "==1.1.1.0" },
     { name = "pyelftools", specifier = "==0.30" },
     { name = "pyfakefs", specifier = "==5.2.4" },
@@ -1023,6 +1025,34 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "uvicorn", specifier = "==0.38.0" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The OpenAPI test imported apis.py and dropped master under the coverage gate.