### PR TITLE
core: frontend: nmea-injector: Fix GPS warning html indent

### DIFF
--- a/core/frontend/src/components/nmea-injector/NMEAInjector.vue
+++ b/core/frontend/src/components/nmea-injector/NMEAInjector.vue
@@ -10,8 +10,8 @@
       text
       dense
     >
-    The autopilot will not use injected position until {{ gps_type_param?.name }} is MAV (14).
-    It is currently {{ gps_type_param?.value }}. Reboot the autopilot after changing the parameter.
+      The autopilot will not use injected position until {{ gps_type_param?.name }} is MAV (14).
+      It is currently {{ gps_type_param?.value }}. Reboot the autopilot after changing the parameter.
     </v-alert>
     <v-card
       class="mx-auto my-6"


### PR DESCRIPTION
## Summary
- Indent the GPS-type warning text in `NMEAInjector.vue` so `vue/html-indent` passes.
- Unblocks `frontend-tests` / Bun lint on `master` after #4322.

## Test plan
- [x] `eslint --max-warnings=0` on `NMEAInjector.vue`
- [ ] Confirm `frontend-tests` is green on this PR
