### PR TITLE
Allow users to change the system ID in the Vehicle Setup component

### DIFF
--- a/core/frontend/src/components/vehiclesetup/Configure.vue
+++ b/core/frontend/src/components/vehiclesetup/Configure.vue
@@ -54,6 +54,7 @@ import LeakInfo from './overview/LeakInfo.vue'
 import LightsInfo from './overview/LightsInfo.vue'
 import ParamSets from './overview/ParamSets.vue'
 import PowerInfo from './overview/PowerInfo.vue'
+import SystemId from './overview/SystemId.vue'
 
 export interface Item {
   title: string,
@@ -82,6 +83,7 @@ export default Vue.extend({
     FailsafesConfiguration,
     Camera,
     NotSafeOverlay,
+    SystemId,
   },
   data() {
     return {
@@ -101,6 +103,7 @@ export default Vue.extend({
         { title: 'Failsafes', value: 'failsafes', component: FailsafesConfiguration },
         { title: 'Power', value: 'power', component: PowerConfiguration },
         { title: 'Camera Gimbal', value: 'camera', component: Camera },
+        { title: 'Vehicle ID', value: 'systemid', component: SystemId },
       ] as Item[],
     }
   },

--- a/core/frontend/src/components/vehiclesetup/overview/SystemId.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/SystemId.vue
@@ -1,0 +1,121 @@
+<template>
+  <v-card class="pa-1" elevation="2">
+    <v-card-title class="d-flex align-center">
+      Configure MAVLink system ID
+    </v-card-title>
+    <v-card-text>
+      Note that it is necessary to restart the BlueOS core container in order for the vehicle ID change to fully
+      take place.
+    </v-card-text>
+    <v-card-text>
+      <inline-parameter-editor
+        v-if="mav_sysid"
+        :param="mav_sysid"
+        :label="'MAVLink system ID'"
+        @change="pending_value = $event"
+        @form-valid-change="is_form_valid = $event"
+      />
+      <v-alert
+        v-if="save_error"
+        type="error"
+        dense
+        text
+        class="mt-3 mb-0"
+      >
+        Failed to set system ID: {{ save_error }}
+      </v-alert>
+    </v-card-text>
+    <v-card-actions class="justify-end">
+      <v-btn
+        v-tooltip="'Restart the BlueOS core container'"
+        :loading="restarting_core"
+        :disabled="restarting_core || saving"
+        @click="restartCore"
+      >
+        <v-icon left color="orange">
+          mdi-folder-refresh
+        </v-icon>
+        Restart Core
+      </v-btn>
+      <v-btn
+        color="primary"
+        :loading="saving"
+        :disabled="!can_save || saving"
+        @click="save"
+      >
+        Save
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import InlineParameterEditor from '@/components/parameter-editor/InlineParameterEditor.vue'
+import Notifier from '@/libs/notifier'
+import autopilot from '@/store/autopilot'
+import Parameter from '@/types/autopilot/parameter'
+import { autopilot_service } from '@/types/frontend_services'
+import back_axios from '@/utils/api'
+
+const notifier = new Notifier(autopilot_service)
+
+export default Vue.extend({
+  name: 'SystemId',
+  components: {
+    InlineParameterEditor,
+  },
+  data() {
+    return {
+      pending_value: undefined as number | undefined,
+      is_form_valid: true,
+      restarting_core: false,
+      saving: false,
+      save_error: undefined as string | undefined,
+    }
+  },
+  computed: {
+    mav_sysid(): Parameter | undefined {
+      return autopilot.parameter('MAV_SYSID')
+    },
+    has_pending_change(): boolean {
+      return this.mav_sysid !== undefined
+        && this.pending_value !== undefined
+        && this.pending_value !== this.mav_sysid.value
+    },
+    can_save(): boolean {
+      return this.has_pending_change && this.is_form_valid
+    },
+  },
+  methods: {
+    async save(): Promise<void> {
+      if (!this.mav_sysid || this.pending_value === undefined) {
+        return
+      }
+
+      this.save_error = undefined
+      this.saving = true
+      await back_axios({
+        method: 'post',
+        url: `/autopilot-manager/v1.0/system_id?value=${this.pending_value}`,
+      }).catch((error) => {
+        this.save_error = error.response?.data?.detail ?? error.response?.data ?? error.message
+        notifier.pushBackError('SET_MAV_SYSTEM_ID', error)
+      }).finally(() => {
+        this.saving = false
+      })
+    },
+    async restartCore(): Promise<void> {
+      this.restarting_core = true
+      await back_axios({
+        method: 'post',
+        url: '/version-chooser/v1.0/version/restart',
+      }).finally(() => {
+        // Give the backend a bit to go down, then reload so the user reconnects to the fresh core
+        setTimeout(() => window.location.reload(), 15000)
+      })
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/vehiclesetup/overview/SystemId.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/SystemId.vue
@@ -28,8 +28,7 @@
     <v-card-actions class="justify-end">
       <v-btn
         v-tooltip="'Restart the BlueOS core container'"
-        :loading="restarting_core"
-        :disabled="restarting_core || saving"
+        :disabled="restarting || saving"
         @click="restartCore"
       >
         <v-icon left color="orange">
@@ -40,12 +39,18 @@
       <v-btn
         color="primary"
         :loading="saving"
-        :disabled="!can_save || saving"
+        :disabled="!can_save || saving || restarting"
         @click="save"
       >
         Save
       </v-btn>
     </v-card-actions>
+    <v-container v-if="restarting">
+      <p class="text-md-center">
+        Core container is restarting, please wait.
+      </p>
+      <spinning-logo size="20%" />
+    </v-container>
   </v-card>
 </template>
 
@@ -59,19 +64,22 @@ import Parameter from '@/types/autopilot/parameter'
 import { autopilot_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
 
+import SpinningLogo from '../../common/SpinningLogo.vue'
+
 const notifier = new Notifier(autopilot_service)
 
 export default Vue.extend({
   name: 'SystemId',
   components: {
     InlineParameterEditor,
+    SpinningLogo,
   },
   data() {
     return {
       pending_value: undefined as number | undefined,
       is_form_valid: true,
-      restarting_core: false,
       saving: false,
+      restarting: false,
       save_error: undefined as string | undefined,
     }
   },
@@ -107,14 +115,24 @@ export default Vue.extend({
       })
     },
     async restartCore(): Promise<void> {
-      this.restarting_core = true
+      this.restarting = true
       await back_axios({
         method: 'post',
         url: '/version-chooser/v1.0/version/restart',
-      }).finally(() => {
-        // Give the backend a bit to go down, then reload so the user reconnects to the fresh core
-        setTimeout(() => window.location.reload(), 15000)
+      }).finally(() => setTimeout(this.waitForBackendToBeOnline, 15000))
+    },
+    async waitForBackendToBeOnline(): Promise<void> {
+      back_axios({
+        method: 'get',
+        url: '/helper/latest/web_services',
       })
+        .then(() => {
+          setTimeout(() => { window.location.reload() }, 1000)
+        })
+        .catch((error) => {
+          console.debug(`Backend is not available yet: ${error}`)
+          setTimeout(this.waitForBackendToBeOnline, 2000)
+        })
     },
   },
 })

--- a/core/frontend/src/components/vehiclesetup/overview/VehicleInfo.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/VehicleInfo.vue
@@ -22,6 +22,10 @@
             <td>{{ model }}</td>
           </tr>
           <tr>
+            <td><b>System ID</b></td>
+            <td>{{ systemId }}</td>
+          </tr>
+          <tr>
             <td><b>Frame</b></td>
             <td>{{ frameType }}</td>
           </tr>
@@ -58,6 +62,9 @@ export default Vue.extend({
     },
     boardType() {
       return autopilot.current_board?.name ?? null
+    },
+    systemId() {
+      return autopilot_data.system_id ?? null
     },
     firmware() {
       const { firmware_info } = autopilot

--- a/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
+++ b/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
@@ -65,7 +65,7 @@ class VehicleManager:
             "confirmation": self.confirmation,
         }
 
-    def command_heartbeat_message(self) -> Dict[str, Any]:
+    def heartbeat_message(self) -> Dict[str, Any]:
         return {
             "type": "HEARTBEAT",
             "custom_mode": 0,
@@ -77,7 +77,7 @@ class VehicleManager:
         }
 
     async def burst_heartbeat(self) -> None:
-        heartbeat_message = self.command_heartbeat_message()
+        heartbeat_message = self.heartbeat_message()
         for _ in range(5):
             await self.mavlink2rest.send_mavlink_message(heartbeat_message)
             await asyncio.sleep(0.1)

--- a/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
+++ b/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
@@ -1,7 +1,11 @@
 import asyncio
+import time
 from typing import Any, Dict, List
 
-from commonwealth.mavlink_comm.exceptions import VehicleDisarmFail
+from commonwealth.mavlink_comm.exceptions import (
+    VehicleDisarmFail,
+    VehicleSystemIdUpdateFail,
+)
 from commonwealth.mavlink_comm.MavlinkComm import MavlinkMessenger
 from commonwealth.mavlink_comm.typedefs import (
     FirmwareInfo,
@@ -31,6 +35,19 @@ class VehicleManager:
 
     def set_confirmation(self, confirmation: int) -> None:
         self.confirmation = confirmation
+
+    def param_set_message(self, parameter: str, value: float) -> Dict[Any, Any]:
+        # param_id is a char[16] array, so zero-pad to 16 bytes
+        param_id = list(parameter) + ["\0"] * (16 - len(parameter))
+
+        return {
+            "type": "PARAM_SET",
+            "param_value": value,
+            "target_system": self.target_system,
+            "target_component": self.target_component,
+            "param_id": param_id,
+            "param_type": {"type": "MAV_PARAM_TYPE_UINT8"},
+        }
 
     def command_long_message(self, command_type: str, params: List[float]) -> Dict[str, Any]:
         return {
@@ -137,3 +154,34 @@ class VehicleManager:
         This might eventually be enhanced to check for other conditions.
         """
         return not await self.is_vehicle_armed()
+
+    async def set_system_id(self, value: int) -> None:
+        # send a `PARAM_SET` message to change `MAV_SYSID`
+        message = self.param_set_message("MAV_SYSID", value)
+        await self.mavlink2rest.send_mavlink_message(message)
+
+        # note: the spec mandates [1] that every PARAM_SET should be
+        # acknowledged by the receiving party by broadcasting a PARAM_VALUE
+        # with the updated parameter, so ideally the cleanest way to check that
+        # the PARAM_SET succeeded would be to read a subsequent PARAM_VALUE
+        # message; however, in this scenario we are sending a message from one
+        # component to another (MAV_TYPE_ONBOARD_CONTROLLER ->
+        # MAV_TYPE_SUBMARINE) in the same vehicle (e.g. equal system ids but
+        # different component ids), and mavlink-server filters out loopbacks
+        # for broadcast messages, so we never actually receive the PARAM_VALUE.
+        #
+        # [1] https://mavlink.io/en/messages/common.html#PARAM_SET
+
+        # hack around this limitation by waiting for self.mavlink2rest to
+        # timeout and trigger system ID detection, then set the new target
+        # system value
+        start_time = time.time()
+        timeout = 30.0
+        while time.time() - start_time < timeout:
+            if await self.is_heart_beating():
+                continue
+        self.set_target_system(await self.mavlink2rest.get_most_recent_vehicle_id())
+
+        # bail out if we end up failing to update the system ID anyway
+        if self.target_system != value:
+            raise VehicleSystemIdUpdateFail("Failed to update the vehicle's system id")

--- a/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
+++ b/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
@@ -13,6 +13,7 @@ from commonwealth.mavlink_comm.typedefs import (
     MavlinkMessageId,
     MavlinkVehicleType,
 )
+from commonwealth.utils.environment import EnvironmentManager
 from loguru import logger
 
 MAV_MODE_FLAG_SAFETY_ARMED = 128
@@ -190,3 +191,7 @@ class VehicleManager:
         # bail out if we failed to update the system id after all
         if self.target_system != value:
             raise VehicleSystemIdUpdateFail("Failed to update the vehicle's system id")
+
+        # persist the new system id in the MAV_SYSTEM_ID environment variable
+        # used by mavlink2rest
+        EnvironmentManager.set_variable("MAV_SYSTEM_ID", value)

--- a/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
+++ b/core/libs/commonwealth/src/commonwealth/mavlink_comm/VehicleManager.py
@@ -156,6 +156,9 @@ class VehicleManager:
         return not await self.is_vehicle_armed()
 
     async def set_system_id(self, value: int) -> None:
+        # update the target system id
+        self.set_target_system(await self.mavlink2rest.get_most_recent_vehicle_id())
+
         # send a `PARAM_SET` message to change `MAV_SYSID`
         message = self.param_set_message("MAV_SYSID", value)
         await self.mavlink2rest.send_mavlink_message(message)
@@ -172,16 +175,18 @@ class VehicleManager:
         #
         # [1] https://mavlink.io/en/messages/common.html#PARAM_SET
 
-        # hack around this limitation by waiting for self.mavlink2rest to
-        # timeout and trigger system ID detection, then set the new target
-        # system value
+        # hack around this limitation by listening to the vehicle heartbeat
+        # messages and waiting for the source system id to change to the value
+        # we just configured. ardupilot sends heartbeats at 1Hz so 10s is a
+        # reasonable timeout
         start_time = time.time()
-        timeout = 30.0
+        timeout = 10.0
         while time.time() - start_time < timeout:
-            if await self.is_heart_beating():
-                continue
-        self.set_target_system(await self.mavlink2rest.get_most_recent_vehicle_id())
+            if await self.mavlink2rest.get_most_recent_vehicle_id() == value:
+                self.set_target_system(value)
+                break
+            await asyncio.sleep(timeout / 10.0)
 
-        # bail out if we end up failing to update the system ID anyway
+        # bail out if we failed to update the system id after all
         if self.target_system != value:
             raise VehicleSystemIdUpdateFail("Failed to update the vehicle's system id")

--- a/core/libs/commonwealth/src/commonwealth/mavlink_comm/exceptions.py
+++ b/core/libs/commonwealth/src/commonwealth/mavlink_comm/exceptions.py
@@ -17,3 +17,7 @@ class FetchUpdatedMessageFail(RuntimeError):
 
 class VehicleDisarmFail(RuntimeError):
     """Could not disarm vehicle."""
+
+
+class VehicleSystemIdUpdateFail(RuntimeError):
+    """Failed to update the vehicle's system id."""

--- a/core/libs/commonwealth/src/commonwealth/utils/environment.py
+++ b/core/libs/commonwealth/src/commonwealth/utils/environment.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import appdirs
+from loguru import logger
+
+
+class EnvironmentManager:
+    """Wrapper for managing environment variables that should be persisted
+    across reboots."""
+
+    BOOTSTRAP_STARTUP_FILE = Path(appdirs.user_config_dir("bootstrap"), "startup.json")
+
+    @staticmethod
+    def set_variable(key: str, value: Any) -> None:
+        # we currently persist environment variables through the
+        # bootstrap/startup.json config file
+        with open(EnvironmentManager.BOOTSTRAP_STARTUP_FILE, "r+", encoding="utf-8") as startup_file:
+            settings = json.load(startup_file)
+            environment = settings["core"].get("environment", [])
+            environment = [variable for variable in environment if not variable.startswith(f"{key}=")]
+            environment.append(f"{key}={value}")
+            settings["core"]["environment"] = environment
+
+            startup_file.seek(0)
+            startup_file.write(json.dumps(settings, indent=2))
+            startup_file.truncate()
+
+        logger.info(f"Set bootstrap environment variable {key}={value}.")

--- a/core/services/ardupilot_manager/api/v1/routers/index.py
+++ b/core/services/ardupilot_manager/api/v1/routers/index.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import shutil
 from functools import wraps
@@ -15,7 +16,7 @@ from commonwealth.mavlink_comm.typedefs import FirmwareInfo, MavlinkVehicleType
 from commonwealth.utils.apis import StackedHTTPException
 from commonwealth.utils.decorators import single_threaded
 from exceptions import InvalidFirmwareFile, NoDefaultFirmwareAvailable
-from fastapi import APIRouter, Body, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Body, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import PlainTextResponse
 from fastapi_versioning import versioned_api_route
 from loguru import logger
@@ -294,3 +295,34 @@ async def restore_default_firmware(board_name: Optional[str] = None) -> Any:
 @index_to_http_exception
 async def available_boards() -> Any:
     return await autopilot.available_boards(True)
+
+
+@index_router_v1.post("/system_id", summary="Set the vehicle's system id.")
+@index_to_http_exception
+async def set_system_id(value: int = Query(ge=1, le=255)) -> Any:
+    if not autopilot.current_board:
+        message = "No board running, system ID is unavailable"
+        logger.warning(message)
+        return PlainTextResponse(message, status_code=503)
+
+    try:
+        await autopilot.vehicle_manager.set_system_id(value)
+
+        if autopilot.vehicle_manager.target_system != value:
+            return PlainTextResponse("Failed to set system ID", status_code=500)
+
+        with open(autopilot.settings.startup_settings_file, "r+", encoding="utf-8") as startup_settings:
+            settings = json.load(startup_settings)
+            environment = settings["core"].get("environment", [])
+
+            # make sure to remove MAV_SYSTEM_ID if it is already defined in
+            # bootstrap/startup.json
+            environment = [v for v in environment if not v.startswith("MAV_SYSTEM_ID=")]
+            environment.append(f"MAV_SYSTEM_ID={value}")
+            settings["core"]["environment"] = environment
+
+            startup_settings.seek(0)
+            startup_settings.write(json.dumps(settings, indent=2))
+            startup_settings.truncate()
+    except Exception as error:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error

--- a/core/services/ardupilot_manager/api/v1/routers/index.py
+++ b/core/services/ardupilot_manager/api/v1/routers/index.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import os
 import shutil
 from functools import wraps
@@ -306,17 +305,3 @@ async def set_system_id(value: int = Query(ge=1, le=255)) -> Any:
         return PlainTextResponse(message, status_code=503)
 
     await autopilot.vehicle_manager.set_system_id(value)
-
-    with open(autopilot.settings.startup_settings_file, "r+", encoding="utf-8") as startup_settings:
-        settings = json.load(startup_settings)
-        environment = settings["core"].get("environment", [])
-
-        # make sure to remove MAV_SYSTEM_ID if it is already defined in
-        # bootstrap/startup.json
-        environment = [v for v in environment if not v.startswith("MAV_SYSTEM_ID=")]
-        environment.append(f"MAV_SYSTEM_ID={value}")
-        settings["core"]["environment"] = environment
-
-        startup_settings.seek(0)
-        startup_settings.write(json.dumps(settings, indent=2))
-        startup_settings.truncate()

--- a/core/services/ardupilot_manager/api/v1/routers/index.py
+++ b/core/services/ardupilot_manager/api/v1/routers/index.py
@@ -305,24 +305,18 @@ async def set_system_id(value: int = Query(ge=1, le=255)) -> Any:
         logger.warning(message)
         return PlainTextResponse(message, status_code=503)
 
-    try:
-        await autopilot.vehicle_manager.set_system_id(value)
+    await autopilot.vehicle_manager.set_system_id(value)
 
-        if autopilot.vehicle_manager.target_system != value:
-            return PlainTextResponse("Failed to set system ID", status_code=500)
+    with open(autopilot.settings.startup_settings_file, "r+", encoding="utf-8") as startup_settings:
+        settings = json.load(startup_settings)
+        environment = settings["core"].get("environment", [])
 
-        with open(autopilot.settings.startup_settings_file, "r+", encoding="utf-8") as startup_settings:
-            settings = json.load(startup_settings)
-            environment = settings["core"].get("environment", [])
+        # make sure to remove MAV_SYSTEM_ID if it is already defined in
+        # bootstrap/startup.json
+        environment = [v for v in environment if not v.startswith("MAV_SYSTEM_ID=")]
+        environment.append(f"MAV_SYSTEM_ID={value}")
+        settings["core"]["environment"] = environment
 
-            # make sure to remove MAV_SYSTEM_ID if it is already defined in
-            # bootstrap/startup.json
-            environment = [v for v in environment if not v.startswith("MAV_SYSTEM_ID=")]
-            environment.append(f"MAV_SYSTEM_ID={value}")
-            settings["core"]["environment"] = environment
-
-            startup_settings.seek(0)
-            startup_settings.write(json.dumps(settings, indent=2))
-            startup_settings.truncate()
-    except Exception as error:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+        startup_settings.seek(0)
+        startup_settings.write(json.dumps(settings, indent=2))
+        startup_settings.truncate()

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -14,6 +14,7 @@ class Settings:
     app_name = SERVICE_NAME
     settings_path = Path(appdirs.user_config_dir(app_name))
     settings_file = Path.joinpath(settings_path, "settings.json")
+    startup_settings_file = Path(appdirs.user_config_dir("bootstrap"), "startup.json")
     firmware_folder = Path.joinpath(settings_path, "firmware")
     user_firmware_folder = Path("/usr/blueos/userdata/firmware")
     log_path = Path.joinpath(settings_path, "logs")


### PR DESCRIPTION
We would like to provide a unified way for users to configure the system ID for a vehicle. As it currently stands, there are two sources of truth for the vehicle ID that need to be kept in sync:

- The `MAV_SYSID` parameter in the Ardupilot firmware
- The `MAV_SYSTEM_ID` environment variable, which is used to determine the vehicle ID in `mavlink-server`/`mavlink2rest`

This PR aims to provide an interface in the UI for users to change the vehicle ID:

- Introduce a new `autopilot_manager` endpoint, `/system_id`, to set the value for `MAV_SYSTEM_ID` through a POST request, making the change persistent across reboots by storing the variable in the `environment` field of `bootstrap/startup.json`
- Add a simple component to the Vehicle Setup tab that allows users to modify the Vehicle ID to their desired value

Note that (currently) it is necessary to restart the BlueOS container in order to have the `MAV_SYSTEM_ID` environment variable propagated to all services (there is a button in the Vehicle ID setup UI for restarting the container).

Depends on #4364
Fixes #3604