### PR TITLE
core: frontend: EndpointCard: Add tooltips to action buttons

### DIFF
--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -68,6 +68,7 @@
     <div class="endpoint-buttons">
       <v-btn
         v-if="!endpoint.protected && is_known_type"
+        v-tooltip="'Edit endpoint'"
         color="primary"
         dark
         fab
@@ -79,6 +80,7 @@
         </v-icon>
       </v-btn>
       <v-btn
+        v-tooltip="'Copy command line string'"
         color="primary"
         dark
         fab
@@ -91,6 +93,7 @@
       </v-btn>
       <v-btn
         v-if="!endpoint.protected || !is_known_type"
+        v-tooltip="'Delete endpoint'"
         color="error"
         dark
         fab

--- a/core/frontend/src/components/autopilot/EndpointManager.vue
+++ b/core/frontend/src/components/autopilot/EndpointManager.vue
@@ -99,6 +99,7 @@
     <v-fab-transition>
       <v-btn
         :key="'create_button'"
+        v-tooltip="'Create endpoint'"
         color="primary"
         fab
         large


### PR DESCRIPTION
MAVLink Endpoints buttons have no tooltips.
Fix #4366