### PR TITLE
[1.4] kraken: Return 409 when deleting a running job

### DIFF
--- a/core/services/kraken/api/v2/routers/jobs.py
+++ b/core/services/kraken/api/v2/routers/jobs.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Body, HTTPException, status
 from fastapi_versioning import versioned_api_route
 
 from jobs import JobsManager
-from jobs.exceptions import JobNotFound
+from jobs.exceptions import JobNotFound, JobOperationNotAllowed
 from jobs.models import Job, JobMethod
 
 jobs_router_v2 = APIRouter(
@@ -24,6 +24,8 @@ def jobs_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., Any]:
             return await endpoint(*args, **kwargs)
         except JobNotFound as error:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+        except JobOperationNotAllowed as error:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error)) from error
         except Exception as error:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 

--- a/core/services/kraken/jobs/exceptions.py
+++ b/core/services/kraken/jobs/exceptions.py
@@ -1,2 +1,6 @@
 class JobNotFound(Exception):
     pass
+
+
+class JobOperationNotAllowed(Exception):
+    pass

--- a/core/services/kraken/jobs/jobs.py
+++ b/core/services/kraken/jobs/jobs.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import aiohttp
 from loguru import logger
 
-from jobs.exceptions import JobNotFound
+from jobs.exceptions import JobNotFound, JobOperationNotAllowed
 from jobs.models import Job
 
 
@@ -37,9 +37,11 @@ class JobsManager:
         while self.is_running:
             await asyncio.sleep(1)
             if self._jobs:
-                self._executing_job = self._jobs.pop(0)
-                await self.execute_job(self._executing_job)
-                self._executing_job = None
+                JobsManager._executing_job = self._jobs.pop(0)
+                try:
+                    await self.execute_job(JobsManager._executing_job)
+                finally:
+                    JobsManager._executing_job = None
 
     async def stop(self) -> None:
         self.is_running = False
@@ -65,4 +67,6 @@ class JobsManager:
     @classmethod
     def delete(cls, identifier: str) -> None:
         job = cls.get_by_identifier(identifier)
+        if job is cls._executing_job:
+            raise JobOperationNotAllowed(f"Job {identifier} is currently executing")
         cls._jobs.remove(job)


### PR DESCRIPTION
Fixes #4282.

`DELETE /kraken/v2.0/jobs/{identifier}` for a job that is currently executing was supposed to be distinguishable from missing (404) and queued (204). On a live `1.4-dev` image it returned **404** while the worker was still retrying. The 500 from `_jobs.remove(job)` (`ValueError`) is what happens once listing actually includes the executing job.

`start()` assigned `self._executing_job` (instance). `get()` / `delete()` are classmethods and read `cls._executing_job`, which stayed `None`. The job is popped off `_jobs` before execute, so GET/DELETE cannot see it. `get()` was already written to prepend `_executing_job`; that never worked.

This writes `_executing_job` on the class, clears it in `finally`, and raises `JobOperationNotAllowed` (HTTP 409) when DELETE targets that job. Queued deletes still `remove` and return 204. Unknown ids still 404. Cancel is not implemented; the worker keeps running.

Same code is on `master`.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`), patched `jobs.py` / `exceptions.py` / `api/v2/routers/jobs.py` via container copy + `docker restart blueos-core`.

Status-code split (enqueue a failing GET with `retries=5` so execute stays in the retry sleep):

- [x] Before patch: executing `GET /jobs/{id}` → 404 while logs still show retries
- [x] Before patch: executing `DELETE /jobs/{id}` → 404
- [x] Before patch: queued `DELETE` → 204; unknown `DELETE` → 404
- [x] After patch: executing `GET /jobs/{id}` → 200
- [x] After patch: executing `DELETE /jobs/{id}` → 409 `Job {id} is currently executing`; GET still 200 (worker continues)
- [x] After patch: queued `DELETE` → 204; unknown `DELETE` → 404

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. `major_tom` left installed. 123/123 checks passed.

- [x] v2 jobs enqueue GET list → 202; GET → 200; queued DELETE → 204
- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] Cockpit listed, enabled, container running; `major_tom` still present
- [x] v2 details by identifier and by identifier+tag → 200
- [x] v1/v2 container list, stats, and log streams
- [x] v2 and v1 restart of the running extension → 202, container comes back
- [x] v2 disable → 204, container gone, restart → 400; v2 enable → 204, container back
- [x] v1 disable → 200; v1 enable of the installed id → 200
- [x] v1 uninstall → 200
- [x] v2 `POST /extension/{id}/{tag}/install` of a never-installed id → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v2 `POST /{id}/install?stable=true` of a never-installed id → 200, not 404
- [x] DUT restored to only `major_tom`; management address still pings
