### PR TITLE
[1.4] Measure all production Python in the coverage gate

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -38,10 +38,12 @@ jobs:
         .hooks/pre-push
 
     - name: Upload coverage
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: htmlcov
+        if-no-files-found: ignore
 
 
   frontend-tests:

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -74,7 +74,6 @@ for arg in "$@"; do
 done
 
 echo "Running pre push hook!"
-repository_path=$(git rev-parse --show-toplevel)
 tag_name=$(git tag --points-at=HEAD | head -n 1)
 
 [ -n "$tag_name" ] && {
@@ -128,6 +127,6 @@ echo "Running mypy.."
 echo "$python_packages" | parallel 'mypy {} --cache-dir "{}/__mypycache__"'
 
 echo "Running pytest.."
-pytest -n 10 --durations=0 --cov="$repository_path" --cov-report html
+pytest -n 10 --durations=0 --cov --cov-report term --cov-report html
 
 exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,23 @@ markers = [
 
 [tool.coverage.run]
 branch = true
+source = [
+    "bootstrap",
+    "core",
+]
 omit = [
     "*/setup.py",
     "*/__init__.py",
-    ]
+    "*/test_*.py",
+    "*/tests/*",
+    "*/.venv/*",
+    "*/__mypycache__/*",
+]
 
 [tool.coverage.report]
-fail_under = 75
+fail_under = 15.5
+include_namespace_packages = true
+precision = 2
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Closes #4241

# Summary
- Coverage now measures every production module under `bootstrap`, `core/libs`, `core/services`, and `core/tools`, including services that tests never import.
- The old 75% gate only saw files a test imported, because coverage.py skips directories without `__init__.py` unless `include_namespace_packages` is on. That is why adding tests for wifi or `blueos_startup_update.py` dropped the number.
- `fail_under` is 15.5% (measured 15.57% of the full tree, tests omitted). Adding tests for previously unmeasured code raises the percentage instead of tanking it.
- CI prints the per-file table and uploads the HTML report even when python-tests fail.


## Test plan
- [x] `python-tests` on this PR reaches ~15.57% and passes the 15.5% gate
- [x] Coverage HTML artifact lists wifi, kraken, commander, helper, and `blueos_startup_update.py` (at 0% until they have tests)
- [x] A failed python-tests run still uploads the `coverage` artifact
- [x] Existing 90 pytest tests still pass
