### PR TITLE
core: configuration: Slow tmux mouse scroll

### DIFF
--- a/core/configuration/tmux.conf
+++ b/core/configuration/tmux.conf
@@ -3,6 +3,8 @@ set-option -g history-limit 10000
 
 # Enable mouse over splits
 set -g mouse on
+bind-key -T copy-mode WheelUpPane send-keys -X -N 1 scroll-up
+bind-key -T copy-mode WheelDownPane send-keys -X -N 1 scroll-down
 
 # Force utf-8 usage for non ASCII characters
 setw -gq utf8 on


### PR DESCRIPTION
Default wheel scroll in copy-mode jumps several lines per tick.
Fix #2388