### PR TITLE
core: frontend: ParameterLoader: Avoid mixed write banners

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -134,7 +134,7 @@
         No parameters to change. This means all the
         parameters in this group are already set to the desired values
       </v-card-text>
-      <v-card-text v-if="error">
+      <v-card-text v-if="error && !write_finished">
         <v-alert
           type="error"
         >
@@ -150,6 +150,14 @@
           @click="writeParams"
         >
           Write Parameters
+        </v-btn>
+        <v-btn
+          v-if="write_finished || error"
+          class="ma-6 elevation-2"
+          x-large
+          @click="done"
+        >
+          Close
         </v-btn>
         <RebootButton v-if="error" />
       </v-card-actions>
@@ -225,9 +233,16 @@ export default Vue.extend({
         this.updateParamCheckboxes(newval)
       },
     },
+    write_finished(finished: boolean) {
+      if (finished && this.writing) {
+        clearInterval(this.retry_interval)
+        this.error = false
+      }
+    },
   },
   methods: {
     done() {
+      clearInterval(this.retry_interval)
       this.$emit('done')
       this.error = false
       this.retries = 0


### PR DESCRIPTION
After 5 retries the error stays even if the vehicle later ACKs.
Fix #2462