### PR TITLE
kraken: Return 404 when fetching details of an unknown extension

### DIFF
--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -62,6 +62,8 @@ async def fetch_by_identifier(identifier: str) -> list[ExtensionSource]:
     List details of all versions of a given extension.
     """
     extensions = cast(List[Extension], await Extension.from_settings(identifier))
+    if not extensions:
+        raise ExtensionNotFound(f"Extension {identifier} not found")
     return [ext.source for ext in extensions]
 
 


### PR DESCRIPTION
Return 404 when fetching details of an extension that is not installed.

Cherry-pick of #4270
Fix #4267