### PR TITLE
[1.4] cable-guy: Do not persist unmanaged kernel routes onto ethernet

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -28,6 +28,8 @@ from typedefs import (
     NetworkInterfaceMetric,
     NetworkInterfaceMetricApi,
     Route,
+    managed_routes_only,
+    persist_managed_route,
 )
 
 # TODO: Replace this by `from pydantic import IPvAnyAddress, IPvAnyNetwork` once we update to pydantic v2
@@ -71,6 +73,15 @@ class EthernetManager:
     async def initialize(self) -> None:
         self.network_handler = await NetworkHandlerDetector().getHandler()
         logger.info("Loading previous settings.")
+        dropped_unmanaged = False
+        for item in self._settings.content:
+            managed = managed_routes_only(item.routes)
+            if len(managed) != len(item.routes):
+                item.routes = managed
+                dropped_unmanaged = True
+        if dropped_unmanaged:
+            logger.warning("Dropped unmanaged saved routes so they are not reapplied on ethernet.")
+            self.save()
         for item in self._settings.content:
             logger.info(f"Loading following configuration: {item}.")
             try:
@@ -140,7 +151,7 @@ class EthernetManager:
     def _set_routes_configuration(self, interface: NetworkInterface) -> None:
         try:
             current_routes = self.get_routes(interface.name, ignore_unmanaged=True)
-            desired_routes = interface.routes
+            desired_routes = managed_routes_only(interface.routes)
 
             # Remove old routes
             for current_route in current_routes:
@@ -657,23 +668,25 @@ class EthernetManager:
 
             act = "Removed" if action == "del" else "Added" if action == "add" else action
             logger.info(f"{act} route to {route.destination_parsed} via {gateway} on {interface_name}")
