### PR TITLE
[1.4] Disable nginx buffering for Kraken log and install streams

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -123,6 +123,7 @@ http {
         location /kraken/ {
             include cors.conf;
             proxy_pass http://127.0.0.1:9134/;
+            proxy_buffering off;
         }
 
         location /nmea-injector/ {


### PR DESCRIPTION
Fixes #4332.

Nginx was holding `GET /kraken/.../log` (and the same chunked install/update pull stream) until a ~4 kB proxy buffer filled. The Extensions Manager stayed on **Awaiting logs** for several seconds, then dumped a burst. Download during that wait saved an empty file because the UI only fills `log_output` from `onDownloadProgress`.

Kraken itself is fine: the same request to `:9134` returns the first byte in ~20 ms. `/version-chooser/` already sets `proxy_buffering off` for docker-pull progress; `/kraken/` did not.

This adds `proxy_buffering off` on `location /kraken/`. Live on a DUT, nginx TTFB dropped from 3.5–10.8 s to ~25 ms.

## Test plan

- [x] Unpatched: `GET /kraken/v1.0/log?container_name=<running-extension>` through nginx TTFB 3.5–10.8 s; `:9134` ~22 ms
- [x] Live `proxy_buffering off` + `nginx -s reload`: nginx TTFB 24–26 ms (Cockpit Lite and BR Docs, three samples each)
- [x] After merge/image: View Logs on Installed shows lines immediately; download after they appear is non-empty
- [x] Extension install/update pull progress still streams in the UI
