### PR TITLE
core: frontend: FirmwareManager: Clear firmware list before fetch

### DIFF
--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -494,6 +494,7 @@ export default Vue.extend({
     },
     async updateAvailableFirmwares(): Promise<void> {
       this.chosen_firmware_url = null
+      this.available_firmwares = []
       this.cloud_firmware_options_status = CloudFirmwareOptionsStatus.Fetching
       await back_axios({
         method: 'get',


### PR DESCRIPTION
A failed fetch left the previous vehicle versions in the dropdown.
Fix #1154