### PR TITLE
kraken: Keep non-zero patch tags in latest-stable

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -297,7 +297,7 @@ class ManifestManager:
                 tagged.append((version, tag))
         tagged.sort(key=lambda item: item[0], reverse=True)
         if stable:
-            tagged = [(version, tag) for version, tag in tagged if not version.prerelease and not version.patch]
+            tagged = [(version, tag) for version, tag in tagged if not version.prerelease]
         return [tag for _, tag in tagged]
 
     async def fetch_latest_extension_version(


### PR DESCRIPTION
Keep non-zero patch tags when resolving latest-stable.

Cherry-pick of #4275
Fix #4272