### PR TITLE
kraken: Return 404 when streaming logs of a missing container

### DIFF
--- a/core/services/kraken/api/v1/routers/index.py
+++ b/core/services/kraken/api/v1/routers/index.py
@@ -1,5 +1,6 @@
 from typing import Any, List, Optional, cast
 
+from api.v2.routers.container import container_to_http_exception
 from api.v2.routers.manifest import manifest_to_http_exception
 from commonwealth.utils.streaming import streamer, timeout_streamer
 from extension.extension import Extension
@@ -38,11 +39,13 @@ async def list_containers() -> Any:
 
 
 @index_router_v1.get("/log", status_code=status.HTTP_200_OK, response_class=PlainTextResponse)
+@container_to_http_exception
 async def log_containers(container_name: str, timeout: Optional[int] = None) -> StreamingResponse:
     """
     Fetch logs of a given container.
     If timeout is provided, the stream will be closed after no log line is received for the given timeout.
     """
+    await ContainerManager.get_running_container_by_name(container_name)
     stream = ContainerManager.get_container_log_by_name(container_name)
 
     if timeout is not None:


### PR DESCRIPTION
Return 404 when streaming logs of a container that is not running.

Cherry-pick of #4276
Fix #4273