### PR TITLE
[1.4] core: frontend: EndpointCard: Add tooltips to action buttons

### DIFF
--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -68,6 +68,7 @@
     <div class="endpoint-buttons">
       <v-btn
         v-if="!endpoint.protected && is_known_type"
+        v-tooltip="'Edit endpoint'"
         color="primary"
         dark
         fab
@@ -79,6 +80,7 @@
         </v-icon>
       </v-btn>
       <v-btn
+        v-tooltip="'Copy command line string'"
         color="primary"
         dark
         fab
@@ -91,6 +93,7 @@
       </v-btn>
       <v-btn
         v-if="!endpoint.protected || !is_known_type"
+        v-tooltip="'Delete endpoint'"
         color="error"
         dark
         fab

--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -65,34 +65,43 @@
         @change="toggleEndpointEnabled"
       />
     </div>
-    <v-btn
-      v-if="!endpoint.protected && is_known_type"
-      color="primary"
-      class="endpoint-edit-btn"
-      dark
-      fab
-      x-small
-      absolute
-      @click="openEditDialog"
-    >
-      <v-icon>
-        mdi-pencil
-      </v-icon>
-    </v-btn>
-    <v-btn
-      v-if="!endpoint.protected || !is_known_type"
-      color="error"
-      class="endpoint-remove-btn"
-      dark
-      fab
-      x-small
-      absolute
-      @click="removeEndpoint"
-    >
-      <v-icon>
-        mdi-trash-can
-      </v-icon>
-    </v-btn>
+    <div class="endpoint-buttons">
+      <v-btn
+        v-if="!endpoint.protected && is_known_type"
+        color="primary"
+        dark
+        fab
+        x-small
+        @click="openEditDialog"
+      >
+        <v-icon>
+          mdi-pencil
+        </v-icon>
+      </v-btn>
+      <v-btn
+        color="primary"
+        dark
+        fab
+        x-small
+        @click="copyEndpoint"
+      >
+        <v-icon>
+          mdi-content-copy
+        </v-icon>
+      </v-btn>
+      <v-btn
+        v-if="!endpoint.protected || !is_known_type"
+        color="error"
+        dark
+        fab
+        x-small
+        @click="removeEndpoint"
+      >
+        <v-icon>
+          mdi-trash-can
+        </v-icon>
+      </v-btn>
+    </div>
 
     <endpoint-creation-dialog
       v-model="show_edit_dialog"
@@ -106,6 +115,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 
+import { copyToClipboard } from '@/cosmos'
 import Notifier from '@/libs/notifier'
 import autopilot from '@/store/autopilot_manager'
 import { AutopilotEndpoint, isKnownEndpointType, userFriendlyEndpointType } from '@/types/autopilot'
@@ -159,6 +169,9 @@ export default Vue.extend({
     },
   },
   methods: {
+    async copyEndpoint(): Promise<void> {
+      await copyToClipboard(`${this.endpoint.connection_type}:${window.location.host}:${this.endpoint.argument}`)
+    },
     async removeEndpoint(): Promise<void> {
       autopilot.setUpdatingEndpoints(true)
       await back_axios({
@@ -197,12 +210,13 @@ export default Vue.extend({
 </script>
 
 <style scoped>
-.endpoint-edit-btn {
-  top: 20%;
+.endpoint-buttons {
+  gap: 8px;
+  display: flex;
+  position: absolute;
   right: -16px;
-}
-.endpoint-remove-btn {
-  bottom: 20%;
-  right: -16px;
+  top: 50%;
+  transform: translateY(-50%);
+  flex-direction: column;
 }
 </style>

--- a/core/frontend/src/components/autopilot/EndpointManager.vue
+++ b/core/frontend/src/components/autopilot/EndpointManager.vue
@@ -73,6 +73,7 @@
     <v-fab-transition>
       <v-btn
         :key="'create_button'"
+        v-tooltip="'Create endpoint'"
         color="primary"
         fab
         large


### PR DESCRIPTION
Includes a8d5d13a first because #4374 depends on the MAVLink endpoint copy-button refactor.

Cherry-pick of #4374
Fix #4366