### PR TITLE
kraken: Return 404 when restarting an uninstalled extension

### DIFF
--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -167,7 +167,7 @@ class Extension:
             if running_ext:
                 await running_ext.disable()
             return running_ext
-        except ExtensionNotRunning:
+        except (ExtensionNotRunning, ExtensionNotFound):
             return None
 
     def _create_extension_settings(self) -> ExtensionSettings:
@@ -389,6 +389,8 @@ class Extension:
     @classmethod
     async def from_running(cls, identifier: str) -> "Extension":
         installed: List[Extension] = cast(List[Extension], await cls.from_settings(identifier))
+        if not installed:
+            raise ExtensionNotFound(f"Extension {identifier} not found")
 
         enabled = [ext for ext in installed if ext.source.enabled]
         if not enabled:


### PR DESCRIPTION
Return 404 when restarting an extension that is not installed.

Cherry-pick of #4264
Fix #4160