### PR TITLE
[1.4] kraken: Keep v-prefix on tags API and tagged lookup

### DIFF
--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -94,7 +94,7 @@ async def fetch_ext_tags_from_manifest(
     ext = await manifest_manager.fetch_extension(extension_identifier, manifest_identifier)
     if not ext:
         raise ExtensionNotFound(f"Extension {extension_identifier} not found")
-    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
+    return manifest_manager.versions_from_entry(ext, stable)
 
 
 @manifest_router_v2.get("/tags/{extension_identifier}", status_code=status.HTTP_200_OK)
@@ -106,7 +106,7 @@ async def fetch_ext_tags_from_consolidated(extension_identifier: str, stable: bo
     ext = await manifest_manager.fetch_extension(extension_identifier)
     if not ext:
         raise ExtensionNotFound(f"Extension {extension_identifier} not found")
-    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
+    return manifest_manager.versions_from_entry(ext, stable)
 
 
 @manifest_router_v2.post("/", status_code=status.HTTP_201_CREATED)

--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -278,7 +278,7 @@ class ManifestManager:
         return next((ext for ext in manifest if ext.identifier == extension_id), None)
 
     @staticmethod
-    def versions_from_entry(ext: RepositoryEntry, stable: bool) -> List[semver.VersionInfo]:
+    def versions_from_entry(ext: RepositoryEntry, stable: bool) -> List[str]:
         if not ext.versions:
             return []
 
@@ -291,13 +291,15 @@ class ManifestManager:
             except ValueError:
                 return None
 
-        versions: List[semver.VersionInfo] = sorted(
-            [version for version in (valid_semver(tag) for tag in ext.versions) if version is not None], reverse=True
-        )
+        tagged = []
+        for tag in ext.versions:
+            version = valid_semver(tag)
+            if version is not None:
+                tagged.append((version, tag))
+        tagged.sort(key=lambda item: item[0], reverse=True)
         if stable:
-            versions = [v for v in versions if not v.prerelease]
-
-        return versions
+            tagged = [(version, tag) for version, tag in tagged if not version.prerelease]
+        return [tag for _, tag in tagged]
 
     async def fetch_latest_extension_version(
         self, extension_id: str, stable: bool, manifest_id: Optional[str] = None
@@ -308,11 +310,15 @@ class ManifestManager:
 
         versions = self.versions_from_entry(ext, stable)
 
-        return (ext.versions.get(str(versions[0])) or ext.versions.get(f"v{versions[0]}")) if versions else None
+        return ext.versions.get(versions[0]) if versions else None
 
     async def fetch_extension_version(self, extension_id: str, tag: str) -> Optional[ExtensionVersion]:
         ext = await self.fetch_extension(extension_id)
         if not ext:
             return None
 
-        return ext.versions.get(tag)
+        return (
+            ext.versions.get(tag)
+            or ext.versions.get(f"v{tag}")
+            or (ext.versions.get(tag[1:]) if tag.startswith("v") else None)
+        )


### PR DESCRIPTION
Fixes #4278.

`GET /kraken/v2.0/manifest/tags/{extension_identifier}` returned `str(semver)` (`1.18.2`). Tagged routes look up the raw manifest dict key, which is often `v1.18.2`, so a client that lists tags and then installs or updates that string gets `404 Extension ... not found`.

#3750 / #4274 added a `v`-prefix fallback only in `from_latest`. Tagged lookup (`fetch_extension_version`) and the tags handlers were unchanged.

This returns the original dict keys from `/tags`, looks up latest by that key, and tries `tag`, `v{tag}`, and an unprefixed fallback in `fetch_extension_version`.

## Test plan

On `192.168.0.177` (`1.4.5`), patched `manifest/manifest.py` and `api/v2/routers/manifest.py` via container copy + `docker restart blueos-core`.

Status-code split:

- [x] Before patch: `GET /kraken/v2.0/manifest/tags/bluerobotics.cockpit` → `1.18.2` (no `v`); catalog keys are `v1.18.2`
- [x] Before patch: `POST /kraken/v2.0/extension/bluerobotics.cockpit/1.18.2/install` → 404 `Extension bluerobotics.cockpit:1.18.2 not found`
- [x] Before patch: `PUT .../bluerobotics.cockpit/1.18.2` → 404 same
- [x] Before patch: v1 `update_to_version?new_version=1.18.2` → 404 same
- [x] After patch: tags → `v1.19.0-beta.9`, ..., `v1.18.2`; `stable=true` → `["v1.18.2","v1.18.1","v1.18.0"]`
- [x] After patch: unprefixed tagged install → 200, installed `v1.18.2`
- [x] After patch: v1 `update_to_version` with `1.18.2` → 200
- [x] After patch: PUT unprefixed `1.18.2` → 200
- [x] `major_tom` left installed; restored to only `major_tom` after the targeted install

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. 118 passed / 5 failed (`--assert-unknown` restart/disable on this `1.4.5` image).

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v2 PUT alt tag and back to primary
- [x] v2 `POST /extension/{id}/install` (`from_latest`, `stable=true`) of a never-installed id → 200, installed `v1.18.2`
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- Unknown restart/disable still 400 `have no running versions` on stock `1.4.5` (this image does not include the `1.4-dev` `from_running` 404 split). Pre-existing. #4264
- Unknown untagged uninstall still 202 on an empty gather. Pre-existing. #4266
