### PR TITLE
[1.4] kraken: Return 400 when installing an incompatible extension

### DIFF
--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -11,6 +11,7 @@ from extension.exceptions import (
     ExtensionInsufficientStorage,
     ExtensionNotFound,
     ExtensionNotRunning,
+    IncompatibleExtension,
 )
 from extension.extension import Extension
 from extension.models import ExtensionSource
@@ -31,6 +32,8 @@ def extension_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., A
         except ExtensionNotFound as error:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
         except ExtensionNotRunning as error:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+        except IncompatibleExtension as error:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
         except ExtensionInsufficientStorage as error:
             raise HTTPException(status_code=status.HTTP_507_INSUFFICIENT_STORAGE, detail=str(error)) from error


### PR DESCRIPTION
Fixes #4279.

Installing or updating a catalog tag with no compatible image returned HTTP 500. `get_compatible_digest` raises `IncompatibleExtension`; the watchdog already catches that, but `extension_to_http_exception` mapped everything except `ExtensionNotFound` / `ExtensionNotRunning` / `ExtensionInsufficientStorage` to 500.

This maps `IncompatibleExtension` to HTTP 400, same class of client error as `ExtensionNotRunning`. Custom-source install (`POST /` and v1 `POST /install`) is unchanged; those skip the digest check by design.

## Test plan

On `192.168.0.69` (`1.4.4-beta.23`, armv7), patched `api/v2/routers/extension.py` via container copy + `docker restart blueos-core`. Vehicle: `waterlinked.ugps:v1.0.7-beta.5` (arm/v5 only).

Status-code split:

- [x] Before patch: v2 `POST /{id}/{tag}/install` → 500 `has no compatible images`
- [x] After patch: same call → 400 `has no compatible images`
- [x] v1 `update_to_version` and v2 PUT of that tag → 400
- [x] v2 `POST /{id}/install` of arm64-only `patrickelectric.foxglove` → 400
- [x] Unknown identifier tagged install → 404 (unchanged)

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 112/112 checks passed, 3 skipped (`from_latest` v-prefix leftover).

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v2 PUT same tag and alt tag switch → 200
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- `POST /{id}/install` / `PUT /{id}` via `from_latest` still 404 `has noversions` for Cockpit. Pre-existing v-prefix lookup. Separate from this mapping change.
