### PR TITLE
[1.4] kraken: Look up latest version with optional v-prefix

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -288,7 +288,7 @@ class ManifestManager:
 
         versions = await self.fetch_extension_versions(extension_id, stable, manifest_id)
 
-        return ext.versions.get(str(versions[0])) if versions else None
+        return (ext.versions.get(str(versions[0])) or ext.versions.get(f"v{versions[0]}")) if versions else None
 
     async def fetch_extension_version(self, extension_id: str, tag: str) -> Optional[ExtensionVersion]:
         ext = await self.fetch_extension(extension_id)


### PR DESCRIPTION
Fixes #4271.

`POST /kraken/v2.0/extension/{identifier}/install` and `PUT /kraken/v2.0/extension/{identifier}` resolve the latest semver, then look up `ext.versions.get(str(versions[0]))`. Production tags are stored with a `v` prefix (`v1.18.2`), so `str(semver)` (`1.18.2`) misses and the handler raises `ExtensionNotFound`.

This is the same lookup as #3750 on master, which never landed on `1.4-dev`. Tagged install is unchanged because it uses the raw tag string.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`), patched `manifest/manifest.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: latest install `stable=false` → 404 `Extension bluerobotics.cockpit has noversions`
- [x] Before patch: PUT latest `stable=false` → 404 same
- [x] Before patch: latest install `stable=true` → 404 `has nostableversions`
- [x] After patch: latest install `stable=true` → 200, installed `v1.18.0`
- [x] After patch: PUT latest while installed → 200
- [x] Unknown identifier latest install/PUT still 404 `not found`

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 119/119 checks passed.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v2 PUT alt tag and back to primary
- [x] v2 `POST /extension/{id}/install` (`from_latest`, `stable=true`) of a never-installed id → 200, not 404
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- `stable=true` still drops tags whose patch component is not 0, so "latest stable" is `v1.18.0` rather than `v1.18.2`. Pre-existing. #4272
- Unknown v1 enable still 500 `list index out of range`. Pre-existing. #4265
- Unknown untagged uninstall still 202 on an empty gather. Pre-existing. #4266
