### PR TITLE
kraken: Return 404 when uninstalling an unknown extension

### DIFF
--- a/core/services/kraken/api/v1/routers/extension.py
+++ b/core/services/kraken/api/v1/routers/extension.py
@@ -3,6 +3,7 @@ from typing import Any, List, cast
 
 from api.v2.routers.extension import extension_to_http_exception
 from commonwealth.utils.streaming import streamer
+from extension.exceptions import ExtensionNotFound
 from extension.extension import Extension
 from extension.models import ExtensionSource
 from fastapi import APIRouter, status
@@ -28,6 +29,8 @@ async def install_extension(body: ExtensionSource) -> StreamingResponse:
 @extension_to_http_exception
 async def uninstall_extension(extension_identifier: str) -> Any:
     extensions = cast(List[Extension], await Extension.from_settings(extension_identifier))
+    if not extensions:
+        raise ExtensionNotFound(f"Extension {extension_identifier} not found")
     await asyncio.gather(*[ext.uninstall() for ext in extensions])
 
 

--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -165,6 +165,8 @@ async def uninstall(identifier: str) -> None:
     Uninstall all versions of an extension by its identifier.
     """
     extensions = cast(List[Extension], await Extension.from_settings(identifier))
+    if not extensions:
+        raise ExtensionNotFound(f"Extension {identifier} not found")
     await asyncio.gather(*[ext.uninstall() for ext in extensions])
 
 


### PR DESCRIPTION
Return 404 when uninstalling an extension that is not installed.

Cherry-pick of #4269
Fix #4266