-        except NetlinkError as e:
-            if e.code == errno.EEXIST and action == "add":
-                logger.debug(
-                    f"Route {route.destination_parsed} via {gateway} on {interface_name} already exists, ignoring"
+        except NetlinkError as error:
+            already_present = error.code == errno.EEXIST and action == "add"
+            already_absent = error.code in (errno.ENOENT, errno.ESRCH) and action == "del"
+            if not already_present and not already_absent:
+                act = "Remove" if action == "del" else "Add" if action == "add" else action
+                logger.error(
+                    f"Failed to {act} route {route.destination_parsed} via {gateway} on {interface_name}: {error}"
                 )
-                return
-
-        except Exception as e:
+                raise
+            logger.debug(
+                f"Route {route.destination_parsed} via {gateway} on {interface_name} already "
+                f"{'exists' if already_present else 'absent'}, persisting anyway"
+            )
+        except Exception as error:
             act = "Remove" if action == "del" else "Add" if action == "add" else action
-            logger.error(f"Failed to {act} route {route.destination_parsed} via {gateway} on {interface_name}: {e}")
+            logger.error(f"Failed to {act} route {route.destination_parsed} via {gateway} on {interface_name}: {error}")
             raise
 
-        # Update settings
-        current_interface.routes = list(self.get_routes(interface_name, ignore_unmanaged=False))
-        for current_route in current_interface.routes:
-            if current_route.destination_parsed == route.destination_parsed and current_route.gateway == route.gateway:
-                current_route.managed = route.managed
+        current_interface.routes = persist_managed_route(current_interface.routes, action, route)
         self._update_interface_settings(interface_name, current_interface)
 
     def get_routes(self, interface_name: str, ignore_unmanaged: bool = True) -> Set[Route]:

--- a/core/services/cable_guy/test_route_persist.py
+++ b/core/services/cable_guy/test_route_persist.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+_CABLE_GUY_DIR = str(Path(__file__).resolve().parent)
+sys.path.insert(0, _CABLE_GUY_DIR)
+# Root pytest also finds other services' top-level modules (e.g. ardupilot_manager/typedefs.py).
+_mod = sys.modules.get("typedefs")
+if _mod is not None and not str(getattr(_mod, "__file__", "")).startswith(_CABLE_GUY_DIR):
+    del sys.modules["typedefs"]
+
+from typedefs import Route, managed_routes_only, persist_managed_route
+
+MULTICAST = Route(destination="224.0.0.0/4", gateway=None, priority=None, managed=True)
+LAN = Route(destination="192.168.0.0/24", gateway=None, priority=None, managed=False)
+DEFAULT = Route(destination="0.0.0.0/0", gateway="192.168.0.1", priority=None, managed=False)
+USER = Route(destination="10.0.0.0/8", gateway="192.168.2.1", priority=100, managed=False)
+
+
+def test_migration_drops_unmanaged_and_keeps_multicast() -> None:
+    assert managed_routes_only([LAN, DEFAULT, MULTICAST]) == [MULTICAST]
+
+
+def test_apply_input_never_includes_dhcp_or_connected_routes() -> None:
+    desired = managed_routes_only([DEFAULT, LAN, MULTICAST])
+    assert DEFAULT not in desired
+    assert LAN not in desired
+    assert MULTICAST in desired
+
+
+def test_add_merges_managed_and_strips_unmanaged() -> None:
+    saved = persist_managed_route([MULTICAST, LAN, DEFAULT], "add", USER)
+    assert MULTICAST in saved
+    assert LAN not in saved
+    assert DEFAULT not in saved
+    owned = next(route for route in saved if route.destination == USER.destination)
+    assert owned.managed is True
+    assert owned.priority == 100
+
+
+def test_add_persists_when_kernel_already_has_route() -> None:
+    saved = persist_managed_route([MULTICAST], "add", MULTICAST)
+    assert saved == [MULTICAST]
+    assert saved[0].managed is True
+
+
+def test_delete_removes_only_matching_managed_route() -> None:
+    extra = Route(destination="10.1.0.0/16", gateway=None, priority=None, managed=True)
+    saved = persist_managed_route([MULTICAST, extra, LAN], "del", extra)
+    assert saved == [MULTICAST]
+
+
+def test_route_identity_is_destination_and_gateway() -> None:
+    unmanaged_copy = Route(destination="224.0.0.0/4", gateway=None, priority=None, managed=False)
+    other_metric = Route(destination="224.0.0.0/4", gateway=None, priority=50, managed=True)
+    assert unmanaged_copy == MULTICAST
+    assert other_metric == MULTICAST

--- a/core/services/cable_guy/typedefs.py
+++ b/core/services/cable_guy/typedefs.py
@@ -85,6 +85,25 @@ class Route(BaseModel):
         return ip_network(self.destination).is_multicast
 
 
+def managed_routes_only(routes: List[Route]) -> List[Route]:
+    return [route for route in routes if route.managed]
+
+
+def persist_managed_route(saved: List[Route], action: str, route: Route) -> List[Route]:
+    """Keep only cable-guy-owned routes; never snapshot kernel/DHCP/connected routes."""
+    owned = [saved_route for saved_route in saved if saved_route.managed and saved_route != route]
+    if action == "add":
+        owned.append(
+            Route(
+                destination=route.destination,
+                gateway=route.gateway,
+                priority=route.priority,
+                managed=True,
+            )
+        )
+    return owned
+
+
 class NetworkInterfaceV1(BaseModel):
     name: str
     addresses: List[InterfaceAddress]


### PR DESCRIPTION
## Summary

- cable-guy snapshots every kernel route it sees on an interface into `settings-2.json`, then reapplies the whole list on boot as `proto static` metric 0.
- Unmanaged prefixes that only exist on WiFi (connected `/24`, DHCP default, host `/32`s) get saved as ethernet routes. After reboot they steal that subnet from `wlan0`: the vehicle still has internet, but the WiFi IP is unreachable from the LAN.
- This keeps settings as an ownership list: persist and apply only `managed=True` routes (the multicast `224.0.0.0/4` default stays). On load, drop already-saved unmanaged routes so polluted devices recover without a manual settings edit.
- Add/delete no longer dumps the kernel table back into settings. `EEXIST` on add still records the managed route. `ENOENT`/`ESRCH` on delete is treated as already gone and still updates settings.
- Other netlink failures on add/delete now raise instead of being swallowed while settings were still rewritten. Use `POST /cable-guy/v1.0/route` to add a route; that path marks it managed. A GET+POST of the full ethernet payload would send kernel connected routes as `managed=False` and those are ignored on purpose.

Related but different: #3996 ignores `RTPROT_KERNEL` connected routes and deletes an orphaned `/24` when an IP is removed. That does not stop unmanaged `proto static`/`boot` WiFi prefixes from being saved and reapplied on ethernet.

## Test plan

- [x] Pi 4 at `192.168.2.2` on 1.4-dev: polluted `settings-2.json` had `192.168.0.0/24` and `default via 192.168.0.1` on eth0; `ip route get 192.168.0.10` used `dev eth0 src 192.168.2.2`
- [x] After this change: restoring that backup and restarting cable-guy left only managed `224.0.0.0/4`; `ip route get 192.168.0.10` is unreachable
- [x] `POST`/`DELETE` `/cable-guy/v1.0/route` of `239.255.0.0/16` only changed that managed route; kernel connected `192.168.2.0/24` `/32`s were not saved
- [x] `python3 -m pytest core/services/cable_guy/test_route_persist.py` (CI python-tests green after fixing the `typedefs` import clash with ardupilot-manager)