### PR TITLE
[1.4] kraken: Return 404 when enabling an unknown extension

### DIFF
--- a/core/services/kraken/api/v1/routers/extension.py
+++ b/core/services/kraken/api/v1/routers/extension.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 from fastapi_versioning import versioned_api_route
 
 from api.v2.routers.extension import extension_to_http_exception
+from extension.exceptions import ExtensionNotFound
 from extension.extension import Extension
 from extension.models import ExtensionSource
 
@@ -43,6 +44,8 @@ async def update_extension(extension_identifier: str, new_version: str) -> Strea
 @extension_to_http_exception
 async def enable_extension(extension_identifier: str) -> Any:
     extension = cast(List[Extension], await Extension.from_settings(extension_identifier))
+    if not extension:
+        raise ExtensionNotFound(f"Extension {extension_identifier} not found")
     await extension[0].enable()
 
 


### PR DESCRIPTION
Fixes #4265.

`POST /kraken/v1.0/extension/enable?extension_identifier={identifier}` for a never-installed identifier returned HTTP 500 (`list index out of range`) instead of HTTP 404 (`not found`).

v1 enable loads settings by identifier and indexes `[0]` with no empty-list check. Tagged v2 enable already 404s because `from_settings(identifier, tag)` raises `ExtensionNotFound` when both are supplied.

This raises `ExtensionNotFound` when that list is empty. The existing `extension_to_http_exception` decorator maps it to 404.

This does not change `from_settings` or `from_running`. Folding the empty-list check into identifier-only `from_settings` would also change unknown uninstall and `GET /{id}/details`, and `from_running` is the helper that 404'd first-time installs in #4185 / #4223.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`), patched `api/v1/routers/extension.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: unknown v1 enable → 500 `list index out of range`
- [x] After patch: unknown v1 enable → 404 `Extension np.no.such.extension not found`
- [x] Unknown tagged v2 enable → 404 (unchanged)
- [x] Installed v1 enable of Cockpit → 200, container comes back

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 112/112 checks passed.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200 (not 500)
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- Unknown `GET /{identifier}/details` still 200 `[]`. Pre-existing. #4267
- Unknown untagged uninstall still 202 on an empty gather. Pre-existing. #4266
