### PR TITLE
core: frontend: FirmwareManager: Add vehicle type change warning

### DIFF
--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -352,6 +352,16 @@ export default Vue.extend({
         (vehicle) => ({ value: vehicle[0], text: vehicle[1] }),
       )
     },
+    current_vehicle(): Vehicle | null {
+      const firmware = autopilot.firmware_vehicle_type
+      if (firmware === null) {
+        return null
+      }
+      const match = Object.values(Vehicle).find(
+        (vehicle) => firmwareVehicleTypeFromVehicle(vehicle) === firmware,
+      )
+      return match ?? null
+    },
     no_sitl_boards(): FlightController[] {
       return autopilot.available_boards.filter((board) => board.name.toLowerCase() !== 'sitl')
     },
@@ -444,7 +454,7 @@ export default Vue.extend({
     'autopilot.firmware_vehicle_type': {
       handler(new_value: FirmwareVehicleType | null): void {
         if (this.chosen_vehicle === null && new_value !== null) {
-          this.setVehicleFromFirmware(new_value)
+          this.setVehicleFromFirmware()
         }
       },
       immediate: true,
@@ -478,17 +488,9 @@ export default Vue.extend({
       const [first_board] = this.no_sitl_boards
       this.chosen_board = first_board
     },
-    setVehicleFromFirmware(firmware_vehicle_type: FirmwareVehicleType): void {
-      const mapping: Record<FirmwareVehicleType, Vehicle | null> = {
-        [FirmwareVehicleType.ArduSub]: Vehicle.Sub,
-        [FirmwareVehicleType.ArduRover]: Vehicle.Rover,
-        [FirmwareVehicleType.ArduPlane]: Vehicle.Plane,
-        [FirmwareVehicleType.ArduCopter]: Vehicle.Copter,
-        [FirmwareVehicleType.Other]: null,
-      }
-      const vehicle = mapping[firmware_vehicle_type]
-      if (vehicle !== null) {
-        this.chosen_vehicle = vehicle
+    setVehicleFromFirmware(): void {
+      if (this.current_vehicle !== null) {
+        this.chosen_vehicle = this.current_vehicle
         this.updateAvailableFirmwares()
       }
     },

--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -122,10 +122,21 @@
             v-model="chosen_vehicle"
             :items="vehicle_types"
             label="Vehicle type"
+            :hint="vehicle_changed ? vehicle_change_warning : ''"
+            :persistent-hint="vehicle_changed"
             required
             class="ma-1 pa-0"
             @change="updateAvailableFirmwares"
-          />
+          >
+            <template
+              v-if="vehicle_changed"
+              #append-outer
+            >
+              <v-icon color="warning">
+                mdi-alert
+              </v-icon>
+            </template>
+          </v-select>
           <div class="d-flex">
             <v-select
               v-model="chosen_firmware_url"
@@ -361,6 +372,14 @@ export default Vue.extend({
         (vehicle) => firmwareVehicleTypeFromVehicle(vehicle) === firmware,
       )
       return match ?? null
+    },
+    vehicle_changed(): boolean {
+      return this.chosen_vehicle !== null
+        && this.current_vehicle !== null
+        && this.chosen_vehicle !== this.current_vehicle
+    },
+    vehicle_change_warning(): string {
+      return `Installing this firmware will change the vehicle from ${this.current_vehicle} to ${this.chosen_vehicle}.`
     },
     no_sitl_boards(): FlightController[] {
       return autopilot.available_boards.filter((board) => board.name.toLowerCase() !== 'sitl')


### PR DESCRIPTION
Changing Sub to Rover has no warning.
Fix #4371


<img width="945" height="815" alt="image" src="https://github.com/user-attachments/assets/5d68e4d6-05bc-440e-8760-335e89b7c341" />
