### PR TITLE
core: frontend: nmea-injector: NMEAInjector: Fix html indent

### DIFF
--- a/core/frontend/src/components/nmea-injector/NMEAInjector.vue
+++ b/core/frontend/src/components/nmea-injector/NMEAInjector.vue
@@ -10,8 +10,8 @@
       text
       dense
     >
-    The autopilot will not use injected position until {{ gps_type_param?.name }} is MAV (14).
-    It is currently {{ gps_type_param?.value }}. Reboot the autopilot after changing the parameter.
+      The autopilot will not use injected position until {{ gps_type_param?.name }} is MAV (14).
+      It is currently {{ gps_type_param?.value }}. Reboot the autopilot after changing the parameter.
     </v-alert>
     <v-card
       class="mx-auto my-6"


### PR DESCRIPTION
The GPS-type warning sat at 4 spaces, vue/html-indent wants 6.

fix issue introduced in: #4322