### PR TITLE
[1.4] core: libs: commonwealth: utils: general: Delete rotated logs in a single pass

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -125,6 +125,49 @@ class DeletionInfo:
         return asdict(self)
 
 
+async def bulk_delete_stream(root: Path, pattern: str) -> AsyncGenerator[dict[str, Any], None]:
+    """Delete every file matching pattern under root with a single find, yielding one info for the batch.
+
+    Each file deleted from python costs a thread hop, a json fragment and a http chunk, and that dominates
+    the time when a folder holds thousands of rotated logs. find does the whole tree in one process, so the
+    batch is reported as a single event with the total freed size.
+    """
+    # fmt: off
+    cmd = [
+        "find", str(root),
+        "-type", "f",
+        "-name", pattern,
+        "-printf", "%s\n",  # sizes have to be printed before -delete, the file is gone after it
+        "-delete",
+    ]
+    # fmt: on
+
+    process = await asyncio.create_subprocess_exec(*cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    except asyncio.TimeoutError:
+        process.kill()
+        logger.error(f"Timed out bulk deleting {pattern} in {root}, the file by file walk takes what is left")
+        return
+
+    if process.returncode != 0:
+        logger.warning(f"Failed to bulk delete {pattern} in {root}: {stderr.decode().strip()}")
+
+    sizes = [int(size) for size in stdout.split()]
+    if not sizes:
+        logger.warning(f"No sizes found for {pattern} in {root}")
+        return
+
+    # fmt: off
+    yield DeletionInfo(
+        path=f"{root}/{pattern} ({len(sizes)} files)",
+        size=sum(sizes),
+        type="file",
+        success=True
+    ).to_dict()
+    # fmt: on
+
+
 async def delete_everything_stream(
     path: Path, open_files: set[Path] | None = None
 ) -> AsyncGenerator[dict[str, Any], None]:

--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -181,8 +181,8 @@ async def delete_everything_stream(
     Yields:
         Dictionary containing information about each file being deleted:
         {
-            'path': str,  # Path of the file being deleted
-            'size': int,  # Size of the file in bytes
+            'path': str,  # Path of the file being deleted, or of the pattern of a bulk deleted batch
+            'size': int,  # Size in bytes, summed over the batch when several files go at once
             'type': str,  # 'file' or 'directory'
             'success': bool  # Whether deletion was successful
         }
@@ -213,6 +213,10 @@ async def delete_everything_stream(
         return
 
     if open_files is None and path.is_dir():
+        # Rotated logs are never held open and are most of the tree, taking them out first also shrinks
+        # what lsof has to walk below
+        async for info in bulk_delete_stream(path, "*.gz"):
+            yield info
         open_files = await asyncio.to_thread(open_files_under, path)
 
     items = await asyncio.to_thread(lambda: list(path.glob("*")))

--- a/core/libs/commonwealth/commonwealth/utils/tests/test_general.py
+++ b/core/libs/commonwealth/commonwealth/utils/tests/test_general.py
@@ -247,16 +247,43 @@ async def test_delete_everything_stream(tmp_path: Path) -> None:
     rotated_log = root / "rotated.gz"
     rotated_log.write_text("gz", encoding="utf-8")
 
-    infos = [info async for info in general.delete_everything_stream(root)]
+    # .gz files are deleted in a single batch, even while a process holds them open
+    with open(rotated_log, "r", encoding="utf-8"):
+        infos = [info async for info in general.delete_everything_stream(root)]
 
-    assert {info["path"] for info in infos} == {str(small), str(nested_file), str(rotated_log)}
+    batch = f"{root}/*.gz (1 files)"
+    assert {info["path"] for info in infos} == {batch, str(small), str(nested_file)}
     assert all(info["success"] for info in infos)
     assert all(info["type"] == "file" for info in infos)
     sizes = {info["path"]: info["size"] for info in infos}
     assert sizes[str(small)] == 5
+    assert sizes[batch] == 2
     assert not small.exists()
     assert not nested_file.exists()
     assert not rotated_log.exists()
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_stream_sums_the_batch(tmp_path: Path) -> None:
+    root = tmp_path / "logs"
+    (root / "nested").mkdir(parents=True)
+    (root / "keep.log").write_text("keep", encoding="utf-8")
+    (root / "a.gz").write_text("aa", encoding="utf-8")
+    (root / "nested" / "b.gz").write_text("bbb", encoding="utf-8")
+
+    infos = [info async for info in general.bulk_delete_stream(root, "*.gz")]
+
+    assert infos == [{"path": f"{root}/*.gz (2 files)", "size": 5, "type": "file", "success": True}]
+    assert (root / "keep.log").exists()
+    assert not list(root.rglob("*.gz"))
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_stream_without_matches(tmp_path: Path) -> None:
+    root = tmp_path / "logs"
+    root.mkdir()
+
+    assert [info async for info in general.bulk_delete_stream(root, "*.gz")] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Cherry-pick of #4356

Tests adapted for 1.4-dev test order.