### PR TITLE
[1.4] kraken: Keep a custom extension when Save cannot pull

### DIFF
--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -5,6 +5,7 @@ import os
 import time
 from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, cast
 
+from aiodocker.exceptions import DockerError
 from commonwealth.settings.manager import Manager
 from loguru import logger
 
@@ -145,7 +146,18 @@ class Extension:
         finally:
             cls.unlock(container_name)
 
-    async def install(self, clear_remaining_tags: bool = True, atomic: bool = False) -> AsyncGenerator[bytes, None]:
+    async def _image_is_available_locally(self) -> bool:
+        try:
+            image_ref = f"{self.source.docker}:{self.tag}" + (f"@{self.digest}" if self.digest else "")
+            async with DockerCtx() as client:
+                await client.images.inspect(image_ref)
+                return True
+        except DockerError:
+            return False
+
+    async def install(  # pylint: disable=too-many-branches
+        self, clear_remaining_tags: bool = True, atomic: bool = False
+    ) -> AsyncGenerator[bytes, None]:
         logger.info(f"Installing extension {self.identifier}:{self.tag}")
 
         # First we should make sure no other tag is running
@@ -191,12 +203,14 @@ class Extension:
             # In case of some external installs kraken shouldn't try to install it again so we remove from settings
             if atomic:
                 should_raise = False
-                if not running_ext or self.unique_entry != running_ext.unique_entry:
-                    should_raise = True
-                    await self.uninstall()
-
-                if running_ext:
-                    await running_ext.enable()
+                if await self._image_is_available_locally():
+                    logger.info(f"Pull failed but image {self.identifier}:{self.tag} is already available locally")
+                else:
+                    if not running_ext or self.unique_entry != running_ext.unique_entry:
+                        should_raise = True
+                        await self.uninstall()
+                    if running_ext:
+                        await running_ext.enable()
 
                 if should_raise:
                     raise ExtensionPullFailed(f"Failed to pull extension {self.identifier}:{self.tag}") from error


### PR DESCRIPTION
Fixes #4187.

The Extensions UI Save button re-installs via `POST /kraken/v1.0/extension/install` (`atomic=True`). Kraken always tries `docker pull` first. When the vehicle is offline that pull fails. If `from_running` does not find an enabled sibling (disabled custom extension, or the same unique_entry is not considered running), atomic recovery called `uninstall()`, which also pruned the local image. The extension disappeared from settings and could not be recovered.

This is the 1.4-shaped port of master #3649: if inspect finds `docker:tag` locally, skip uninstall/prune and keep the already-written settings. First-time install of an image that is not local still uninstalls and raises `ExtensionPullFailed`.

Does not skip the pull when the image is already local (that is a separate improvement). Host reboot recreates `blueos-core` from the image, so this code patch is not reboot-durable.

## Test plan

On `192.168.0.124` (`joaoantoniocardoso/blueos-core:1.4-dev-next`, mgmt `eth0` `192.168.0.124`). Baseline `blueos.major_tom` left installed. Custom vehicle `repro.test4187` / `hello-world:latest` (not in the store). Outbound 443/80 blocked; LAN kept. Patched `extension/extension.py` via container copy + `docker restart blueos-core`.

Before patch:

- [x] Online custom install listed `repro.test4187`
- [x] Same-tag Save while enabled and offline kept the row (unique_entry matched)
- [x] Disable, then Save while offline → HTTP stream 500 `Failed to pull`, identifier gone from `GET /kraken/v2.0/extension/` and from `settings-2.json`, `hello-world` image pruned

After patch:

- [x] Same disable + offline Save: row stays, name updates, `hello-world` image kept, log `Pull failed but image repro.test4187:latest is already available locally`
- [x] Uninstalled `repro.test4187`; identifiers restored to `major_tom` only; iptables restored; management address still pings

Full Kraken lifecycle with `bluerobotics.cockpit:v1.18.2`. 173 passed, 2 failed (pre-existing, not this diff). DUT restored to baseline identifiers; no leftover dummy manifest; factory still present; management address still pings.

- [x] v1 `POST /extension/install` of a never-installed id → 200 pull stream, not 404
- [x] v2 custom `POST /` and tagged `POST /{id}/{tag}/install` never-installed → 200, not 404
- [x] Reinstall while already running → 200, not 404
- [x] v1/v2 enable, disable, restart, uninstall of the vehicle
- [x] v2 dummy manifest create/details/enable/disable/reorder/delete
- [x] Factory manifest still present; `DELETE` factory still 409

## Skipped

- Skipping `docker pull` when the image is already local. Save still contacts the registry; this patch only stops the uninstall/prune on failure.
- NP-114 (`PUT` unknown manifest order → 409 vs 404) and duplicate dummy create → 201 (#4295). Pre-existing catalog HTTP leftovers, not this install path.
- Local unit tests for `Extension.install`. `Manager` / Docker are live-DUT concerns; the offline Save repro is the check.
