### PR TITLE
frontend: Stop create from installing a placeholder identifier

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -36,6 +36,7 @@
           <v-text-field
             v-model="new_extension.identifier"
             label="Extension Identifier"
+            placeholder="yourorganization.yourextension"
             :disabled="is_editing"
             :rules="[validate_identifier]"
           />

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -851,7 +851,7 @@ export default Vue.extend({
     },
     openCreationDialog() : void {
       this.edited_extension = {
-        identifier: 'yourorganization.yourextension',
+        identifier: '',
         name: '',
         docker: '',
         enabled: true,

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -290,7 +290,7 @@
         <div class="installed-extensions-container">
           <InstalledExtensionCard
             v-for="extension in installed_extensions"
-            :key="extension.docker"
+            :key="extension.identifier"
             :extension="extension"
             :loading="extension.loading"
             :metrics="metricsFor(extension)"


### PR DESCRIPTION
Create Extension prefills a placeholder identifier that already passes validation.

Cherry-pick of #4298
Fix #4014