### PR TITLE
core: services: ardupilot_manager: Return none if board path is gone

### DIFF
--- a/core/services/ardupilot_manager/api/v1/routers/index.py
+++ b/core/services/ardupilot_manager/api/v1/routers/index.py
@@ -220,7 +220,7 @@ async def install_firmware_from_file(
 )
 @index_to_http_exception
 def get_board() -> Any:
-    return autopilot.current_board
+    return autopilot.current_board_sanitized
 
 
 @index_router_v1.post("/board", summary="Set board to be used.")

--- a/core/services/ardupilot_manager/autopilot_manager.py
+++ b/core/services/ardupilot_manager/autopilot_manager.py
@@ -264,6 +264,13 @@ class AutoPilotManager(metaclass=Singleton):
         return self._current_board
 
     @property
+    def current_board_sanitized(self) -> Optional[FlightController]:
+        board = self._current_board
+        if board and board.path and not pathlib.Path(board.path).exists():
+            return None
+        return board
+
+    @property
     def current_sitl_frame(self) -> SITLFrame:
         return self._current_sitl_frame
 


### PR DESCRIPTION
GET /board keeps the last USB board after unplug.
Fix #1974