### PR TITLE
kraken: Return 409 when creating a duplicate catalog source

### DIFF
--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -163,6 +163,11 @@ class ManifestManager:
     async def add_source(self, source: ManifestSource, validate_url: bool) -> Manifest:
         manifests = self._get_settings()
 
+        if any(manifest.name == source.name and manifest.url == source.url for manifest in manifests):
+            raise ManifestOperationNotAllowed(
+                f"Manifest source with name [{source.name}] and url [{source.url}] already exists"
+            )
+
         new_manifest_settings = ManifestSettings(
             identifier=str(uuid.uuid4()),
             priority=len(manifests),


### PR DESCRIPTION
Return 409 when creating a catalog source with a name and URL that already exist.

Cherry-pick of #4296
Fix #4295