### PR TITLE
[master] Measure all production Python in the coverage gate

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -39,10 +39,12 @@ jobs:
         .hooks/pre-push
 
     - name: Upload coverage
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: coverage
         path: ./core/htmlcov
+        if-no-files-found: ignore
 
 
   frontend-tests:

--- a/.hooks/lib/python_checks.sh
+++ b/.hooks/lib/python_checks.sh
@@ -3,7 +3,6 @@
 declare -a isort_args=()
 declare -a black_args=()
 : "${fixing:=false}"
-: "${DEFAULT_COVERAGE_FAIL_UNDER:=73}"
 
 setup_python_environment() {
     local env_label="$1"
@@ -84,9 +83,7 @@ run_python_checks() {
     fi
 
     echo "Running pytest (${env_label}).."
-    local pytest_args=(-n 10 --durations=0 --cov="$ROOT_DIR" --cov-report html)
-    local coverage_threshold="${COVERAGE_FAIL_UNDER_OVERRIDE:-$DEFAULT_COVERAGE_FAIL_UNDER}"
-    pytest_args+=(--cov-fail-under "$coverage_threshold")
+    local pytest_args=(-n 10 --durations=0 --cov --cov-report term --cov-report html)
     local ignore_path
     for ignore_path in "${pytest_ignores[@]}"; do
         [[ -z "$ignore_path" ]] && continue
@@ -106,17 +103,11 @@ run_environment_phase() {
     local pytest_ignores_ref="$3"
     local pytest_targets_ref="$4"
     local run_bootstrap="${5:-false}"
-    local coverage_threshold="${6:-}"
 
     (
         setup_python_environment "$env_label" "$project_dir"
         if [ "$run_bootstrap" = true ]; then
             bootstrap_runtime_dependencies
-        fi
-        if [ -n "$coverage_threshold" ]; then
-            COVERAGE_FAIL_UNDER_OVERRIDE="$coverage_threshold"
-        else
-            unset COVERAGE_FAIL_UNDER_OVERRIDE
         fi
         run_python_checks "$env_label" "$pytest_ignores_ref" "$pytest_targets_ref"
     )

--- a/.hooks/lib/python_checks.sh
+++ b/.hooks/lib/python_checks.sh
@@ -83,7 +83,14 @@ run_python_checks() {
     fi
 
     echo "Running pytest (${env_label}).."
-    local pytest_args=(-n 10 --durations=0 --cov --cov-report term --cov-report html)
+    local pytest_args=(
+        -n 10
+        --durations=0
+        --cov="$CORE_DIR"
+        --cov="$ROOT_DIR/bootstrap"
+        --cov-report term
+        --cov-report html
+    )
     local ignore_path
     for ignore_path in "${pytest_ignores[@]}"; do
         [[ -z "$ignore_path" ]] && continue

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -89,13 +89,23 @@ markers = [
 
 [tool.coverage.run]
 branch = true
+source = [
+  ".",
+  "../bootstrap",
+]
 omit = [
   "*/setup.py",
   "*/__init__.py",
+  "*/test_*.py",
+  "*/tests/*",
+  "*/.venv/*",
+  "*/__mypycache__/*",
 ]
 
 [tool.coverage.report]
-fail_under = 74
+fail_under = 10.8
+include_namespace_packages = true
+precision = 2
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Port of #4240 into `master`, adapted.

Closes #4241.