### PR TITLE
[1.4] kraken: Return 409 when creating a duplicate catalog source

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -164,6 +164,11 @@ class ManifestManager:
     async def add_source(self, source: ManifestSource, validate_url: bool) -> Manifest:
         manifests = self._get_settings()
 
+        if any(manifest.name == source.name and manifest.url == source.url for manifest in manifests):
+            raise ManifestOperationNotAllowed(
+                f"Manifest source with name [{source.name}] and url [{source.url}] already exists"
+            )
+
         new_manifest_settings = ManifestSettings(
             identifier=str(uuid.uuid4()),
             priority=len(manifests),


### PR DESCRIPTION
Fixes #4295.

`POST /kraken/v2.0/manifest/?validate_url=false` with a name and URL that already exist returned **HTTP 201** and a new UUID. `add_source` always appended; there was no uniqueness check on the catalog coordinates the user types.

A second create of the same name+URL now raises `ManifestOperationNotAllowed` (**HTTP 409**). Identifier stays a UUID. Same name with a different URL, or same URL with a different name, is still a new source.

Same code is on `master`.

## Test plan

On `192.168.0.177` (`1.4.5` on `eth0`), patched `manifest/manifest.py` via container copy + `docker restart blueos-core`.

Before patch:

- [x] POST dummy `validate_url=false` → 201, new UUID
- [x] Repeat the same POST → 201, a **different** UUID; `GET /manifest/?data=false` listed both
- [x] DELETE both dummies → 204; list back to factory only

After patch:

- [x] POST dummy → 201
- [x] Repeat the same POST → 409 `Manifest source with name [...] and url [...] already exists`; list still has one dummy
- [x] POST factory name+URL → 409
- [x] Same name, different URL → 201; different name, same URL → 201
- [x] DELETE dummy → 204

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. 141 passed, 27 failed (pre-existing on this 1.4.5 image, not this patch: tags v-prefix, factory enable/disable/reorder 409, unknown details/uninstall, job-delete-running, offline-source 500 vs 502). Ticket check passed.

- [x] `duplicate dummy create -> 409`
- [x] v1/v2 install of never-installed Cockpit → 200, not 404
- [x] enable/disable/restart/uninstall restore
- [x] dummy manifest mutate including DELETE → 204
- [x] DUT restored to only `major_tom`; management address still pings

## Skipped

- `update_source` can still rename a source onto another row's name+URL. The ticket is create (`add_source`); PUT is a separate path.
- No new pytest. Kraken has no manifest tests today; the 409 contract was checked on the DUT.
