### PR TITLE
[1.4] core: frontend: version-chooser: VersionChooser: Add search for remote versions

### DIFF
--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -114,7 +114,7 @@
             name="BlueOS Remote Repository"
             label="Remote repository"
             :append-icon="selected_image != default_repository ? 'mdi-restore' : undefined"
-            @click:append="selected_image = default_repository"
+            @click:append="resetToDefaultRepository()"
           />
         </v-form>
         <v-alert
@@ -712,6 +712,10 @@ export default Vue.extend({
     },
     isBeingDeleted(image: Version) {
       return this.deleting === `${image.repository}:${image.tag}`
+    },
+    resetToDefaultRepository() {
+      this.selected_image = this.default_repository
+      this.loadAvailableVersions()
     },
   },
 })

--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -117,6 +117,13 @@
             @click:append="resetToDefaultRepository()"
           />
         </v-form>
+        <v-text-field
+          v-if="showRemoteSearch"
+          v-model="search"
+          label="Search images"
+          prepend-inner-icon="mdi-magnify"
+          clearable
+        />
         <v-alert
           v-if="remote_alert_message"
 
@@ -233,6 +240,7 @@
 </template>
 
 <script lang="ts">
+import Fuse from 'fuse.js'
 import { gt as sem_ver_greater, SemVer } from 'semver'
 import Vue from 'vue'
 
@@ -273,6 +281,7 @@ export default Vue.extend({
       pull_output: '',
       show_pull_output: false,
       page: 1,
+      search: '',
       local_versions: {
         result: {
           local: [],
@@ -304,11 +313,30 @@ export default Vue.extend({
     }
   },
   computed: {
+    // Keyed off the loaded images instead of the repository field, so the bar
+    // doesn't flicker while the field is still being typed into
+    showRemoteSearch(): boolean {
+      const [first] = this.available_versions.remote
+      return first !== undefined && !first.repository.startsWith('bluerobotics/')
+    },
+    fuse(): Fuse<Version> {
+      return new Fuse(this.available_versions.remote, {
+        keys: ['tag'],
+        shouldSort: true,
+        threshold: 0.3,
+      })
+    },
+    filteredRemoteVersions(): Version[] {
+      if (!this.showRemoteSearch || !this.search) {
+        return this.available_versions.remote
+      }
+      return this.fuse.search(this.search).map(({ item }) => item)
+    },
     paginatedComponents(): Version[] {
-      return this.available_versions.remote.slice((this.page - 1) * 10, this.page * 10)
+      return this.filteredRemoteVersions.slice((this.page - 1) * 10, this.page * 10)
     },
     totalPages(): number {
-      return Math.ceil(this.available_versions.remote.length / 10)
+      return Math.ceil(this.filteredRemoteVersions.length / 10)
     },
     inputFileRequiredMessage(): string {
       return 'File is required'
@@ -331,6 +359,9 @@ export default Vue.extend({
     },
   },
   watch: {
+    search() {
+      this.page = 1
+    },
     is_offline(offline: boolean) {
       if (offline) {
         this.resetToNoInternetAvailable()
@@ -715,6 +746,7 @@ export default Vue.extend({
     },
     resetToDefaultRepository() {
       this.selected_image = this.default_repository
+      this.search = ''
       this.loadAvailableVersions()
     },
   },


### PR DESCRIPTION
Cherry-pick of #3913
Cherry-pick of #4386

<img width="964" height="448" alt="image" src="https://github.com/user-attachments/assets/a47b4205-67ba-44d4-80bf-99a00dd48f3e" />

Fix #4385