### PR TITLE
kraken: Keep v-prefix on tags API and tagged lookup

### DIFF
--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -86,7 +86,7 @@ async def fetch_ext_tags_from_manifest(
     ext = await manifest_manager.fetch_extension(extension_identifier, manifest_identifier)
     if not ext:
         raise ExtensionEntryNotFound(f"Extension {extension_identifier} not found")
-    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
+    return manifest_manager.versions_from_entry(ext, stable)
 
 
 @manifest_router_v2.get("/tags/{extension_identifier}", status_code=status.HTTP_200_OK)
@@ -98,7 +98,7 @@ async def fetch_ext_tags_from_consolidated(extension_identifier: str, stable: bo
     ext = await manifest_manager.fetch_extension(extension_identifier)
     if not ext:
         raise ExtensionEntryNotFound(f"Extension {extension_identifier} not found")
-    return [str(version) for version in manifest_manager.versions_from_entry(ext, stable)]
+    return manifest_manager.versions_from_entry(ext, stable)
 
 
 @manifest_router_v2.post("/", status_code=status.HTTP_201_CREATED)

--- a/core/services/kraken/manifest/manifest.py
+++ b/core/services/kraken/manifest/manifest.py
@@ -257,7 +257,7 @@ class ManifestManager:
         return next((ext for ext in manifest if ext.identifier == extension_id), None)
 
     @staticmethod
-    def versions_from_entry(ext: RepositoryEntry, stable: bool) -> List[semver.VersionInfo]:
+    def versions_from_entry(ext: RepositoryEntry, stable: bool) -> List[str]:
         if not ext.versions:
             return []
 
@@ -270,14 +270,15 @@ class ManifestManager:
             except ValueError:
                 return None
 
-        versions: List[semver.VersionInfo] = sorted(
-            [ver for ver in (valid_semver(tag) for tag in ext.versions) if ver is not None],
-            reverse=True,
-        )
+        tagged = []
+        for tag in ext.versions:
+            version = valid_semver(tag)
+            if version is not None:
+                tagged.append((version, tag))
+        tagged.sort(key=lambda item: item[0], reverse=True)
         if stable:
-            versions = [v for v in versions if not v.prerelease and not v.patch]
-
-        return versions
+            tagged = [(version, tag) for version, tag in tagged if not version.prerelease and not version.patch]
+        return [tag for _, tag in tagged]
 
     async def fetch_latest_extension_version(
         self, extension_id: str, stable: bool, manifest_id: Optional[str] = None
@@ -288,11 +289,15 @@ class ManifestManager:
 
         versions = self.versions_from_entry(ext, stable)
 
-        return (ext.versions.get(str(versions[0])) or ext.versions.get(f"v{versions[0]}")) if versions else None
+        return ext.versions.get(versions[0]) if versions else None
 
     async def fetch_extension_version(self, extension_id: str, tag: str) -> Optional[ExtensionVersion]:
         ext = await self.fetch_extension(extension_id)
         if not ext:
             return None
 
-        return ext.versions.get(tag)
+        return (
+            ext.versions.get(tag)
+            or ext.versions.get(f"v{tag}")
+            or (ext.versions.get(tag[1:]) if tag.startswith("v") else None)
+        )


### PR DESCRIPTION
/tags returned str(semver) while catalog keys are often v-prefixed.

Cherry-pick of #4284
~~needs: #4312~~