### PR TITLE
[1.4] cable-guy: Apply POST /route priority to kernel metric

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import asyncio
 import errno
 import re

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -663,7 +663,7 @@ class EthernetManager:
                 oif=interface_index,
                 dst=str(route.destination_parsed),
                 gateway=str(gateway) if gateway else None,
-                metrics={"metric": route.priority} if route.priority else None,
+                priority=route.priority if action == "add" else None,
             )
 
             act = "Removed" if action == "del" else "Added" if action == "add" else action


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluerobotics/BlueOS/issues/4248.

`POST /cable-guy/v1.0/route` accepted `priority` but `_execute_route` passed it as `metrics={"metric": ...}`. pyroute2 0.7.12 ignores that key, so the kernel route had no metric and `GET /route` reported `priority: null`.

Use the `priority=` kwarg to `ipr.route()` on **add** only (same as `set_interfaces_priority_using_ipr` for default routes). Omit `priority` on delete so GET→DELETE cannot fail when settings carry a priority the kernel route never had.

Rebased onto `1.4-dev` after #4246 merged. Kept `persist_managed_route` (it already copies `route.priority` on add). Dropped this PR's old kernel-dump settings sync so unmanaged routes stay out of settings.

Verified on DUT `192.168.2.2` (reached as `192.168.0.124` on the same eth0): `ip route show` reports `metric N` and `GET /route` round-trips `priority: N`.

Also fall back to saved priority in `get_routes` when the kernel omits `RTA_PRIORITY`.

## Test plan

- [x] Repro on DUT (usb0, dummy `10.66.66.0/24`, gateway `192.168.3.1`)
- [x] After rebase: POST `priority: 50` → kernel `metric 50`, GET returns `priority: 50`
- [x] DELETE via GET body removes route; MGMT still reachable
- [x] GET `/interfaces`, GET `/route` on wlan0 (no-op POST), GET `/ethernet`
- [x] `persist_managed_route` unit tests still pass (priority 100 copied on add)

## Out of scope (pre-existing)

- `EEXIST` on add still does not update an existing kernel route's metric; #4246 persists the requested priority anyway
- `/ethernet` GET+POST round-trip ignores route `priority` because `Route.__eq__` omits it