### PR TITLE
[1.4] commonwealth: Return 422 for missing required API fields

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/apis.py
+++ b/core/libs/commonwealth/commonwealth/utils/apis.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Callable, Coroutine, Dict, Optional
 
 from fastapi import HTTPException, Request, Response, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 from loguru import logger
 from starlette.responses import Response as StarletteResponse
@@ -33,6 +34,8 @@ class GenericErrorHandlingRoute(APIRoute):
                 if error.status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR:
                     logger.exception(error)
                 raise error
+            except RequestValidationError:
+                raise
             except Exception as error:
                 logger.error("Unhandled service exception.")
                 logger.exception(error)


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluerobotics/BlueOS/issues/4247.

`GenericErrorHandlingRoute` caught `RequestValidationError` in its broad `except Exception` handler and re-raised HTTP 500 with a stringified pydantic error. Missing required query/body fields on cable-guy `/route` (and every other service using this route class) should be a client error.

Re-raise `RequestValidationError` so FastAPI's default handler returns HTTP 422 with the standard `detail` array.

Verified on DUT `192.168.2.2` (`docker cp` into `blueos-core` + restart):

- `GET /cable-guy/v1.0/route` → **422** (was 500)
- `POST /cable-guy/v1.0/route` with `{}` → **422** (was 500)
- `GET /cable-guy/v1.0/route?interface_name=eth0` → **200**; MGMT (`eth0` / `192.168.2.2`) still reachable

**Adjacent PRs (different bugs):** #4246 (managed route persistence), #4249 (route priority metric). This change only touches `commonwealth/utils/apis.py` — no conflict with those manager changes.

## Test plan

- [x] Live repro on `192.168.2.2`: missing `interface_name` / `destination` return 422 with FastAPI validation JSON
- [x] Valid `GET /route?interface_name=eth0` still 200; ping MGMT OK
- [x] `./.hooks/pre-push --fix` + `./.hooks/pre-push` (85 passed; 4 env-dependent hardware-id tests failed locally as before)
