### PR TITLE
[1.4] frontend: Stop create from installing a placeholder identifier

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -35,6 +35,7 @@
           <v-text-field
             v-model="new_extension.identifier"
             label="Extension Identifier"
+            placeholder="yourorganization.yourextension"
             :disabled="is_editing"
             :rules="[validate_identifier]"
           />

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -120,7 +120,7 @@
         <div class="installed-extensions-container">
           <InstalledExtensionCard
             v-for="extension in installed_extensions"
-            :key="extension.docker"
+            :key="extension.identifier"
             :extension="extension"
             :loading="extension.loading"
             :metrics="metricsFor(extension)"

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -389,7 +389,7 @@ export default Vue.extend({
     },
     openCreationDialog() : void {
       this.edited_extension = {
-        identifier: 'yourorganization.yourextension',
+        identifier: '',
         name: '',
         docker: '',
         enabled: true,


### PR DESCRIPTION
Fixes #4014.

Create Extension prefills `yourorganization.yourextension`, which already passes identifier validation. Changing only Docker URL and tag, then CREATE, installs a second extension under that placeholder id. Kraken starts both. Installed cards were keyed by `docker`, so two rows that share an image repo collapse to one card. Uninstalling the visible store entry leaves the extra one running.

On `192.168.0.147` (`1.4-dev` on `eth0`), issue kraken logs plus a live API repro showed `yourorganization.yourextension:<copied tag>` sitting next to the original identifier.

This PR:

- Starts the identifier field empty (example stays as placeholder text). CREATE with only docker/tag fails validation.
- Keys installed cards by `identifier` instead of `docker`.

`createOrUpdateExtension` still installs `this.edited_extension`. The modal's `new_extension` is that same object on a fresh Create (`data()` assigns the prop; `watch.extension` is not `immediate`), so form edits already land on the parent. Switching to the emit payload was a no-op and was dropped.

Same create-dialog defaults and `:key="extension.docker"` are on `master`.

## Test plan

Vite frontend (`BLUEOS_ADDRESS=http://192.168.0.147/`) against that DUT, after dropping the payload switch.

Before patch (DUT UI + v1 install):

- [x] Create dialog identifier is `yourorganization.yourextension`
- [x] Store-like install + CREATE with that default identifier + different tag → both in `GET /kraken/v2.0/extension/`
- [x] Uninstall store identifier → placeholder leftover still in settings and started by the watchdog

After patch:

- [x] Create dialog identifier is empty
- [x] Issue steps: disabled store-like `bluerobotics.radcam-manager` + CREATE with name/docker/tag only → validation error; no `yourorganization.yourextension`
- [x] CREATE with identifier `testharness.ghostfix` (alpine 3.19) while store-like alpine 3.20 is present → settings get `testharness.ghostfix`, both cards visible (same `docker`, different identifier)
- [x] Uninstall both test vehicles → only `blueos.major_tom` remains

## Skipped

- Full Kraken HTTP lifecycle: backend routes are unchanged.
- Installed cards still do not print `identifier`; two same-named custom cards can look identical.
- Typing the example identifier is still allowed.