### PR TITLE
[1.4] Fix System Information tabs going blank after Pirate Mode

### DIFF
--- a/core/frontend/src/views/SystemInformationView.vue
+++ b/core/frontend/src/views/SystemInformationView.vue
@@ -3,7 +3,7 @@
     height="100%"
   >
     <v-tabs
-      v-model="page_selected"
+      v-model="current_page"
       centered
       icons-and-text
       show-arrows
@@ -12,27 +12,19 @@
       <v-tab
         v-for="page in pages"
         :key="page.value"
+        :tab-value="page.value"
       >
         {{ page.title }}
         <v-icon>{{ page.icon }}</v-icon>
       </v-tab>
     </v-tabs>
-    <v-tabs-items v-model="page_selected">
-      <v-tab-item
-        v-for="(page, index) in pages"
-        :key="page.value"
-      >
-        <!-- Only mount the active tab so heavy consumers (kernel WS) tear down when leaving -->
-        <template v-if="page_selected === index">
-          <processes v-if="page.value === 'process'" />
-          <system-condition v-else-if="page.value === 'system_condition'" />
-          <network v-else-if="page.value === 'network'" />
-          <kernel v-else-if="page.value === 'kernel'" />
-          <firmware v-else-if="page.value === 'firmware'" />
-          <about-this-system v-else-if="page.value === 'about'" />
-        </template>
-      </v-tab-item>
-    </v-tabs-items>
+    <!-- Only mount the active tab so heavy consumers (kernel WS) tear down when leaving -->
+    <processes v-if="current_page === 'process'" />
+    <system-condition v-else-if="current_page === 'system_condition'" />
+    <network v-else-if="current_page === 'network'" />
+    <kernel v-else-if="current_page === 'kernel'" />
+    <firmware v-else-if="current_page === 'firmware'" />
+    <about-this-system v-else-if="current_page === 'about'" />
   </v-card>
 </template>
 
@@ -79,13 +71,22 @@ export default Vue.extend({
         },
         { title: 'About', icon: 'mdi-information', value: 'about' },
       ] as Item[],
-      page_selected: 0 as number,
+      page_value: 'system_condition',
     }
   },
   computed: {
     pages(): Item[] {
       return this.items
         .filter((item: Item) => item?.is_pirate !== true || this.settings.is_pirate_mode)
+    },
+    current_page: {
+      get(): string {
+        return this.pages.find((page) => page.value === this.page_value)?.value
+          ?? this.pages[0].value
+      },
+      set(value: string) {
+        this.page_value = value
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- Enabling Pirate Mode inserts the Kernel and Firmware tabs into System Information. Tab selection used a numeric index, so those panes (and About) rendered empty until a reload.
- Select tabs by page name (`tab-value`) and mount only the active pane, without `v-tabs-items`.

Fixes https://github.com/bluerobotics/BlueOS/issues/4237

## Test plan
- [x] Open System Information with Pirate Mode off, switch to About, then enable Pirate Mode. About should stay populated; Kernel and Firmware should show content without a reload.
- [x] Switch among System Monitor, Processes, Network, Kernel, Firmware, and About. Each pane should render.
- [x] Disable Pirate Mode while on Kernel or Firmware. The view should fall back to System Monitor instead of going blank.
