### PR TITLE
kraken: Return 400 when installing an incompatible extension

### DIFF
--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -8,6 +8,7 @@ from extension.exceptions import (
     ExtensionNotFound,
     ExtensionNotRunning,
     ExtensionPullFailed,
+    IncompatibleExtension,
 )
 from extension.extension import Extension
 from extension.models import ExtensionSource
@@ -32,6 +33,8 @@ def extension_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., A
         except ExtensionNotFound as error:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
         except ExtensionNotRunning as error:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+        except IncompatibleExtension as error:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
         except ExtensionInsufficientStorage as error:
             raise HTTPException(status_code=status.HTTP_507_INSUFFICIENT_STORAGE, detail=str(error)) from error


### PR DESCRIPTION
Return 400 when installing an extension with no compatible image.

Cherry-pick of #4285
Fix #4279