### PR TITLE
[1.4] core: frontend: kraken: ExtensionCreationModal: Populate permissions correctly

### DIFF
--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -173,8 +173,8 @@ export default Vue.extend({
   },
   methods: {
     populatePermissions() {
-      const user_permissions = JSON.parse(this.extension?.user_permissions ?? '{}')
-      const original_permissions = JSON.parse(this.extension?.permissions ?? '{}')
+      const user_permissions = JSON.parse(this.extension?.user_permissions || '{}')
+      const original_permissions = JSON.parse(this.extension?.permissions || '{}')
       if (user_permissions) {
         this.new_permissions = user_permissions
       } else {

--- a/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
+++ b/core/frontend/src/components/kraken/modals/ExtensionCreationModal.vue
@@ -174,12 +174,11 @@ export default Vue.extend({
   methods: {
     populatePermissions() {
       const user_permissions = JSON.parse(this.extension?.user_permissions || '{}')
-      const original_permissions = JSON.parse(this.extension?.permissions || '{}')
-      if (user_permissions) {
+      if (Object.keys(user_permissions).length > 0) {
         this.new_permissions = user_permissions
-      } else {
-        this.new_permissions = original_permissions
+        return
       }
+      this.new_permissions = JSON.parse(this.extension?.permissions || '{}')
     },
     closeDialog() {
       this.new_extension = {


### PR DESCRIPTION
Properly loads permissions only if they contain keys, since they are empty objects by default.

Cherry-pick of #3556
Cherry-pick of #4419

Fixes #4416

<img width="1094" height="977" alt="image" src="https://github.com/user-attachments/assets/f2aa09d8-ee56-44d5-9128-f43c9b7013a2" />