### PR TITLE
[1.4] helper: Fall back to TCP when ICMP ping is filtered

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -14,7 +14,7 @@ from enum import Enum
 from functools import cache
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -662,18 +662,80 @@ async def internet_test_previous_result() -> Any:
     return SPEED_TEST.results.dict()
 
 
+async def _tcp_reachable(host: str, ports: Tuple[int, ...], interface: Optional[str], timeout: float = 2.0) -> bool:
+    """TCP connect bound to an iface. Used when ICMP is filtered (amazon.com, etc).
+
+    `interface` is an iface name (`SO_BINDTODEVICE`) or an IPv4 source (`bind()`).
+    DNS uses the default route; only the TCP connect is bound.
+    """
+    event_loop = asyncio.get_running_loop()
+    try:
+        socket.inet_aton(host)
+        ips = [host]
+    except OSError:
+        try:
+            infos = await asyncio.wait_for(
+                event_loop.getaddrinfo(host, None, family=socket.AF_INET, type=socket.SOCK_STREAM),
+                timeout,
+            )
+        except (OSError, asyncio.TimeoutError):
+            return False
+        ips = list(dict.fromkeys(info[4][0] for info in infos))
+        if not ips:
+            return False
+
+    async def connect(ip: str, port: int) -> bool:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setblocking(False)
+        try:
+            if interface:
+                try:
+                    socket.inet_aton(interface)
+                except OSError:
+                    try:
+                        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, interface.encode() + b"\0")
+                    except PermissionError as exc:
+                        logger.warning(f"SO_BINDTODEVICE {interface}: {exc}")
+                        return False
+                else:
+                    sock.bind((interface, 0))
+            await asyncio.wait_for(event_loop.sock_connect(sock, (ip, port)), timeout)
+            return True
+        except (OSError, asyncio.TimeoutError):
+            return False
+        finally:
+            sock.close()
+
+    for ip in ips:
+        if any(await asyncio.gather(*(connect(ip, port) for port in ports))):
+            return True
+    return False
+
+
 @fast_api_app.get(
     "/ping",
-    summary="Ping a server using a specific interface.",
+    summary="Check that a host is reachable via a specific interface (ICMP, then TCP 80/443).",
 )
 @version(1, 0)
 async def ping(host: str, interface_addr: Optional[str] = None) -> bool:
     iface = ["-I", interface_addr] if interface_addr else []
     process = await asyncio.create_subprocess_exec(
-        "ping", "-c", "1", *iface, host, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        "ping",
+        "-c",
+        "1",
+        "-W",
+        "2",
+        "-n",
+        *iface,
+        host,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
     )
     await process.communicate()
-    return process.returncode == 0
+    if process.returncode == 0:
+        return True
+    # ICMP-deaf HTTP hosts (amazon.com, telemetry.blueos.cloud) still have internet.
+    return await _tcp_reachable(host, (80, 443), interface_addr)
 
 
 async def periodic() -> None:


### PR DESCRIPTION
## Summary

- `/ping` is used by the network-priority menu as a per-interface internet check, but it only sent ICMP.
- `check_internet_access` (the tray globe) is HTTP. Hosts like `amazon.com` and `telemetry.blueos.cloud` are HTTP-ok and ICMP-deaf, so every iface showed offline while the globe stayed online (`as_completed` order decides which host is pinged).
- After a 2s ICMP attempt, `/ping` now TCP-connects to ports 80 and 443 bound to the requested iface (`SO_BINDTODEVICE`, or `bind()` if an IP is passed).

This is complementary to #4183 (HTTP-check timeout / DNS hang). It does not change `reachable_hosts` or the frontend.

## Test plan

- [x] On a 1.4-dev vehicle, `GET /helper/latest/check_internet_access` lists `amazon.com` online
- [x] Before: `/helper/latest/ping?host=amazon.com&interface_addr=eth0` → `false`
- [x] After: same call → `true` in ~2s; `wlan0` (down) stays `false`; `192.0.2.1` stays `false`
- [x] With `iptables -I OUTPUT -p icmp -j DROP`, `/ping?host=1.1.1.1&interface_addr=eth0` still `true` via TCP
- [x] Force `reachable_hosts[0]='amazon.com'` in the UI: globe stays online, `eth0` green, down ifaces red
