### PR TITLE
[1.4] Kraken: Reject whitespace in manual extension creation

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -200,6 +200,9 @@ export default Vue.extend({
     validate_identifier(input: string): (true | string) {
       // Identifiers should be two words separated by a period
       // They can contain lower and uppercase characters, but cannot begin with a number
+      if (/\s/.test(input)) {
+        return 'This field must not contain whitespace.'
+      }
       const name_validator = '[A-Za-z][A-Za-z0-9]+'
       const regex = RegExp(`^${name_validator}\\.${name_validator}`)
       if (regex.test(input)) {
@@ -212,6 +215,7 @@ export default Vue.extend({
       const path_part_regex = /^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*$/
 
       if (!input) return 'Name must not be empty'
+      if (/\s/.test(input)) return 'Name must not contain whitespace'
 
       const parts = input.split('/')
 
@@ -232,16 +236,21 @@ export default Vue.extend({
       return true
     },
     validate_name(input: string): (true | string) {
-      if (input.trim().length === 0) {
+      // Trim only for checks so a space while typing the next word is not an error.
+      const name = input.trim()
+      if (name.length === 0) {
         return 'This field must not be empty.'
       }
-      if (input.length > 128) {
+      if (name.length > 128) {
         return 'This entry must fit within 128 characters.'
       }
       return true
     },
     validate_tag(input: string) {
-      if (input.includes(' ')) {
+      if (!input) {
+        return 'Tag name must not be empty.'
+      }
+      if (/\s/.test(input)) {
         return 'Tag name must not include spaces.'
       }
       if (input.startsWith('-') || input.startsWith('.')) {
@@ -260,6 +269,7 @@ export default Vue.extend({
       if (this.new_permissions) {
         this.new_extension.user_permissions = JSON.stringify(this.new_permissions)
       }
+      this.new_extension.name = this.new_extension.name.trim()
       if (this.form.validate() === true) {
         this.$emit('extensionChange', this.new_extension)
       }

--- a/core/services/kraken/api/v1/routers/extension.py
+++ b/core/services/kraken/api/v1/routers/extension.py
@@ -9,7 +9,7 @@ from fastapi_versioning import versioned_api_route
 from api.v2.routers.extension import extension_to_http_exception
 from extension.exceptions import ExtensionNotFound
 from extension.extension import Extension
-from extension.models import ExtensionSource
+from extension.models import ExtensionInstallSource
 
 extension_router_v1 = APIRouter(
     prefix="/extension",
@@ -21,7 +21,7 @@ extension_router_v1 = APIRouter(
 
 @extension_router_v1.post("/install", status_code=status.HTTP_201_CREATED)
 @extension_to_http_exception
-async def install_extension(body: ExtensionSource) -> StreamingResponse:
+async def install_extension(body: ExtensionInstallSource) -> StreamingResponse:
     extension = Extension(body)
     return StreamingResponse(streamer(extension.install(atomic=True)))
 

--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -14,7 +14,7 @@ from extension.exceptions import (
     IncompatibleExtension,
 )
 from extension.extension import Extension
-from extension.models import ExtensionSource
+from extension.models import ExtensionInstallSource, ExtensionSource
 from manifest.exceptions import ManifestBackendOffline
 
 extension_router_v2 = APIRouter(
@@ -82,7 +82,7 @@ async def fetch_by_identifier_and_tag(identifier: str, tag: str) -> ExtensionSou
 
 @extension_router_v2.post("/", status_code=status.HTTP_201_CREATED)
 @extension_to_http_exception
-async def install(body: ExtensionSource) -> StreamingResponse:
+async def install(body: ExtensionInstallSource) -> StreamingResponse:
     """
     Install an extension by a custom source instead of the valid manifests, be careful with this endpoint because it
     can install incompatible extensions. Make sure to check the extension source before installing it.

--- a/core/services/kraken/extension/models.py
+++ b/core/services/kraken/extension/models.py
@@ -1,7 +1,8 @@
 import json
+import re
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from manifest.models import ExtensionVersion, RepositoryEntry
 from settings import ExtensionSettings
@@ -45,3 +46,26 @@ class ExtensionSource(BaseModel):
             permissions=json.dumps(version.permissions),
             user_permissions="",
         )
+
+
+class ExtensionInstallSource(ExtensionSource):
+    """Manual-install body. Separate from ExtensionSource so already-installed values still list."""
+
+    @validator("identifier", "docker", "tag")
+    @classmethod
+    def reject_whitespace(cls, value: str) -> str:
+        if not value:
+            raise ValueError("must not be empty")
+        if re.search(r"\s", value):
+            raise ValueError("must not contain whitespace")
+        return value
+
+    @validator("name")
+    @classmethod
+    def strip_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be empty")
+        if len(value) > 128:
+            raise ValueError("must fit within 128 characters")
+        return value


### PR DESCRIPTION
Fixes https://github.com/bluerobotics/BlueOS/issues/1741

Manual Create Extension accepted whitespace that Docker cannot use. On the DUT the identifier and name allowed trailing spaces, and the docker image field allowed a leading space (or a space before `/`) because the first path component is treated as a domain and `URL.canParse` is lenient. Submitting that form called `POST /kraken/v1.0/extension/install` and failed with `Failed to pull extension test.whitespace :latest`. The same payload on `POST /kraken/v2.0/extension/` returned 200 and streamed the pull failure. The backend stored the spaced identifier before the atomic uninstall.

This PR:

- Rejects any whitespace in identifier, docker image, and tag, and leading/trailing whitespace in the extension name, in the create/edit form
- Validates the same rules on the v1 install and v2 custom-install bodies via `ExtensionInstallSource`, returning 422 before settings are saved
- Leaves `ExtensionSource` unvalidated so already-installed dirty identifiers still list

## Test plan

- [x] Unpatched DUT `192.168.0.124`: create form accepts `test.whitespace `, `Whitespace Test `, and ` library/busybox`; CREATE pulls `test.whitespace :latest` and fails
- [x] Unpatched `POST /kraken/v2.0/extension/` with those fields returns 200 then a pull error; installed list is unchanged after atomic uninstall
- [x] Hosted frontend (`BLUEOS_ADDRESS=http://192.168.0.124/ bun run dev`): CREATE with those spaced fields is blocked (identifier / name / docker errors); CREATE does not start a pull
- [x] Overlay kraken `models.py` and v1/v2 extension routers on the DUT: 11 whitespace/empty cases x v1+v2 = 22/22 HTTP 422; GET still lists the existing dirty identifier
- [x] Hosted frontend CREATE with clean `test.whitespace1741` / `bluerobotics/blueos-docs:2025.2.8` installs; v2 DELETE restores baseline
- [x] `journey_http --extension-lifecycle --allow-mutating --skip-latest`: passed=162 failed=0 skipped=4; DUT back to baseline identifiers