### PR TITLE
[1.4] kraken: Keep non-zero patch tags in latest-stable

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -275,7 +275,7 @@ class ManifestManager:
 
         versions: List[semver.VersionInfo] = sorted([valid_semver(tag) for tag in ext.versions], reverse=True)
         if stable:
-            versions = [v for v in versions if not v.prerelease and not v.patch]
+            versions = [v for v in versions if not v.prerelease]
 
         return versions
 


### PR DESCRIPTION
Fixes #4272.

`fetch_extension_versions(..., stable=True)` kept only tags that were both non-prerelease **and** `patch == 0`. That drops `1.18.2`, `1.0.10`, and every other `x.y.N` with `N != 0`, so "latest stable" becomes the newest `x.y.0`.

Treat stable as "no prerelease" only.

The v-prefix dict lookup in `fetch_latest_extension_version` (`get(str(semver))` vs keys like `v1.18.2`) is a different miss, tracked by #4271 / #4274. This change does not include that lookup. On stock `1.4-dev`, `GET /manifest/tags?stable=true` is fixed by this PR; `POST /{id}/install?stable=true` and `PUT /{id}?stable=true` still 404 until #4274 lands.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`, management `eth0`), patched `manifest/manifest.py` via container sed + `docker restart blueos-core`. The live container also had the #4274 v-prefix lookup from an earlier session.

- [x] Before patch: `GET /kraken/v2.0/manifest/tags/bluerobotics.cockpit?stable=true` → `["1.18.0"]` (latest non-prerelease is `1.18.2`)
- [x] Before patch: `GET .../bluerobotics.water-linked-dvl?stable=true` → `["1.0.0"]` (latest is `1.0.10`)
- [x] Before patch: `POST /kraken/v2.0/extension/bluerobotics.cockpit/install?stable=true` installed `v1.18.0`; restored to only `major_tom`
- [x] After patch: cockpit `stable=true` → `["1.18.2","1.18.1","1.18.0"]`; DVL `stable=true` → `["1.0.10",...,"1.0.0"]`; `stable=false` still lists prereleases first
- [x] After patch: latest install `stable=true` → 200, installed `v1.18.2` (not `v1.18.0`)
- [x] After patch: PUT latest `stable=true` while installed → 200, stayed on `v1.18.2`
- [x] `major_tom` left installed; management address still pings

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. 115/115 checks passed.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v2 PUT alt tag and back to primary
- [x] v2 `POST /extension/{id}/install` (`from_latest`, `stable=true`) of a never-installed id → 200, installed `v1.18.2`
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- Stock `1.4-dev` latest-install still 404s on `get(str(semver))` until #4274. Pre-existing. #4271
- Unknown v1 enable still 500 `list index out of range`. Pre-existing. #4265
- Unknown untagged uninstall still 202 on an empty gather. Pre-existing. #4266
