### PR TITLE
[1.4] kraken: Return 409 when mutating the factory catalog

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionSettingsModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionSettingsModal.vue
@@ -10,7 +10,7 @@
           <v-card-subtitle class="text-md-center" max-width="30">
             Drag manifest sources to set priority. <br /><b>Top ones have higher priority.</b>
           </v-card-subtitle>
-          <draggable v-model="manifests">
+          <draggable v-model="manifests" :move="preventFactoryReorder">
             <v-card
               v-for="(element, index) in manifests"
               :key="index"
@@ -90,10 +90,10 @@
     <v-dialog v-model="operation_open" width="600px">
       <v-card elevation="0">
         <v-card-title class="mb-7">
-          {{ is_editing ? 'Update Source' : 'Add a new source' }}
+          {{ is_factory ? 'Factory source' : is_editing ? 'Update Source' : 'Add a new source' }}
         </v-card-title>
-        <v-card-subtitle class="text-md-center" max-width="30">
-          <b>Factory sources can only be enabled/disabled.</b>
+        <v-card-subtitle v-if="is_factory" class="text-md-center" max-width="30">
+          <b>Factory sources cannot be modified.</b>
         </v-card-subtitle>
         <v-text-field
           v-model="source_url"
@@ -116,6 +116,7 @@
         />
         <v-checkbox
           v-model="source_enabled"
+          :disabled="is_factory"
           class="mx-6 mt-0"
           label="Source Enabled"
         />
@@ -153,6 +154,7 @@
           </v-btn>
           <v-spacer />
           <v-btn
+            v-if="!is_factory"
             color="success"
             @click="applySubModalAction"
           >
