### PR TITLE
[1.4] core: services: cable_guy: api: manager: Disable too-many-lines

### DIFF
--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import asyncio
 import errno
 import ipaddress


### PR DESCRIPTION
manager.py is 1002 lines after #4252, over pylint's 1000 limit.