### PR TITLE
core: tools: mavlink2rest: Update to 0.11.28

### DIFF
--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -3,7 +3,7 @@
 # Immediately exit on errors
 set -e
 
-VERSION="0.11.27"
+VERSION="0.11.28"
 REPOSITORY_ORG="mavlink"
 REPOSITORY_NAME="mavlink2rest"
 PROJECT_NAME="$REPOSITORY_NAME"


### PR DESCRIPTION
Add json5 support in websocket, ping @williangalvani

[changelog](https://github.com/mavlink/mavlink2rest/releases/tag/0.11.28)