### PR TITLE
core: frontend: store: add missing Module imports

### DIFF
--- a/core/frontend/src/store/ardupilot_sensors.ts
+++ b/core/frontend/src/store/ardupilot_sensors.ts
@@ -8,6 +8,7 @@ import store from '@/store'
 import Parameter from '@/types/autopilot/parameter'
 import { Dictionary } from '@/types/common'
 import decode, { deviceId } from '@/utils/deviceid_decoder'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 import autopilot_data from './autopilot'
 

--- a/core/frontend/src/store/autopilot.ts
+++ b/core/frontend/src/store/autopilot.ts
@@ -19,6 +19,7 @@ import {
 import {
   FRAME_CONFIG as SUB_FRAME_CONFIG,
 } from '@/types/autopilot/parameter-sub-enums'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 import autopilot_manager from './autopilot_manager'
 

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -9,6 +9,7 @@ import {
   FlightController, SerialEndpoint, SITLFrame,
 } from '@/types/autopilot'
 import { SERVO_FUNCTION as SUB_SERVO_FUNCTION } from '@/types/autopilot/parameter-sub-enums'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 // ArduSub <= 4.5.5 used RCIN9/RCIN10 for lights control; newer versions handle lights natively
 const LEGACY_SUB_LIGHTS_MAX_VERSION = '4.5.5'

--- a/core/frontend/src/store/beacon.ts
+++ b/core/frontend/src/store/beacon.ts
@@ -9,6 +9,7 @@ import store from '@/store'
 import { Domain } from '@/types/beacon'
 import { beacon_service } from '@/types/frontend_services'
 import back_axios, { isBackendOffline } from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 const notifier = new Notifier(beacon_service)
 

--- a/core/frontend/src/store/bridget.ts
+++ b/core/frontend/src/store/bridget.ts
@@ -9,6 +9,7 @@ import store from '@/store'
 import { Bridge } from '@/types/bridges'
 import { bridget_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 const notifier = new Notifier(bridget_service)
 

--- a/core/frontend/src/store/commander.ts
+++ b/core/frontend/src/store/commander.ts
@@ -7,6 +7,7 @@ import store from '@/store'
 import { ReturnStruct, ShutdownType } from '@/types/commander'
 import { commander_service } from '@/types/frontend_services'
 import back_axios, { isBackendOffline } from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 const notifier = new Notifier(commander_service)
 

--- a/core/frontend/src/store/customization.ts
+++ b/core/frontend/src/store/customization.ts
@@ -8,6 +8,7 @@ import store from '@/store'
 import { BrandingAsset, ModelEntry, ThemeStatus } from '@/types/customization'
 import { customization_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 const API_URL = '/customization/v1.0'
 const notifier = new Notifier(customization_service)

--- a/core/frontend/src/store/disk.ts
+++ b/core/frontend/src/store/disk.ts
@@ -6,6 +6,7 @@ import store from '@/store'
 import { DiskSpeedResult, DiskSpeedTestPoint, DiskUsageQuery, DiskUsageResponse } from '@/types/disk'
 import back_axios, { isBackendOffline } from '@/utils/api'
 import { parseStreamingResponse } from '@/utils/streaming'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 @Module({ dynamic: true, store, name: 'disk' })
 class DiskStore extends VuexModule {

--- a/core/frontend/src/store/ethernet.ts
+++ b/core/frontend/src/store/ethernet.ts
@@ -7,6 +7,7 @@ import store from '@/store'
 import { DHCPServerDetails, EthernetInterface } from '@/types/ethernet'
 import { ethernet_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 import Notifier from '@/libs/notifier'
 
 const notifier = new Notifier(ethernet_service)

--- a/core/frontend/src/store/frontend.ts
+++ b/core/frontend/src/store/frontend.ts
@@ -5,6 +5,7 @@ import {
 } from 'vuex-module-decorators'
 
 import store from '@/store'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 @Module({
   dynamic: true,

--- a/core/frontend/src/store/helper.ts
+++ b/core/frontend/src/store/helper.ts
@@ -9,6 +9,7 @@ import store from '@/store'
 import { helper_service } from '@/types/frontend_services'
 import { InternetConnectionState, Service } from '@/types/helper'
 import back_axios, { isBackendOffline } from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 const notifier = new Notifier(helper_service)
 

--- a/core/frontend/src/store/mavlink.ts
+++ b/core/frontend/src/store/mavlink.ts
@@ -8,6 +8,7 @@ import Listener from '@/libs/MAVLink2Rest/Listener'
 import store from '@/store'
 import { Dictionary } from '@/types/common'
 import { MavlinkMessage } from '@/types/mavlink'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 import autopilot_data from './autopilot'
 

--- a/core/frontend/src/store/nmea-injector.ts
+++ b/core/frontend/src/store/nmea-injector.ts
@@ -7,6 +7,7 @@ import store from '@/store'
 import { nmea_injector_service } from '@/types/frontend_services'
 import { NMEASocket } from '@/types/nmea-injector'
 import back_axios from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 const notifier = new Notifier(nmea_injector_service)
 

--- a/core/frontend/src/store/notifications.ts
+++ b/core/frontend/src/store/notifications.ts
@@ -6,6 +6,7 @@ import store from '@/store'
 import {
   CumulatedNotification, Notification, NotificationLevel,
 } from '@/types/notifications'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 @Module({
   dynamic: true,

--- a/core/frontend/src/store/pardal.ts
+++ b/core/frontend/src/store/pardal.ts
@@ -9,6 +9,7 @@ import store from "@/store"
 import { pardal_service } from "@/types/frontend_services"
 import { SpeedTestResult } from "@/types/pardal"
 import back_axios from "@/utils/api"
+import { DynamicModule as Module } from "@/utils/vuex"
 
 const notifier = new Notifier(pardal_service)
 

--- a/core/frontend/src/store/ping.ts
+++ b/core/frontend/src/store/ping.ts
@@ -9,6 +9,7 @@ import store from '@/store'
 import { ping_service } from '@/types/frontend_services'
 import { PingDevice } from '@/types/ping'
 import back_axios from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 const notifier = new Notifier(ping_service)
 

--- a/core/frontend/src/store/records.ts
+++ b/core/frontend/src/store/records.ts
@@ -5,6 +5,7 @@ import {
 import store from '@/store'
 import { ProcessingFile, RecordingFile } from '@/types/records'
 import back_axios, { isBackendOffline } from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 @Module({ dynamic: true, store, name: 'records' })
 class RecordsStore extends VuexModule {

--- a/core/frontend/src/store/settings.ts
+++ b/core/frontend/src/store/settings.ts
@@ -6,6 +6,7 @@ import {
 import store from '@/store'
 import beacon from '@/store/beacon'
 import { castString } from '@/utils/helper_functions'
+import { DynamicModule as Module } from '@/utils/vuex'
 import bag from '@/store/bag'
 
 @Module({

--- a/core/frontend/src/store/system-information.ts
+++ b/core/frontend/src/store/system-information.ts
@@ -20,6 +20,7 @@ import {
 } from '@/types/system-information/system'
 import back_axios, { isBackendOffline } from '@/utils/api'
 import { linux2restProbeRateBps } from '@/utils/linux2rest'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 export enum FetchType {
     ModelType = 'model',

--- a/core/frontend/src/store/video.ts
+++ b/core/frontend/src/store/video.ts
@@ -12,6 +12,7 @@ import {
   CreatedStream, Device, StreamStatus,
 } from '@/types/video'
 import back_axios, { isBackendOffline } from '@/utils/api'
+import { DynamicModule as Module } from '@/utils/vuex'
 
 export interface Thumbnail {
   source: string | undefined

--- a/core/frontend/src/store/wifi.ts
+++ b/core/frontend/src/store/wifi.ts
@@ -6,6 +6,7 @@ import store from '@/store'
 import {
   Network, NetworkCredentials, SavedNetwork, WifiStatus, HotspotStatus
 } from '@/types/wifi'
+import { DynamicModule as Module } from '@/utils/vuex'
 import { sorted_networks } from '@/utils/wifi'
 
 @Module({


### PR DESCRIPTION
We forgot to import the new type-safe DynamicModule helpers from utils/vuex.ts after removing the previous Module imports from vuex-module-decorators; this adds the missing import across all stores.

Fixes: 44af0831706e ("core: frontend: fix vuex-module-decorators typing under TypeScript 5")

Fixes #4362