### PR TITLE
[1.4] do not try to fetch remote tags if there is no internet

### DIFF
--- a/core/frontend/src/components/app/NewVersionNotificator.vue
+++ b/core/frontend/src/components/app/NewVersionNotificator.vue
@@ -27,6 +27,8 @@
 import Vue from 'vue'
 
 import settings from '@/libs/settings'
+import helper from '@/store/helper'
+import { InternetConnectionState } from '@/types/helper'
 import { Version, VersionsQuery } from '@/types/version-chooser'
 import * as VCU from '@/utils/version_chooser'
 
@@ -47,6 +49,19 @@ export default Vue.extend({
       should_open: false,
     }
   },
+  computed: {
+    can_fetch_remote(): boolean {
+      return helper.has_internet === InternetConnectionState.ONLINE
+        || helper.has_internet === InternetConnectionState.LIMITED
+    },
+  },
+  watch: {
+    can_fetch_remote(can_fetch: boolean) {
+      if (can_fetch) {
+        this.run()
+      }
+    },
+  },
   mounted() {
     this.run()
   },
@@ -62,6 +77,10 @@ export default Vue.extend({
           this.current_version = image
           this.selected_image = image.repository
         })
+
+      if (!this.can_fetch_remote) {
+        return
+      }
 
       await VCU.loadAvailableVersions(this.selected_image)
         .then((versions_query) => {

--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -44,12 +44,13 @@
           @pull-and-apply="pullAndSetVersion"
         />
         <v-alert
-          v-if="available_versions.error"
+          v-if="remote_alert_message"
+
           color="red lighten-2"
           dark
         >
           <div class="d-flex align-center justify-space-between">
-            <span>{{ available_versions.error }}</span>
+            <span>{{ remote_alert_message }}</span>
             <v-btn
               color="warning"
               dark
@@ -117,12 +118,13 @@
           />
         </v-form>
         <v-alert
-          v-if="available_versions.error"
+          v-if="remote_alert_message"
+
           color="red lighten-2"
           dark
         >
           <div class="d-flex align-center justify-space-between">
-            <span>{{ available_versions.error }}</span>
+            <span>{{ remote_alert_message }}</span>
             <v-btn
               color="warning"
               dark
@@ -311,16 +313,32 @@ export default Vue.extend({
     inputFileRequiredMessage(): string {
       return 'File is required'
     },
-    has_internet(): boolean {
-      return helper.has_internet !== InternetConnectionState.OFFLINE
+    internet_state(): InternetConnectionState {
+      return helper.has_internet
+    },
+    is_offline(): boolean {
+      return this.internet_state === InternetConnectionState.OFFLINE
+    },
+    can_fetch_remote(): boolean {
+      return this.internet_state === InternetConnectionState.ONLINE
+        || this.internet_state === InternetConnectionState.LIMITED
+    },
+    remote_alert_message(): string | null {
+      if (this.is_offline) {
+        return "No internet connection available, can't fetch remote images"
+      }
+      return this.available_versions.error
     },
   },
   watch: {
-    has_internet(value: boolean) {
-      if (value) {
-        this.loadAvailableVersions()
-      } else {
+    is_offline(offline: boolean) {
+      if (offline) {
         this.resetToNoInternetAvailable()
+      }
+    },
+    can_fetch_remote(can_fetch: boolean) {
+      if (can_fetch) {
+        this.loadAvailableVersions()
       }
     },
   },
@@ -445,8 +463,11 @@ export default Vue.extend({
         })
     },
     async loadAvailableVersions() {
-      if (!this.has_internet) {
+      if (this.is_offline) {
         this.resetToNoInternetAvailable()
+        return
+      }
+      if (!this.can_fetch_remote) {
         return
       }
 
@@ -684,7 +705,7 @@ export default Vue.extend({
       this.available_versions = {
         ...this.available_versions,
         remote: [],
-        error: "No internet connection available, can't fetch remote images",
+        error: null,
       }
       this.latest_stable = undefined
       this.latest_beta = undefined

--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import aiodocker
+import aiohttp
 import appdirs
 import docker
 from aiohttp import web
@@ -357,6 +358,14 @@ class VersionChooser:
             assert isinstance(output["local"], list)
             output["error"], online_tags = await TagFetcher().fetch_remote_tags(
                 repository, [image["tag"] for image in output["local"]]
+            )
+        except (TimeoutError, aiohttp.ClientConnectionError, OSError) as error:
+            logger.warning(f"Skipping remote tags, DockerHub unreachable: {error or type(error).__name__}")
+            online_tags = []
+            output["error"] = (
+                DNS_FAILURE_MESSAGE
+                if is_name_resolution_error(error)
+                else "Unable to reach DockerHub, can't fetch remote images"
             )
         except Exception as error:
             logger.critical(f"error fetching online tags: {error}")

--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -23,6 +23,9 @@ DNS_FAILURE_MESSAGE = (
     "Check DNS nameservers under Network, or use Manual Upload."
 )
 
+# Unreachable DockerHub used to hang on aiohttp's 5-minute default timeout.
+DOCKERHUB_TIMEOUT = aiohttp.ClientTimeout(total=60, connect=10)
+
 
 def get_current_arch() -> str:
     """Maps platform.machine() outputs to docker architectures"""
@@ -161,6 +164,7 @@ class _HappyEyeballsConnector(aiohttp.TCPConnector):
 def _session() -> aiohttp.ClientSession:
     return aiohttp.ClientSession(
         connector=_HappyEyeballsConnector(resolver=_FamilyRaceResolver()),
+        timeout=DOCKERHUB_TIMEOUT,
     )
 
 


### PR DESCRIPTION
Unreachable DockerHub used to hang on aiohttp's 5-minute default timeout.

Cherry-pick of #4331
Fix #1788