### PR TITLE
[1.4] kraken: Return 502 when the catalog host is offline

### DIFF
--- a/core/services/kraken/api/v1/routers/index.py
+++ b/core/services/kraken/api/v1/routers/index.py
@@ -6,6 +6,7 @@ from fastapi.responses import PlainTextResponse, RedirectResponse, StreamingResp
 from fastapi_versioning import versioned_api_route
 
 from api.v2.routers.container import container_to_http_exception
+from api.v2.routers.manifest import manifest_to_http_exception
 from extension.extension import Extension
 from extension.models import ExtensionSource
 from harbor import ContainerManager
@@ -22,6 +23,7 @@ manifest_manager = ManifestManager.instance()
 
 
 @index_router_v1.get("/extensions_manifest", status_code=status.HTTP_200_OK)
+@manifest_to_http_exception
 async def fetch_manifest() -> list[RepositoryEntry]:
     return await manifest_manager.fetch_consolidated()
 

--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -7,6 +7,7 @@ from fastapi_versioning import versioned_api_route
 
 from manifest import ManifestManager
 from manifest.exceptions import (
+    ManifestBackendOffline,
     ManifestDataFetchFailed,
     ManifestDataParseFailed,
     ManifestInvalidURL,
@@ -35,7 +36,12 @@ def manifest_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., An
     async def wrapper(*args: Tuple[Any], **kwargs: dict[str, Any]) -> Any:
         try:
             return await endpoint(*args, **kwargs)
-        except (ManifestDataFetchFailed, ManifestDataParseFailed, ManifestInvalidURL) as error:
+        except (
+            ManifestBackendOffline,
+            ManifestDataFetchFailed,
+            ManifestDataParseFailed,
+            ManifestInvalidURL,
+        ) as error:
             raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(error)) from error
         except ManifestNotFound as error:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error


### PR DESCRIPTION
Fixes #4280.

When the catalog host is unreachable, `_fetch_manifest_data` raises `ManifestBackendOffline`. `manifest_to_http_exception` already maps `ManifestDataFetchFailed`, `ManifestDataParseFailed`, and `ManifestInvalidURL` to HTTP 502. `ManifestBackendOffline` was omitted from that tuple, so v2 manifest routes returned HTTP 500 with `Unable to fetch manifest, backend is offline`.

v1 `GET /kraken/v1.0/extensions_manifest` had no exception wrapper, so the same failure was an unhandled HTTP 500 (`Internal Server Error`).

This adds `ManifestBackendOffline` to the existing 502 group and wraps the v1 route with the same decorator (same pattern as v1 `/log` importing `container_to_http_exception` from v2).

The watchdog already catches `ManifestBackendOffline`. This does not change fetch/gather behavior: one unreachable enabled source still fails the whole consolidated list, now as 502 instead of 500.

## Test plan

On `192.168.0.88` (`1.4.4-beta.23`, mgmt `eth0`), patched `api/v2/routers/manifest.py` and `api/v1/routers/index.py` via container copy + `docker restart blueos-core`. Factory source left enabled. Dummy non-factory source pointed at `http://127.0.0.1:1/...` (`validate_url=false`).

Status-code split:

- [x] Before patch: dummy source + `GET /kraken/v2.0/manifest/consolidated` → HTTP 500 `Unable to fetch manifest, backend is offline`
- [x] Before patch: same dummy + `GET /kraken/v1.0/extensions_manifest` → HTTP 500 `Internal Server Error`
- [x] Before patch: `POST /kraken/v2.0/manifest/` invalid URL → HTTP 502 (unchanged sibling)
- [x] Before patch: `POST /kraken/v2.0/manifest/` closed-port + `validate_url=true` → HTTP 500
- [x] After patch: dummy + v2 consolidated / v2 list `data=true` / v2 dummy details / v2 tags / v1 `extensions_manifest` → HTTP 502 same detail
- [x] After patch: list `data=false` with dummy still 200; invalid URL still 502; closed-port create `validate_url=true` → 502
- [x] After patch: unknown manifest details → 404; `DELETE` factory → 409
- [x] Dummy deleted; identifiers restored to factory-only; consolidated 200 (59 entries)

Full Kraken lifecycle with `bluerobotics.power-switch-calibration:v1.0.0`. Baseline (`radcam-manager`, `cockpit`, `smoke.catalog`, `major_tom`) left installed. 104 passed, 0 failed, 4 skipped (no second compatible tag; `from_latest` leftover). DUT restored to baseline identifiers; no leftover dummy manifest; management address still pings.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] v2 custom `POST /` and tagged `POST /{id}/{tag}/install` never-installed → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v1/v2 enable, disable, restart, uninstall of the vehicle
- [x] v2 dummy manifest create/details/enable/disable/reorder/delete
- [x] Factory manifest still present; `DELETE` factory still 409

## Skipped

- Mapping `ManifestBackendOffline` in `extension_to_http_exception` (install / `update_to_version` / v2 tagged install). Different endpoint family than the ticket. Confirmed still HTTP 500 with a dummy offline source; filed as #4288.
- Making `fetch_consolidated` survive one dead source (`asyncio.gather` without `return_exceptions`). Pre-existing; this PR only changes 500 to 502 on that path. Filed as #4287.
- aiohttp total-timeout / payload errors that are not `ClientConnectionError`. Root cause is `_fetch_manifest_data` setting no `ClientTimeout`.
- Local unit tests for the decorator. `ManifestManager.instance()` runs at import; live DUT repro is the check.