### PR TITLE
[1.4] kraken: Keep catalog browse when one manifest source is offline

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -7,6 +7,7 @@ import aiohttp
 import semver
 from aiocache import cached
 from commonwealth.settings.manager import Manager
+from loguru import logger
 
 from config import DEFAULT_MANIFESTS, SERVICE_NAME
 from manifest.exceptions import (
@@ -126,7 +127,21 @@ class ManifestManager:
         if enabled:
             settings = [source for source in settings if source.enabled]
 
-        return await asyncio.gather(*[self._fetch_manifest(source, fetch_data) for source in settings])
+        results = await asyncio.gather(
+            *[self._fetch_manifest(source, fetch_data) for source in settings],
+            return_exceptions=True,
+        )
+
+        manifests: List[Manifest] = []
+        for source, result in zip(settings, results):
+            if isinstance(result, BaseException):
+                if not isinstance(result, Exception):
+                    raise result
+                logger.warning(f"Skipping unreachable manifest source {source.identifier} ({source.url}): {result}")
+                manifests.append(await self._fetch_manifest(source, fetch_data=False))
+            else:
+                manifests.append(cast(Manifest, result))
+        return manifests
 
     async def fetch_by_identifier(self, identifier: str, fetch_data: bool) -> Manifest:
         settings = self._get_settings_by_identifier(identifier)


### PR DESCRIPTION
Fixes #4287.

`ManifestManager.fetch` used `asyncio.gather` without `return_exceptions`. One unreachable enabled source raised `ManifestBackendOffline` and failed the whole list, so store browse died even when `bluerobotics-production` was fine.

This isolates per-source fetch failures: a dead extra catalog is logged and returned without `data`, and `fetch_consolidated` already skips those. Single-source routes (`fetch_by_identifier`, `add_source`/`update_source` with `validate_url=true`) still raise.

Does not change the HTTP status of a single-source offline fetch (that is #4280).

## Test plan

On `192.168.0.69` (`1.4.4-beta.23`, mgmt `eth0`), patched `manifest/manifest.py` via container copy + `docker restart blueos-core`. Factory source left enabled. Dummy non-factory source pointed at `http://127.0.0.1:1/offline-manifest.json` (`validate_url=false`, enabled).

Before patch:

- [x] Dummy + `GET /kraken/v2.0/manifest/consolidated` → HTTP 500 `Unable to fetch manifest, backend is offline`
- [x] Dummy + `GET /kraken/v1.0/extensions_manifest` → HTTP 500
- [x] Dummy + `GET /kraken/v2.0/manifest/` (`data=true`) → HTTP 500
- [x] Dummy + `GET /kraken/v2.0/manifest/tags/bluerobotics.cockpit` → HTTP 500
- [x] `GET /kraken/v2.0/manifest/?data=false` still 200; factory details still 200 with 59 entries

After patch:

- [x] Same dummy enabled: consolidated / v1 `extensions_manifest` / `GET /manifest/` / tags → HTTP 200 with the 59 factory entries (cockpit tags present)
- [x] `GET /manifest/` lists the dummy with `data: null` and factory with 59 entries
- [x] Dummy deleted; identifiers restored to factory-only; consolidated 200

Full Kraken lifecycle with `bluerobotics.power-switch-calibration:v1.0.0`. Baseline (`major_tom`) left installed. 110 passed, 5 failed (`--assert-unknown` restart/disable 400 vs 404), 1 skipped (no second compatible tag). DUT restored to baseline identifiers; no leftover dummy manifest; management address still pings.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] v2 custom `POST /` and tagged `POST /{id}/{tag}/install` never-installed → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v1/v2 enable, disable, restart, uninstall of the vehicle
- [x] v2 dummy manifest create/details/enable/disable/reorder/delete
- [x] Factory manifest still present; `DELETE` factory still 409

## Skipped

- Mapping `ManifestBackendOffline` to HTTP 502. Different ticket (#4280 / PR 4286). After this change the multi-source list no longer raises; single-source dummy details still 500 until that lands.
- Unknown restart/disable → 404 (`--assert-unknown`). Pre-existing `from_running` empty list → 400. Restart is #4160; disable is the same helper.
- Local unit tests for `ManifestManager`. `instance()` runs at import; live DUT repro is the check.
