### PR TITLE
core: kraken: Warn on extension platform incompatibility

### DIFF
--- a/core/frontend/src/types/kraken.ts
+++ b/core/frontend/src/types/kraken.ts
@@ -72,6 +72,7 @@ export interface InstalledExtensionData {
     enabled: boolean
     permissions: string
     user_permissions: string
+    platform?: string
     status?: string
     loading?: boolean
 }
@@ -112,10 +113,12 @@ export interface ExtensionUploadMetadata {
     docker?: string
     tag?: string
     permissions?: JSONValue
+    platform?: string
 }
 
 export interface ExtensionUploadResponse {
     temp_tag: string
     metadata: ExtensionUploadMetadata
     image_name: string
+    is_incompatible?: boolean
 }

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -158,6 +158,18 @@
               </div>
             </v-col>
           </v-row>
+          <v-row
+            v-if="upload_metadata && upload_is_incompatible"
+          >
+            <v-alert
+              type="warning"
+              dense
+              class="mt-4"
+            >
+              The extension's platform ({{ upload_metadata?.platform }}) doesn't match the one from your device.
+              Installing it might result in the extension failing to load.
+            </v-alert>
+          </v-row>
           <v-expand-transition>
             <div
               v-if="upload_metadata"
@@ -197,6 +209,14 @@
                   </div>
                   <div class="body-2">
                     {{ upload_metadata.tag || 'latest' }}
+                  </div>
+                </div>
+                <div>
+                  <div class="caption text--secondary">
+                    Platform
+                  </div>
+                  <div class="body-2">
+                    {{ upload_metadata.platform || 'Pending' }}
                   </div>
                 </div>
               </div>
@@ -502,6 +522,7 @@ export default Vue.extend({
       fab_menu: false,
       upload_temp_tag: null as null | string,
       upload_metadata: null as null | ExtensionUploadMetadata,
+      upload_is_incompatible: null as null | boolean,
       upload_keep_alive_task: null as null | OneMoreTime,
       selected_tar_file: null as null | File,
       file_uploading: false,
@@ -788,6 +809,7 @@ export default Vue.extend({
         )
         this.upload_temp_tag = response.temp_tag
         this.upload_metadata = response.metadata
+        this.upload_is_incompatible = response.is_incompatible
         this.startUploadKeepAlive()
         this.setInstallFromFilePhase('ready')
       } catch (error) {
@@ -1116,6 +1138,7 @@ export default Vue.extend({
         name: metadata.name || '',
         docker: metadata.docker || '',
         tag: metadata.tag || 'latest',
+        platform: metadata.platform || 'unknown',
         enabled: true,
         permissions: serializedPermissions,
         user_permissions: serializedPermissions,

--- a/core/services/kraken/api/v2/routers/extension.py
+++ b/core/services/kraken/api/v2/routers/extension.py
@@ -17,6 +17,7 @@ from fastapi.responses import Response, StreamingResponse
 from fastapi_versioning import versioned_api_route
 from loguru import logger
 from manifest.exceptions import ManifestBackendOffline
+from manifest.models import DockerPlatforms
 
 extension_router_v2 = APIRouter(
     prefix="/extension",
@@ -219,6 +220,7 @@ async def upload_tar_file(file: UploadFile = File(...)) -> dict[str, Any]:
             "temp_tag": temp_extension.tag,
             "metadata": metadata,
             "image_name": image_name,
+            "is_incompatible": metadata.get("platform") != DockerPlatforms.from_machine(),
         }
     except Exception as error:
         logger.error(f"Failed to process tar file: {error}")

--- a/core/services/kraken/extension/extension.py
+++ b/core/services/kraken/extension/extension.py
@@ -32,7 +32,7 @@ from harbor import ContainerManager, DockerCtx
 from harbor.exceptions import ContainerNotFound
 from loguru import logger
 from manifest import ManifestManager
-from manifest.models import ExtensionVersion
+from manifest.models import DockerPlatforms, ExtensionVersion
 from settings import ExtensionSettings, SettingsV2
 from utils import has_enough_disk_space
 
@@ -483,6 +483,7 @@ class Extension:
 
                 metadata = Extension._metadata_from_labels(labels)
                 metadata.update(Extension._docker_metadata(image_info))
+                metadata["platform"] = Extension._get_docker_platform_from_image_info(image_info)
                 Extension._ensure_extension_name(metadata)
 
                 return metadata
@@ -555,6 +556,19 @@ class Extension:
         image_id = image_info.get("Id", "")
         docker = image_id[:12] if image_id else "unknown"
         return {"docker": docker, "tag": "latest"}
+
+    @staticmethod
+    def _get_docker_platform_from_image_info(config: Dict[str, Any]) -> DockerPlatforms | None:
+        print("DEBUG config: ", config)
+        match config.get("Architecture", None):
+            case "arm/v6" | "arm/v7":
+                return DockerPlatforms.ARM_V7
+            case "amd64":
+                return DockerPlatforms.AMD64
+            case "arm64":
+                return DockerPlatforms.ARM64
+            case _:
+                return None
 
     @staticmethod
     def _ensure_extension_name(metadata: Dict[str, Any]) -> None:


### PR DESCRIPTION
This adds an extra `platform` field to the extension import dialog, as well as a warning when the backend detects an incompatibility between the image's architecture and the running system's.

Closes #4393 

---

On a compatible platform (in my case, `amd64`):

<img width="1440" height="981" alt="2026-09-10T13-05-21" src="https://github.com/user-attachments/assets/19571ed0-217e-4041-9530-09c9aa0d2252" />

On an incompatible one:

<img width="1440" height="981" alt="2026-09-10T13-03-44" src="https://github.com/user-attachments/assets/3e98dde4-3f4b-4119-b339-b1672b892a22" />
