### PR TITLE
kraken: Return 404 when listing tags of an unknown extension

### DIFF
--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -3,6 +3,8 @@ from typing import Any, Callable, Tuple
 
 from fastapi import APIRouter, HTTPException, status
 from fastapi_versioning import versioned_api_route
+
+from extension.exceptions import ExtensionNotFound
 from manifest import ManifestManager
 from manifest.exceptions import (
     ManifestDataFetchFailed,
@@ -35,7 +37,7 @@ def manifest_to_http_exception(endpoint: Callable[..., Any]) -> Callable[..., An
             return await endpoint(*args, **kwargs)
         except (ManifestDataFetchFailed, ManifestDataParseFailed, ManifestInvalidURL) as error:
             raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(error)) from error
-        except ManifestNotFound as error:
+        except (ManifestNotFound, ExtensionNotFound) as error:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
         except ManifestOperationNotAllowed as error:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error)) from error
@@ -82,6 +84,8 @@ async def fetch_ext_tags_from_manifest(
     """
     Get all tags for a given extension identifier using one manifest as source.
     """
+    if not await manifest_manager.fetch_extension(extension_identifier, manifest_identifier):
+        raise ExtensionNotFound(f"Extension {extension_identifier} not found")
     versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable, manifest_identifier)
 
     return [str(version) for version in versions]
@@ -93,6 +97,8 @@ async def fetch_ext_tags_from_consolidated(extension_identifier: str, stable: bo
     """
     Get all tags for a given extension identifier using consolidated manifest as source.
     """
+    if not await manifest_manager.fetch_extension(extension_identifier):
+        raise ExtensionNotFound(f"Extension {extension_identifier} not found")
     versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable)
 
     return [str(version) for version in versions]

--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -1,10 +1,9 @@
 from functools import wraps
 from typing import Any, Callable, Tuple
 
+from extension.exceptions import ExtensionNotFound
 from fastapi import APIRouter, HTTPException, status
 from fastapi_versioning import versioned_api_route
-
-from extension.exceptions import ExtensionNotFound
 from manifest import ManifestManager
 from manifest.exceptions import (
     ManifestDataFetchFailed,

--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -84,11 +84,10 @@ async def fetch_ext_tags_from_manifest(
     """
     Get all tags for a given extension identifier using one manifest as source.
     """
-    if not await manifest_manager.fetch_extension(extension_identifier, manifest_identifier):
+    ext = await manifest_manager.fetch_extension(extension_identifier, manifest_identifier)
+    if not ext:
         raise ExtensionNotFound(f"Extension {extension_identifier} not found")
-    versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable, manifest_identifier)
-
-    return [str(version) for version in versions]
+    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
 
 
 @manifest_router_v2.get("/tags/{extension_identifier}", status_code=status.HTTP_200_OK)
@@ -97,11 +96,10 @@ async def fetch_ext_tags_from_consolidated(extension_identifier: str, stable: bo
     """
     Get all tags for a given extension identifier using consolidated manifest as source.
     """
-    if not await manifest_manager.fetch_extension(extension_identifier):
+    ext = await manifest_manager.fetch_extension(extension_identifier)
+    if not ext:
         raise ExtensionNotFound(f"Extension {extension_identifier} not found")
-    versions = await manifest_manager.fetch_extension_versions(extension_identifier, stable)
-
-    return [str(version) for version in versions]
+    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
 
 
 @manifest_router_v2.post("/", status_code=status.HTTP_201_CREATED)

--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -256,11 +256,9 @@ class ManifestManager:
 
         return next((ext for ext in manifest if ext.identifier == extension_id), None)
 
-    async def fetch_extension_versions(
-        self, extension_id: str, stable: bool, manifest_id: Optional[str] = None
-    ) -> List[semver.VersionInfo]:
-        ext = await self.fetch_extension(extension_id, manifest_id)
-        if not ext or not ext.versions:
+    @staticmethod
+    def versions_from_entry(ext: RepositoryEntry, stable: bool) -> List[semver.VersionInfo]:
+        if not ext.versions:
             return []
 
         def valid_semver(string: str) -> Optional[semver.VersionInfo]:
@@ -288,7 +286,7 @@ class ManifestManager:
         if not ext or not ext.versions:
             return None
 
-        versions = await self.fetch_extension_versions(extension_id, stable, manifest_id)
+        versions = self.versions_from_entry(ext, stable)
 
         return (ext.versions.get(str(versions[0])) or ext.versions.get(f"v{versions[0]}")) if versions else None
 


### PR DESCRIPTION
Return 404 when listing tags of an unknown extension.

Cherry-pick of #4283
Fix #4277