### PR TITLE
[1.4] Timeout extension pulls from last Docker progress

### DIFF
--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -212,6 +212,29 @@ const API_URL = '/kraken/v1.0'
 const notifier = new Notifier(kraken_service)
 const ansi = new AnsiUp()
 
+// Axios `timeout` is a hard deadline from request start, so large or slow pulls die
+// while Docker is still streaming. Cancel only after this long with no new bytes.
+const PULL_IDLE_TIMEOUT_MS = 120000
+
+function startPullIdleWatchdog() {
+  const source = axios.CancelToken.source()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const stop = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+  }
+  const bump = () => {
+    stop()
+    timer = setTimeout(() => {
+      source.cancel(`No data received for ${PULL_IDLE_TIMEOUT_MS}ms`)
+    }, PULL_IDLE_TIMEOUT_MS)
+  }
+  bump()
+  return { cancelToken: source.token, bump, stop }
+}
+
 export default Vue.extend({
   name: 'ExtensionManagerView',
   components: {
@@ -330,6 +353,7 @@ export default Vue.extend({
           notifier.pushBackError('EXTENSIONS_INSTALL_FAIL', error)
         },
       )
+      const watchdog = startPullIdleWatchdog()
       back_axios({
         url: `${API_URL}/extension/update_to_version`,
         method: 'POST',
@@ -337,8 +361,9 @@ export default Vue.extend({
           extension_identifier: extension.identifier,
           new_version: version,
         },
-        timeout: 120000,
+        cancelToken: watchdog.cancelToken,
         onDownloadProgress: (progressEvent) => {
+          watchdog.bump()
           tracker.digestNewData(progressEvent)
           this.pull_output = tracker.pull_output
           this.download_percentage = tracker.download_percentage
@@ -355,6 +380,7 @@ export default Vue.extend({
           notifier.pushBackError('EXTENSIONS_INSTALL_FAIL', error)
         })
         .finally(() => {
+          watchdog.stop()
           this.show_pull_output = false
           this.show_dialog = false
           this.pull_output = ''
@@ -549,6 +575,7 @@ export default Vue.extend({
         },
       )
 
+      const watchdog = startPullIdleWatchdog()
       back_axios({
         url: `${API_URL}/extension/install`,
         method: 'POST',
@@ -561,7 +588,9 @@ export default Vue.extend({
           permissions,
           user_permissions,
         },
+        cancelToken: watchdog.cancelToken,
         onDownloadProgress: (progressEvent) => {
+          watchdog.bump()
           tracker.digestNewData(progressEvent)
           this.pull_output = tracker.pull_output
           this.download_percentage = tracker.download_percentage
@@ -578,6 +607,7 @@ export default Vue.extend({
           notifier.pushBackError('EXTENSIONS_INSTALL_FAIL', error)
         })
         .finally(() => {
+          watchdog.stop()
           this.show_pull_output = false
           this.show_dialog = false
           this.pull_output = ''


### PR DESCRIPTION
Fixes #3078.

Axios `timeout: 120000` on extension **update** is a wall-clock deadline from request start. A large or slow Docker pull still streams progress, but the UI aborts at two minutes with `timeout of 120000ms exceeded` (the install path had no timeout at all).

Cancel only after 120s with no new download bytes. `install()` uses the same idle watchdog so a hung pull does not sit forever, while a long pull that is still moving is left alone.

## Test plan

DUT `192.168.0.124` (`bluerobotics/blueos-core:1.4-dev`), management `eth0`. Local frontend (`BLUEOS_ADDRESS=http://192.168.0.124/`) for the UI path.

- [x] Repro: `POST /kraken/v1.0/extension/update_to_version` of `bluerobotics.jupyter:0.2.0` with a 120s total client timeout while the stream was still delivering data (`timeout of 120000ms exceeded`, last chunk at ~128s)
- [x] After the change: idle client on the same endpoint survived 142s with data still arriving (idle watchdog did not fire)
- [x] Local frontend install of Cockpit Lite `v1.19.0-beta.9` completed; no timeout banner
- [x] Kraken lifecycle `bluerobotics.cockpit:v1.19.0-beta.9`: 177 passed, 0 failed; DUT restored to `blueos-docs` + `major_tom`

Leftover (not this PR): if Docker goes silent for >120s *after* the last pull line (e.g. deleting leftover tags), the UI can still idle-cancel while the backend finishes. Heartbeats on the kraken stream would cover that.
