### PR TITLE
[1.4] kraken: Skip non-semver tags when listing versions

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -271,9 +271,11 @@ class ManifestManager:
             try:
                 return semver.VersionInfo.parse(string)
             except ValueError:
-                return []
+                return None
 
-        versions: List[semver.VersionInfo] = sorted([valid_semver(tag) for tag in ext.versions], reverse=True)
+        versions: List[semver.VersionInfo] = sorted(
+            [version for version in (valid_semver(tag) for tag in ext.versions) if version is not None], reverse=True
+        )
         if stable:
             versions = [v for v in versions if not v.prerelease]
 


### PR DESCRIPTION
Fixes #4291.

`GET /kraken/v2.0/manifest/tags/{extension_identifier}` (and the factory-source variant) 500s when any version key in the catalog fails `semver` parse. `valid_semver` is typed to return `Optional[semver.VersionInfo]` but the `ValueError` branch returned `[]`. `sorted()` then mixed `VersionInfo` with `list` and raised `TypeError`; the generic handler maps that to 500.

Returning `None` is not enough: `sorted()` still TypeErrors comparing `None` with `Version`. Invalid tags are dropped before sort.

Factory Cockpit on the current catalog has only valid semver keys, so those endpoints already return 200. The 500 is triggered by a mixed set such as `v1.0.0` plus `latest`.

Keeping the raw `v`-prefix on tag strings is #4278 / a separate PR, not this change.

## Test plan

On `192.168.0.177` (`1.4.5` image, stock `1.4-dev` kraken `manifest.py` + this patch via container copy, `docker restart blueos-core`). Management path `eth0`. Baseline installed: `blueos.major_tom` only.

- [x] Stock `1.4-dev` files: `GET /kraken/v2.0/manifest/tags/bluerobotics.cockpit` → 200 (all 16 tags parse)
- [x] Dummy enabled manifest with versions `v1.0.0` and `latest`: both tag routes → 500 `Version.__init__() missing 1 required positional argument: 'major'`
- [x] After patch, same dummy: 200 `["1.0.0"]` (`latest` skipped); Cockpit still 200
- [x] Dummy source deleted; factory `bluerobotics-production` left enabled
- [x] Kraken lifecycle harness `bluerobotics.cockpit:v1.18.2`: 119 passed / 0 failed / 0 skipped, including `v2 tags from consolidated` and `v2 tags from factory manifest`
- [x] DUT restored to only `major_tom`; management address still pings
