### PR TITLE
[1.4] kraken: Return 404 when listing tags of an unknown extension

### DIFF
--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -85,11 +85,10 @@ async def fetch_ext_tags_from_manifest(
     """
     Get all tags for a given extension identifier using one manifest as source.
     """
-    if not await manifest_manager.fetch_extension(extension_identifier, manifest_identifier):
+    ext = await manifest_manager.fetch_extension(extension_identifier, manifest_identifier)
+    if not ext:
         raise ExtensionNotFound(f"Extension {extension_identifier} not found")
-    versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable, manifest_identifier)
-
-    return [str(version) for version in versions]
+    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
 
 
 @manifest_router_v2.get("/tags/{extension_identifier}", status_code=status.HTTP_200_OK)
@@ -98,11 +97,10 @@ async def fetch_ext_tags_from_consolidated(extension_identifier: str, stable: bo
     """
     Get all tags for a given extension identifier using consolidated manifest as source.
     """
-    if not await manifest_manager.fetch_extension(extension_identifier):
+    ext = await manifest_manager.fetch_extension(extension_identifier)
+    if not ext:
         raise ExtensionNotFound(f"Extension {extension_identifier} not found")
-    versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable)
-
-    return [str(version) for version in versions]
+    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
 
 
 @manifest_router_v2.post("/", status_code=status.HTTP_201_CREATED)

--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import Response
 from fastapi_versioning import versioned_api_route
 
+from extension.exceptions import ExtensionNotFound
 from manifest import ManifestManager
 from manifest.exceptions import (
     ManifestDataFetchFailed,
@@ -37,7 +38,7 @@ def manifest_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., An
             return await endpoint(*args, **kwargs)
         except (ManifestDataFetchFailed, ManifestDataParseFailed, ManifestInvalidURL) as error:
             raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(error)) from error
-        except ManifestNotFound as error:
+        except (ManifestNotFound, ExtensionNotFound) as error:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
         except ManifestOperationNotAllowed as error:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error)) from error
@@ -84,6 +85,8 @@ async def fetch_ext_tags_from_manifest(
     """
     Get all tags for a given extension identifier using one manifest as source.
     """
+    if not await manifest_manager.fetch_extension(extension_identifier, manifest_identifier):
+        raise ExtensionNotFound(f"Extension {extension_identifier} not found")
     versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable, manifest_identifier)
 
     return [str(version) for version in versions]
@@ -95,6 +98,8 @@ async def fetch_ext_tags_from_consolidated(extension_identifier: str, stable: bo
     """
     Get all tags for a given extension identifier using consolidated manifest as source.
     """
+    if not await manifest_manager.fetch_extension(extension_identifier):
+        raise ExtensionNotFound(f"Extension {extension_identifier} not found")
     versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable)
 
     return [str(version) for version in versions]

--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -257,11 +257,9 @@ class ManifestManager:
 
         return next((ext for ext in manifest if ext.identifier == extension_id), None)
 
-    async def fetch_extension_versions(
-        self, extension_id: str, stable: bool, manifest_id: Optional[str] = None
-    ) -> List[semver.VersionInfo]:
-        ext = await self.fetch_extension(extension_id, manifest_id)
-        if not ext or not ext.versions:
+    @staticmethod
+    def versions_from_entry(ext: RepositoryEntry, stable: bool) -> List[semver.VersionInfo]:
+        if not ext.versions:
             return []
 
         def valid_semver(string: str) -> Optional[semver.VersionInfo]:
@@ -286,7 +284,7 @@ class ManifestManager:
         if not ext or not ext.versions:
             return None
 
-        versions = await self.fetch_extension_versions(extension_id, stable, manifest_id)
+        versions = self.versions_from_entry(ext, stable)
 
         return (ext.versions.get(str(versions[0])) or ext.versions.get(f"v{versions[0]}")) if versions else None
 


### PR DESCRIPTION
Fixes #4277.

`GET /kraken/v2.0/manifest/tags/{extension_identifier}` for an identifier that is not in the catalog returned HTTP 200 with body `[]`. The same empty-list path is used by `GET /kraken/v2.0/manifest/tags/{manifest_identifier}/{extension_identifier}/` when the extension is missing from a known manifest. Unknown manifest sources already 404 via `ManifestNotFound`.

`fetch_extension_versions` returned `[]` when `fetch_extension` found nothing. The tags handlers serialized that as success. Clients could not tell a missing catalog identifier from an extension that has no tags.

This raises `ExtensionNotFound` in the two tags handlers when `fetch_extension` returns `None`. An extension that exists but has an empty `versions` dict, or `stable=true` with only prereleases, still returns 200 `[]`. The existing `manifest_to_http_exception` decorator now maps `ExtensionNotFound` to 404 alongside `ManifestNotFound`.

The handlers look up the catalog entry once and derive tags from it (`versions_from_entry`). They do not call `fetch_extension` a second time. `fetch_latest_extension_version` uses the same helper on its already-fetched entry. `fetch_consolidated` is not cached at the merge layer, so a second lookup was a full rebuild of the enabled-manifest list.

Independent of #4267 / #4270 (unknown installed details). That PR touches `fetch_by_identifier` on the extension router.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`), patched `api/v2/routers/manifest.py` and `manifest/manifest.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: unknown `GET /manifest/tags/{id}` → 200 `[]`
- [x] Before patch: unknown `GET /manifest/tags/{factory}/{id}/` → 200 `[]`
- [x] After patch: unknown `GET /manifest/tags/{id}` → 404 `Extension np.no.such.extension not found`
- [x] After patch: unknown `GET /manifest/tags/{factory}/{id}/` → 404
- [x] Known `GET /manifest/tags/bluerobotics.cockpit` → 200, 16 tags
- [x] Known `?stable=true` → 200 `["1.18.2","1.18.1","1.18.0"]`
- [x] Unknown manifest details → 404 (unchanged)

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 123/123 checks passed after the single-lookup change, including never-installed `POST /{id}/install?stable=true`.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag → 200
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v2 `POST /{id}/install?stable=true` of a never-installed id → 200, not 404
- [x] DUT restored to only `major_tom`; management address still pings