### PR TITLE
[1.4] kraken: Return 404 when uninstalling an unknown extension

### DIFF
--- a/core/services/kraken/api/v1/routers/extension.py
+++ b/core/services/kraken/api/v1/routers/extension.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 from fastapi_versioning import versioned_api_route
 
 from api.v2.routers.extension import extension_to_http_exception
+from extension.exceptions import ExtensionNotFound
 from extension.extension import Extension
 from extension.models import ExtensionSource
 
@@ -29,6 +30,8 @@ async def install_extension(body: ExtensionSource) -> StreamingResponse:
 @extension_to_http_exception
 async def uninstall_extension(extension_identifier: str) -> Any:
     extensions = cast(List[Extension], await Extension.from_settings(extension_identifier))
+    if not extensions:
+        raise ExtensionNotFound(f"Extension {extension_identifier} not found")
     await asyncio.gather(*[ext.uninstall() for ext in extensions])
 
 

--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -162,6 +162,8 @@ async def uninstall(identifier: str) -> None:
     Uninstall all versions of an extension by its identifier.
     """
     extensions = cast(List[Extension], await Extension.from_settings(identifier))
+    if not extensions:
+        raise ExtensionNotFound(f"Extension {identifier} not found")
     await asyncio.gather(*[ext.uninstall() for ext in extensions])
 
 


### PR DESCRIPTION
Fixes #4266.

`DELETE /kraken/v2.0/extension/{identifier}` for a never-installed identifier returned HTTP 202 with a null body. v1 `POST /kraken/v1.0/extension/uninstall` had the same empty-gather path (HTTP 200). Tagged uninstall already 404s because `from_settings(identifier, tag)` raises `ExtensionNotFound` when both are supplied.

Identifier-only `from_settings` returns an empty list when nothing is installed. Both uninstall handlers then gathered uninstall on that list and succeeded. Clients could not tell a missing extension from a successful uninstall.

This raises `ExtensionNotFound` when that list is empty. The existing `extension_to_http_exception` decorator maps it to 404.

This does not change `from_settings` or `from_running`. Folding the empty-list check into identifier-only `from_settings` would also 404 `GET /{id}/details` (currently 200 `[]`) and would 404 first-time installs via `from_running` (the #4185 / #4223 regression). `install()` remaining-tag cleanup calls `uninstall()` on `Extension` objects, not these HTTP handlers.

Independent of #4268 (unknown v1 enable). Both add the same `ExtensionNotFound` import in the v1 router; rebase whichever lands second.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`), patched `api/v1/routers/extension.py` and `api/v2/routers/extension.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: unknown v2 `DELETE /{id}` → 202 `null`; unknown v1 uninstall → 200 `null`
- [x] After patch: both → 404 `Extension np.no.such.extension not found`
- [x] Unknown tagged v2 uninstall → 404 (unchanged)
- [x] Unknown `GET /{id}/details` → 200 `[]` (unchanged)

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 108/108 checks passed.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200
- [x] v1 uninstall of installed Cockpit → 200, container gone
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v2 tagged uninstall of installed Cockpit → 202
- [x] v2 identifier uninstall of installed Cockpit → 202
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- Unknown v1 enable still 500 `list index out of range`. Pre-existing. #4265 / #4268
- Unknown `GET /{identifier}/details` still 200 `[]`. Pre-existing. #4267