@@ -226,6 +228,13 @@ export default Vue.extend({
       // Based over: https://stackoverflow.com/a/39466341
       return `${index}${['st', 'nd', 'rd'][((index + 90) % 100 - 10) % 10 - 1] || 'th'}`
     },
+    preventFactoryReorder(evt: {
+      draggedContext: { element: Manifest },
+      relatedContext: { element?: Manifest },
+    }): boolean {
+      // vuedraggable :move — false refuses the drag. Refuse the factory row or a drop onto it.
+      return !(evt.draggedContext.element.factory || evt.relatedContext.element?.factory)
+    },
     blockNameAutoComplete() {
       this.allow_deduct_name = false
     },
@@ -287,15 +296,16 @@ export default Vue.extend({
       // approach
       if (this.is_editing) {
         if (this.is_factory) {
-          await this.setSourceEnable(this.editing_source!.identifier, this.source_enabled)
-        } else {
-          await this.updateSource(
-            this.editing_source!.identifier,
-            this.source_name,
-            this.source_url,
-            this.source_enabled,
-          )
+          // Fields are disabled; skip the API that would 409.
+          this.operation_open = false
+          return
         }
+        await this.updateSource(
+          this.editing_source!.identifier,
+          this.source_name,
+          this.source_url,
+          this.source_enabled,
+        )
       } else {
         await this.addSource(this.source_name, this.source_url, this.source_enabled)
       }
@@ -377,19 +387,6 @@ export default Vue.extend({
         this.settings_open = false
       } catch (error) {
         this.operation_error = `Unable to update order: ${error}`
-      } finally {
-        this.operation_loading = false
-      }
-    },
-    async setSourceEnable(identifier: string, enable: boolean) {
-      this.prepareRequest()
-
-      try {
-        await (enable ? kraken.enabledManifestSource(identifier) : kraken.disabledManifestSource(identifier))
-
-        this.fetchManifestsSources()
-      } catch (error) {
-        this.operation_error = `Unable to ${enable ? 'enable' : 'disable'} source: ${error}`
       } finally {
         this.operation_loading = false
       }

--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -54,16 +54,37 @@ class ManifestManager:
 
     @classmethod
     def _set_default_manifests(cls) -> None:
+        default_ids = [source["identifier"] for source in DEFAULT_MANIFESTS]
+        had_settings = bool(cls._settings.manifests)
+
+        def factory_snap() -> Tuple[dict[str, Tuple[Any, ...]], dict[str, int], dict[str, int]]:
+            fields: dict[str, Tuple[Any, ...]] = {}
+            index: dict[str, int] = {}
+            counts: dict[str, int] = {}
+            for i, manifest in enumerate(cls._settings.manifests):
+                ident = manifest.identifier
+                if ident not in default_ids:
+                    continue
+                counts[ident] = counts.get(ident, 0) + 1
+                if ident not in fields:
+                    fields[ident] = (manifest.enabled, manifest.factory, manifest.name, manifest.url)
+                    index[ident] = i
+            return fields, index, counts
+
+        before = factory_snap()
+
         for source in DEFAULT_MANIFESTS:
             identifier = source["identifier"]
             name = source["name"]
             url = source["url"]
 
-            # If already exists only update the name and url otherwise add it
+            # Keep factory sources present, named, enabled, and marked factory
             try:
                 manifest = cls._get_settings_by_identifier(identifier)
                 manifest.url = url
                 manifest.name = name
+                manifest.enabled = True
+                manifest.factory = True
             except ManifestNotFound:
                 cls._settings.manifests.append(
                     ManifestSettings(
@@ -75,6 +96,26 @@ class ManifestManager:
                         url=url,
                     )
                 )
+
+        # Pin factory sources first and drop duplicate factory rows left by older builds
+        by_id: dict[str, ManifestSettings] = {}
+        others: List[ManifestSettings] = []
+        for manifest in cls._settings.manifests:
+            if manifest.identifier in default_ids:
+                by_id.setdefault(manifest.identifier, manifest)
+            else:
+                others.append(manifest)
+        cls._settings.manifests = [by_id[identifier] for identifier in default_ids if identifier in by_id] + others
+        for i, manifest in enumerate(cls._settings.manifests):
+            manifest.priority = i
+        after = factory_snap()
+        if had_settings and before != after:
+            logger.info(
+                "Healed factory catalog sources "
+                f"(fields {before[0]} -> {after[0]}; "
+                f"index {before[1]} -> {after[1]}; "
+                f"rows {before[2]} -> {after[2]})"
+            )
         cls._manager.save()
 
     @classmethod
@@ -167,6 +208,17 @@ class ManifestManager:
         if identifier in default_identifiers:
             raise ManifestOperationNotAllowed(f"Operation is not allowed in default manifest [{identifier}]")
 
+    def _raise_if_default_manifests_demoted(self, new_order: List[str]) -> None:
+        # 409 if a factory source would lose its current index or be omitted.
+        # Unknown ids are not this check: callers look up first (404). Dummy
+        # order/0 is 409 because factory would drop from 0 to 1.
+        current = [manifest.identifier for manifest in self._get_settings()]
+        for identifier in (source["identifier"] for source in DEFAULT_MANIFESTS):
+            if identifier not in current:
+                continue
+            if identifier not in new_order or new_order.index(identifier) > current.index(identifier):
+                self._raise_in_default_source(identifier)
+
     @staticmethod
     def not_on_default_manifest(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
@@ -220,6 +272,7 @@ class ManifestManager:
         self._manager.save()
 
     def _set_enabled(self, identifier: str, enabled: bool) -> None:
+        self._raise_in_default_source(identifier)
         manifest = self._get_settings_by_identifier(identifier)
         manifest.enabled = enabled
         self._manager.save()
@@ -230,11 +283,16 @@ class ManifestManager:
     async def disable_source(self, identifier: str) -> None:
         self._set_enabled(identifier, False)
 
+    @not_on_default_manifest
     async def order_source(self, identifier: str, order: int) -> None:
         manifest = self._get_settings_by_identifier(identifier)
+        manifests = self._get_settings()
+        proposed = [item.identifier for item in manifests if item.identifier != identifier]
+        proposed.insert(min(order, len(proposed)), identifier)
+        self._raise_if_default_manifests_demoted(proposed)
+
         manifest.priority = order
 
-        manifests = self._get_settings()
         if manifest in manifests:
             manifests.remove(manifest)
 
@@ -250,14 +308,21 @@ class ManifestManager:
         manifests = self._get_settings()
         manifest_record = {manifest.identifier: manifest for manifest in manifests}
 
+        for identifier in identifiers:
+            if identifier not in manifest_record:
+                raise ManifestNotFound(f"Manifest with identifier {identifier} not found")
+
+        if len(identifiers) != len(set(identifiers)):
+            raise ManifestOperationNotAllowed("Duplicate manifest identifiers are not allowed")
+
+        omitted = [manifest.identifier for manifest in manifests if manifest.identifier not in identifiers]
+        self._raise_if_default_manifests_demoted(identifiers + omitted)
+
         ordered_manifests = []
         for order, identifier in enumerate(identifiers):
-            if identifier in manifest_record:
-                manifest = manifest_record[identifier]
-                manifest.priority = order
-                ordered_manifests.append(manifest)
-            else:
-                raise ManifestNotFound(f"Manifest with identifier {identifier} not found")
+            manifest = manifest_record[identifier]
+            manifest.priority = order
+            ordered_manifests.append(manifest)
 
         for manifest in manifests:
             if manifest.identifier not in identifiers:


### PR DESCRIPTION
Fixes #4281.

## What broke

`POST /kraken/v2.0/manifest/bluerobotics-production/disable` (and enable, and `PUT .../order/{n}`) returned 204 and wrote settings. Disabling the production catalog emptied `GET /manifest/consolidated` (59 entries to 0). Delete and PUT details already 409 via `@not_on_default_manifest`.

## Contract (backend)

Two commits on purpose: Python first (the HTTP contract), Vue second (the UI cannot offer those actions).

| Call | Result |
|---|---|
| factory enable / disable / order / details / delete | 409 |
| dummy `PUT .../order/0` or `PUT /orders` dummy-first | 409 (would demote factory) |
| unknown order id | 404 (lookup **before** the demote check) |
| duplicate ids in `PUT /orders` | 409 |
| `PUT /orders` factory-first (and factory-only) | 204 |

Kraken start heals an already-demoted or disabled factory from an older build: re-enable, restore name/url, mark `factory=True`, pin first, drop duplicate factory rows. That logs only when factory fields, index, or duplicate count actually change (not when a custom source is deleted, and not on first boot). New demotions stay 409.

**Product note:** after this change there is no API or UI to keep the factory catalog disabled. Air-gapped setups that used disable under the old 204 behavior get it turned back on at upgrade. That is intentional recovery for #4281, not a silent side effect.

## UI

Factory row: no enable toggle, no delete, no drag of/onto factory. Opening the factory row is read-only (`Factory source`, fields disabled, no Apply). Backend still 409s if something else hits those routes.

## Test plan

On `192.168.0.177` (`1.4.5` on `eth0`). Overlay `manifest/manifest.py` (+ `exceptions.py` and the v2 manifest router so 1.4.5 can load a rebased 1.4-dev tree). Frontend was not live-tested (needs an image rebuild).

Before patch:

- [x] DELETE factory → 409
- [x] PUT details factory → 409
- [x] POST disable factory → 204, `enabled=false`, consolidated 59 → 0
- [x] POST enable restore → 204, consolidated 59
- [x] PUT `/orders` `[dummy, factory]` → 204, factory priority 1

After patch (re-tested after the GitHub UI rebase, with the updated catalog harness):

- [x] POST disable/enable factory → 409, factory stays enabled
- [x] PUT factory `order/99` → 409
- [x] PUT `/orders` dummy-first → 409
- [x] PUT dummy `order/0` → 409
- [x] unknown `PUT .../order/0` → 404 (NP-114)
- [x] Dummy create/enable/disable/`order/99`/DELETE still 201/204
- [x] PUT `/orders` factory-first restore → 204
- [x] Boot heal: factory `enabled=false`/`factory=false` restart logs `Healed factory catalog sources` and restores enabled + factory; a second restart does not log
- [x] `major_tom` still installed; management address still pings; no leftover dummy

Full Kraken lifecycle `bluerobotics.cockpit:v1.18.2` with `--assert-unknown`: **165 passed, 14 failed**. Every factory-catalog line above passed. The 14 failures are leftovers on this 1.4.5 image (unknown details 200, unknown DELETE 202, v1 uninstall 200, v1 enable 500, unknown restart/disable 400, jobs DELETE 404, incompatible/too-big install 500, restart-after-uninstall 400). Unknown catalog tags now 404. DUT restored to only `major_tom`.

## Not in this PR

- Hiding the factory pencil entirely (read-only dialog is enough for the 204-vs-409 bug).
- Drag handle / cursor still visible on the factory row (`:move` refuses with no toast).
- No new pytest. Kraken has no manifest tests today; the 409 contract was checked on the DUT.
- Splitting boot-heal into a third commit: it edits the same `_set_default_manifests` function as the 409 pin.