### PR TITLE
[1.4] Omit catalog readmes so Extensions Manager loads on slow links

### DIFF
--- a/core/frontend/src/components/kraken/KrakenManager.ts
+++ b/core/frontend/src/components/kraken/KrakenManager.ts
@@ -88,8 +88,8 @@ export async function fetchConsolidatedManifests(): Promise<ExtensionData[]> {
 export async function fetchCatalogExtension(identifier: string): Promise<ExtensionData> {
   const response = await back_axios({
     method: 'get',
-    url: `${KRAKEN_API_V2_URL}/manifest/consolidated/${identifier}`,
-    timeout: 15000,
+    url: `${KRAKEN_API_V2_URL}/manifest/consolidated/${encodeURIComponent(identifier)}`,
+    timeout: 60000,
   })
 
   return withCompatibility(response.data as ExtensionData)

--- a/core/frontend/src/components/kraken/KrakenManager.ts
+++ b/core/frontend/src/components/kraken/KrakenManager.ts
@@ -82,6 +82,20 @@ export async function fetchConsolidatedManifests(): Promise<ExtensionData[]> {
 }
 
 /**
+ * Fetch one catalog entry including per-version readme/docs, uses API v2
+ * @param {string} identifier The extension identifier
+ */
+export async function fetchCatalogExtension(identifier: string): Promise<ExtensionData> {
+  const response = await back_axios({
+    method: 'get',
+    url: `${KRAKEN_API_V2_URL}/manifest/consolidated/${identifier}`,
+    timeout: 15000,
+  })
+
+  return withCompatibility(response.data as ExtensionData)
+}
+
+/**
  * Creates a new manifest source in kraken, uses API v2
  * @param {boolean} validateUrl If true, will throw in case an invalid manifest source is provided in given URL
  * @returns {Promise<Manifest>} The created manifest source with data already fetched in case validate is true,
@@ -191,6 +205,7 @@ export default {
   fetchManifestSources,
   fetchManifestSource,
   fetchConsolidatedManifests,
+  fetchCatalogExtension,
   fetchInstalledExtensions,
   addManifestSource,
   updateManifestSource,

--- a/core/frontend/src/components/kraken/KrakenManager.ts
+++ b/core/frontend/src/components/kraken/KrakenManager.ts
@@ -57,6 +57,15 @@ export async function fetchManifestSource(identifier: string, data = true): Prom
   return response.data as Manifest
 }
 
+function withCompatibility(extension: ExtensionData): ExtensionData {
+  return {
+    ...extension,
+    is_compatible: Object.values(extension.versions).some(
+      (version) => version.images.some((image) => image.compatible),
+    ),
+  }
+}
+
 /**
  * Fetch all manifests from kraken in a single merged representation, repeated entries will be excluded, only the one
  * present in the manifest wth higher priority will be kept, uses API v2
@@ -69,12 +78,7 @@ export async function fetchConsolidatedManifests(): Promise<ExtensionData[]> {
     timeout: 25000,
   })
 
-  return (response.data as ExtensionData[]).map((extension: ExtensionData) => ({
-    ...extension,
-    is_compatible: Object.values(extension.versions).some(
-      (version) => version.images.some((image) => image.compatible),
-    ),
-  }))
+  return (response.data as ExtensionData[]).map(withCompatibility)
 }
 
 /**

--- a/core/frontend/src/components/kraken/KrakenManager.ts
+++ b/core/frontend/src/components/kraken/KrakenManager.ts
@@ -75,7 +75,7 @@ export async function fetchConsolidatedManifests(): Promise<ExtensionData[]> {
   const response = await back_axios({
     method: 'get',
     url: `${KRAKEN_API_V2_URL}/manifest/consolidated`,
-    timeout: 25000,
+    timeout: 60000,
   })
 
   return (response.data as ExtensionData[]).map(withCompatibility)

--- a/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionDetailsModal.vue
@@ -246,7 +246,7 @@ export default Vue.extend({
     },
   },
   watch: {
-    extension() {
+    'extension.identifier'() {
       this.selected_version = this.getLatestTag()
       this.editing_permissions = this.getVersionPermissions()
       this.custom_permissions = {}

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -520,9 +520,17 @@ export default Vue.extend({
       const file = new File([this.log_output ?? ''], `${this.log_container_name}.log`, { type: 'text/plain' })
       saveAs(file)
     },
-    showModal(extension: ExtensionData) {
+    async showModal(extension: ExtensionData) {
       this.show_dialog = true
       this.selected_extension = extension
+      try {
+        const full = await kraken.fetchCatalogExtension(extension.identifier)
+        if (this.selected_extension?.identifier === full.identifier) {
+          this.selected_extension = full
+        }
+      } catch {
+        // Compact catalog entry is enough to install; readme stays empty.
+      }
     },
     async install(
       identifier: string,

--- a/core/services/kraken/api/v1/routers/index.py
+++ b/core/services/kraken/api/v1/routers/index.py
@@ -25,7 +25,7 @@ manifest_manager = ManifestManager.instance()
 @index_router_v1.get("/extensions_manifest", status_code=status.HTTP_200_OK)
 @manifest_to_http_exception
 async def fetch_manifest() -> list[RepositoryEntry]:
-    return await manifest_manager.fetch_consolidated()
+    return [entry.without_readme() for entry in await manifest_manager.fetch_consolidated()]
 
 
 @index_router_v1.get("/installed_extensions", status_code=status.HTTP_200_OK)

--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -79,8 +79,10 @@ async def fetch_consolidated() -> list[RepositoryEntry]:
     """
     List a consolidation of all repository entries from all manifest sources merged by its sorted priority, if a
     repository entry is duplicated, the one with the highest priority will be kept.
+
+    Per-version readme/docs are omitted so the store list stays small.
     """
-    return await manifest_manager.fetch_consolidated()
+    return [entry.without_readme() for entry in await manifest_manager.fetch_consolidated()]
 
 
 @manifest_router_v2.get("/tags/{manifest_identifier}/{extension_identifier}/", status_code=status.HTTP_200_OK)

--- a/core/services/kraken/api/v2/routers/manifest.py
+++ b/core/services/kraken/api/v2/routers/manifest.py
@@ -85,6 +85,18 @@ async def fetch_consolidated() -> list[RepositoryEntry]:
     return [entry.without_readme() for entry in await manifest_manager.fetch_consolidated()]
 
 
+@manifest_router_v2.get("/consolidated/{extension_identifier}", status_code=status.HTTP_200_OK)
+@manifest_to_http_exception
+async def fetch_consolidated_extension(extension_identifier: str) -> RepositoryEntry:
+    """
+    Get one catalog entry from the consolidated manifests, including readme and docs.
+    """
+    ext = await manifest_manager.fetch_extension(extension_identifier)
+    if not ext:
+        raise ExtensionEntryNotFound(f"Extension {extension_identifier} not found")
+    return ext
+
+
 @manifest_router_v2.get("/tags/{manifest_identifier}/{extension_identifier}/", status_code=status.HTTP_200_OK)
 @manifest_to_http_exception
 async def fetch_ext_tags_from_manifest(

--- a/core/services/kraken/manifest/models.py
+++ b/core/services/kraken/manifest/models.py
@@ -113,6 +113,16 @@ class ExtensionMetadata(BaseModel):
 class RepositoryEntry(ExtensionMetadata):
     versions: Dict[str, ExtensionVersion] = Field(default_factory=dict)
 
+    def without_readme(self) -> "RepositoryEntry":
+        """Shallow copy with per-version readme/docs cleared for catalog list payloads."""
+        return self.copy(
+            update={
+                "versions": {
+                    tag: version.copy(update={"readme": None, "docs": None}) for tag, version in self.versions.items()
+                }
+            }
+        )
+
 
 # Local Manifest models
 


### PR DESCRIPTION
## Summary
- The Extensions Manager store timed out on slow links because `GET /kraken/v2.0/manifest/consolidated` returned ~9.6MB of JSON, almost all per-version README HTML.
- Catalog list responses now omit `readme`/`docs`. Opening an extension fetches the full entry from `GET /kraken/v2.0/manifest/consolidated/{identifier}`.

Fixes #3429

## Test plan
- [x] On DUT 192.168.0.69 (Pi 3, `1.4-dev`), unpatched Slow 3G: store shows "Failed to fetch extension manifest"
- [x] After overlay: consolidated payload 398KB (was 9629KB); all 333 version readmes omitted from the list; single-entry endpoint still returns readme
- [x] Store lists extensions including OpenVSCoder; unknown identifier returns 404
- [x] Kraken lifecycle on DUT: vehicle `bluerobotics.power-switch-calibration:v1.0.0`, 168 passed / 1 skipped / 1 leftover FAIL (`too-big` -> 400 incompatible on armv7, not 507)
- [ ] Details modal on a built frontend shows readme after the lazy fetch
