### PR TITLE
[1.4] kraken: Revert raise ExtensionNotFound when restarting uninstalled extension

### DIFF
--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -341,8 +341,6 @@ class Extension:
     @classmethod
     async def from_running(cls, identifier: str) -> "Extension":
         installed: List[Extension] = cast(List[Extension], await cls.from_settings(identifier))
-        if not installed:
-            raise ExtensionNotFound(f"Extension {identifier} not found")
 
         enabled = [ext for ext in installed if ext.source.enabled]
         if not enabled:


### PR DESCRIPTION
install() only catches ExtensionNotRunning, so first-time install dies with ExtensionNotFound.

Fix #4223