### PR TITLE
core: frontend: ParamSets: Remount loader when selecting a paramset

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -218,6 +218,7 @@ export default Vue.extend({
       },
     },
     parameters: {
+      immediate: true,
       handler(newval) {
         if (Object.keys(this.writeable_param_set).length !== 0) {
           this.should_open = true

--- a/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
@@ -59,7 +59,8 @@
       </v-card-actions>
     </v-card>
     <ParameterLoader
-      v-if="selected_paramset"
+      v-if="Object.keys(selected_paramset).length"
+      :key="selected_paramset_name"
       :parameters="selected_paramset"
       @done="selected_paramset = {}"
     />
@@ -140,7 +141,7 @@ export default Vue.extend({
     },
     async loadParams(name: string, paramset: Dictionary<number>) {
       this.selected_paramset_name = name
-      this.selected_paramset = paramset
+      this.selected_paramset = { ...paramset }
     },
     async restartAutopilot(): Promise<void> {
       this.rebooting = true


### PR DESCRIPTION
v-if on the object is always true. leftover writing/error survive the next click.

Fix #3136