### PR TITLE
core: frontend: ping1d: Start MAVLink Distances off

### DIFF
--- a/core/frontend/src/components/ping/ping1d.vue
+++ b/core/frontend/src/components/ping/ping1d.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
   data() {
     return {
       expand: false,
-      user_desired_mavlink_driver_state: true,
+      user_desired_mavlink_driver_state: false,
     }
   },
   computed: {


### PR DESCRIPTION
The switch defaulted on before the backend status arrived.
Helps #2755