### PR TITLE
core: frontend: kraken: ExtensionCreationModal: Populate permissions correctly

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -187,12 +187,11 @@ export default Vue.extend({
   methods: {
     populatePermissions() {
       const user_permissions = JSON.parse(this.extension?.user_permissions || '{}')
-      const original_permissions = JSON.parse(this.extension?.permissions || '{}')
-      if (user_permissions) {
+      if (Object.keys(user_permissions).length > 0) {
         this.new_permissions = user_permissions
-      } else {
-        this.new_permissions = original_permissions
+        return
       }
+      this.new_permissions = JSON.parse(this.extension?.permissions || '{}')
     },
     closeDialog() {
       this.new_extension = {


### PR DESCRIPTION
Properly loads permissions only if they contain keys, since they are empty objects by default.

Fixes #4416

---

When editing a freshly installed extension in pirate mode, it now displays:

<img width="1094" height="977" alt="image" src="https://github.com/user-attachments/assets/f2aa09d8-ee56-44d5-9128-f43c9b7013a2" />
