### PR TITLE
[1.4] kraken: Return 404 when fetching details of an unknown extension

### DIFF
--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -59,6 +59,8 @@ async def fetch_by_identifier(identifier: str) -> list[ExtensionSource]:
     List details of all versions of a given extension.
     """
     extensions = cast(List[Extension], await Extension.from_settings(identifier))
+    if not extensions:
+        raise ExtensionNotFound(f"Extension {identifier} not found")
     return [ext.source for ext in extensions]
 
 


### PR DESCRIPTION
Fixes #4267.

`GET /kraken/v2.0/extension/{identifier}/details` for a never-installed identifier returned HTTP 200 with body `[]`. Tagged details already 404 because `from_settings(identifier, tag)` raises `ExtensionNotFound` when both are supplied.

Identifier-only `from_settings` returns an empty list when nothing is installed. The details handler serialized that list as success. Clients could not tell a missing extension from an installed extension with no versions in settings.

This raises `ExtensionNotFound` when that list is empty. The existing `extension_to_http_exception` decorator maps it to 404.

This does not change `from_settings` or `from_running`. Folding the empty-list check into identifier-only `from_settings` would also 404 first-time installs via `from_running` (the #4185 / #4223 regression). `GET /kraken/v2.0/extension/` (list all) is unchanged and still returns 200 `[]` when nothing is installed.

Independent of #4268 (unknown v1 enable) and #4269 (unknown uninstall). Those PRs touch other handlers; this only edits `fetch_by_identifier`.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`), patched `api/v2/routers/extension.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: unknown `GET /{id}/details` → 200 `[]`
- [x] After patch: unknown `GET /{id}/details` → 404 `Extension np.no.such.extension not found`
- [x] Unknown tagged `GET /{id}/{tag}/details` → 404 (unchanged)
- [x] Installed `GET /{id}/details` for `blueos.major_tom` → 200, one item

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 108/108 checks passed.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag → 200
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- Unknown v1 enable still 500 `list index out of range`. Pre-existing. #4265 / #4268
- Unknown untagged uninstall still 202 on an empty gather. Pre-existing. #4266 / #4269