### PR TITLE
[1.4] kraken: Return 404 when streaming logs of a missing container

### DIFF
--- a/core/services/kraken/api/v1/routers/index.py
+++ b/core/services/kraken/api/v1/routers/index.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, status
 from fastapi.responses import PlainTextResponse, RedirectResponse, StreamingResponse
 from fastapi_versioning import versioned_api_route
 
+from api.v2.routers.container import container_to_http_exception
 from extension.extension import Extension
 from extension.models import ExtensionSource
 from harbor import ContainerManager
@@ -37,11 +38,13 @@ async def list_containers() -> Any:
 
 
 @index_router_v1.get("/log", status_code=status.HTTP_200_OK, response_class=PlainTextResponse)
+@container_to_http_exception
 async def log_containers(container_name: str, timeout: Optional[int] = None) -> StreamingResponse:
     """
     Fetch logs of a given container.
     If timeout is provided, the stream will be closed after no log line is received for the given timeout.
     """
+    await ContainerManager.get_running_container_by_name(container_name)
     stream = ContainerManager.get_container_log_by_name(container_name)
 
     if timeout is not None:


### PR DESCRIPTION
Fixes #4273.

`GET /kraken/v1.0/log?container_name={name}` for a container that does not exist returned HTTP 200 and started a stream. The 404, if it appeared at all, was a JSON fragment in the body after headers were sent.

v1 built a `StreamingResponse` around `ContainerManager.get_container_log_by_name` without resolving the container first. Docker lookup (and `ContainerNotFound`) only ran on the first yield. The default path also sent heartbeats, so a client could see 200 with no HTTP error.

v2 `GET /kraken/v2.0/container/{name}/log` already awaits `get_running_container_by_name` before constructing the stream (#4186, 1.4 backport #4197). This applies the same pre-check on v1 and maps `ContainerNotFound` to HTTP 404 via the existing `container_to_http_exception` decorator (same pattern as v1 extension handlers importing `extension_to_http_exception` from v2).

This does not change harbor or the v2 log route. A lookup still happens again on first yield inside `get_container_log_by_name`; if the container disappears in that window, the 404 is still a stream fragment (same as shipped v2).

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`, mgmt `eth0`), patched `api/v1/routers/index.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: unknown v1 `GET /log?container_name=extension-nosuchcontainerlifecycle&timeout=2` → HTTP 200, body fragment `status: 404`
- [x] Before patch: unknown v1 `GET /log` (heartbeat path, no timeout) → HTTP 200
- [x] After patch: unknown v1 log (timeout=2 and no-timeout) → HTTP 404 `Container extension-nosuchcontainerlifecycle not found in running containers`
- [x] Unknown v2 container log → 404 (unchanged)
- [x] Installed `extension-publicecrawsblueosbcloudagent20260211` v1/v2 logs → 200

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 115/115 checks passed.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag → 200
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- Local `try/except ContainerNotFound` instead of importing `container_to_http_exception` from v2. Behavior matches shipped v2; v1 extension.py already imports the v2 extension decorator. No lockout or data loss.
- Unknown v1 enable still 500 `list index out of range`. Pre-existing. #4265 / #4268
- Unknown untagged uninstall still 202 on an empty gather. Pre-existing. #4266 / #4269
