### PR TITLE
[1.4] core: services: ping: Remove sensors available log

### DIFF
--- a/core/services/ping/main.py
+++ b/core/services/ping/main.py
@@ -39,8 +39,7 @@ ping_manager = PingManager()
 @version(1, 0)
 def get_sensors() -> Any:
     devices = ping_manager.devices()
-    logger.info(f"Sensors available: {devices}")
-    return [PingDeviceDescriptorModel.from_descriptor(device) for device in ping_manager.devices()]
+    return [PingDeviceDescriptorModel.from_descriptor(device) for device in devices]
 
 
 @app.post("/sensors", status_code=status.HTTP_200_OK, summary="Set sensor settings.")


### PR DESCRIPTION
This endpoint is polled, so the log fills the terminal.

Cherry-pick of #4345
Fix #4344