### PR TITLE
[1.4] core: services: ping: Fix last_valid_baud starting at 115200

### DIFF
--- a/core/services/ping/pingdriver.py
+++ b/core/services/ping/pingdriver.py
@@ -27,7 +27,7 @@ class PingDriver:
         failure_threshold = 0.1  # allow up to 10% failure rate
         attempts = 10  # try up to 10 times per baudrate
         max_failures = attempts * failure_threshold
-        last_valid_baud = Baudrate.b115200
+        last_valid_baud: Optional[Baudrate] = None
 
         if self.ping.port is None:
             raise InvalidDeviceDescriptor("PingDeviceDescriptor has no usable port")
@@ -53,6 +53,8 @@ class PingDriver:
             if failures <= max_failures:
                 last_valid_baud = baud
             logger.debug(f"Baudrate {baud} is {'valid' if baud==last_valid_baud else 'invalid'}")
+        if last_valid_baud is None:
+            raise RuntimeError("No valid baudrate detected")
         logger.info(f"Highest baudrate detected: {last_valid_baud}")
         return last_valid_baud
 


### PR DESCRIPTION
A failed baud sweep still returned 115200 and registered a dead device.

Cherry-pick of #4220
Fix #1190