### PR TITLE
[1.4] kraken: Return 404 when restarting an uninstalled extension

### DIFF
--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -154,7 +154,7 @@ class Extension:
             running_ext = await self.from_running(self.identifier)
             if running_ext:
                 await running_ext.disable()
-        except ExtensionNotRunning:
+        except (ExtensionNotRunning, ExtensionNotFound):
             pass
 
         new_extension = ExtensionSettings(
@@ -341,6 +341,8 @@ class Extension:
     @classmethod
     async def from_running(cls, identifier: str) -> "Extension":
         installed: List[Extension] = cast(List[Extension], await cls.from_settings(identifier))
+        if not installed:
+            raise ExtensionNotFound(f"Extension {identifier} not found")
 
         enabled = [ext for ext in installed if ext.source.enabled]
         if not enabled:


### PR DESCRIPTION
Fixes #4160.

`POST /kraken/v2.0/extension/{identifier}/restart` for a never-installed identifier returned HTTP 400 (`have no running versions`) instead of HTTP 404 (`not found`). The same helper is used by disable.

#4185 fixed `from_running` only. That broke first-time installs (#4223) because `install()` calls `from_running` to disable a running sibling and only caught `ExtensionNotRunning`. Reverted in #4226.

This restores the 404 for an empty install list, and also catches `ExtensionNotFound` in `install()` so a first-time install still proceeds.

Installed-but-disabled still returns 400. A running identifier can still be restarted.

When this is moved to master, `_disable_running_extension` must catch `ExtensionNotFound` as well. Copying only the `from_running` two-liner will repeat #4223.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`), patched `extension.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: unknown restart → 400
- [x] After patch: unknown restart v1 and v2 → 404
- [x] Unknown disable → 404
- [x] Installed but disabled → 400
- [x] Tagged uninstall of an unknown id → 404 (unchanged)

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2` (the #4223 install path). `major_tom` left installed. 58/58 checks passed.

- [x] v1 `POST /extension/install` (UI path) of a never-installed id → 200 pull stream, not 404 `Extension … not found`
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200 (not 500)
- [x] v1 uninstall → 200; restart of that id → 404
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] v2 `DELETE /extension/{id}` → 202, container gone
- [x] Reinstall while already running → 200, not 404 (covers `from_running` finding a sibling)
- [x] v1 `update_to_version` of the installed tag → 200, still running
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- v1 enable of an unknown identifier still 500 (`list index out of range`). Pre-existing, not this helper. #4265
- Unknown `GET /{identifier}/details` still 200 `[]`. Pre-existing. #4267
- Unknown untagged uninstall still 202 on an empty gather. Pre-existing. #4266
