### PR TITLE
[1.4] kraken: Return 502 on install when the catalog host is offline

### DIFF
--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -14,6 +14,7 @@ from extension.exceptions import (
 )
 from extension.extension import Extension
 from extension.models import ExtensionSource
+from manifest.exceptions import ManifestBackendOffline
 
 extension_router_v2 = APIRouter(
     prefix="/extension",
@@ -34,6 +35,8 @@ def extension_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., A
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
         except ExtensionInsufficientStorage as error:
             raise HTTPException(status_code=status.HTTP_507_INSUFFICIENT_STORAGE, detail=str(error)) from error
+        except ManifestBackendOffline as error:
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(error)) from error
         except HTTPException as error:
             raise error
         except Exception as error:


### PR DESCRIPTION
Fixes #4288.

`from_manifest` / `from_latest` raise `ManifestBackendOffline` when an enabled catalog source is unreachable. `extension_to_http_exception` had no mapping for that class, so v1 `update_to_version` and v2 tagged/latest install and update returned HTTP 500 with `Unable to fetch manifest, backend is offline`.

This maps `ManifestBackendOffline` to HTTP 502 in the shared decorator (v1 imports it from v2). Same status as the catalog-offline group on public manifest GET routes. Fetch/gather behavior is unchanged: one unreachable enabled source still fails the whole install/update, now as 502 instead of 500.

## Test plan

On `192.168.0.124` (`1.4.4-beta.23`, mgmt `eth0`), patched `api/v2/routers/extension.py` via container copy + `docker restart blueos-core`. Factory source left enabled. Dummy non-factory source pointed at `http://127.0.0.1:1/...` (`validate_url=false`). Vehicle for the status-code split: `bluerobotics.power-switch-calibration:v1.0.0` (not installed; failure is during manifest fetch).

- [x] Before patch: dummy source + `POST /kraken/v2.0/extension/{id}/{tag}/install` → HTTP 500
- [x] Before patch: dummy + v1 `POST /extension/update_to_version` → HTTP 500
- [x] Before patch: dummy + v2 `POST /{id}/install`, `PUT /{id}/{tag}`, `PUT /{id}` → HTTP 500
- [x] After patch: same five routes → HTTP 502, same detail
- [x] After patch: unknown tagged details still 404
- [x] Dummy deleted; identifiers restored to `blueos.major_tom`; factory-only manifests

Full Kraken lifecycle with `williangalvani.virtualhere:v1.0.5` (smallest compatible unused extension on this arm64 DUT). Baseline (`blueos.major_tom`) left installed. 115 passed, 0 failed, 1 skipped (no second compatible tag). DUT restored to baseline identifiers; no leftover dummy manifest; management address still pings.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] v2 custom `POST /` and tagged `POST /{id}/{tag}/install` never-installed → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v1/v2 enable, disable, restart, uninstall of the vehicle
- [x] v2 dummy manifest create/details/enable/disable/reorder/delete
- [x] Factory manifest still present; `DELETE` factory still 409
- [x] `--assert-unknown`: missing restart/disable → 404

## Skipped

- Mapping `ManifestDataFetchFailed` / `ManifestDataParseFailed` / `ManifestInvalidURL` in `extension_to_http_exception`. Host-offline is `ClientConnectionError` → `ManifestBackendOffline` only. Those sibling classes remain 500 on install if they fire.
- Mapping `ManifestBackendOffline` on public manifest GET routes. Different endpoint family; #4280 / #4286.
- Making `fetch_consolidated` survive one dead source. Pre-existing; this PR only changes 500 to 502 on the install/update path. #4287.
- Local unit tests for the decorator. `ManifestManager.instance()` runs at import; live DUT repro is the check.
