### PR TITLE
frontend goes vroom

### DIFF
--- a/core/frontend/src/components/app/BackendStatusChecker.vue
+++ b/core/frontend/src/components/app/BackendStatusChecker.vue
@@ -14,10 +14,12 @@ const notifier = new Notifier(frontend_service)
 
 export default Vue.extend({
   name: 'BackendStatusChecker',
-  data: () => ({
-    backend_offline: false,
-    check_backend_status_task: new OneMoreTime({ delay: 3000, disposeWith: this }),
-  }),
+  data() {
+    return {
+      backend_offline: false,
+      check_backend_status_task: new OneMoreTime({ delay: 3000, disposeWith: this }),
+    }
+  },
   computed: {
     status_text(): string {
       return this.backend_offline ? 'Disconnected' : ''

--- a/core/frontend/src/components/vehiclesetup/overview/VideoOverview.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/VideoOverview.vue
@@ -69,8 +69,8 @@ export default Vue.extend({
   },
   data() {
     return {
-      fetch_devices_task: new OneMoreTime({ delay: 1000, disposeWith: this }),
-      fetch_streams_task: new OneMoreTime({ delay: 1000, disposeWith: this }),
+      fetch_devices_task: new OneMoreTime({ delay: 5000, disposeWith: this }),
+      fetch_streams_task: new OneMoreTime({ delay: 5000, disposeWith: this }),
     }
   },
   computed: {

--- a/core/frontend/src/components/wizard/DefaultParamLoader.vue
+++ b/core/frontend/src/components/wizard/DefaultParamLoader.vue
@@ -113,16 +113,18 @@ export default Vue.extend({
       required: true,
     },
   },
-  data: () => ({
-    all_param_sets: {} as Dictionary<Dictionary<number>>,
-    selected_param_set: {},
-    selected_param_set_name: '' as string,
-    version: undefined as (undefined | SemVer),
-    fetch_retries: 0,
-    is_loading_parameters: false,
-    has_parameters_load_error: false,
-    fetch_current_board_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
-  }),
+  data() {
+    return {
+      all_param_sets: {} as Dictionary<Dictionary<number>>,
+      selected_param_set: {},
+      selected_param_set_name: '' as string,
+      version: undefined as (undefined | SemVer),
+      fetch_retries: 0,
+      is_loading_parameters: false,
+      has_parameters_load_error: false,
+      fetch_current_board_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
+    }
+  },
   computed: {
     filtered_param_sets(): Dictionary<Dictionary<number>> {
       return {

--- a/core/frontend/src/components/wizard/ScriptLoader.vue
+++ b/core/frontend/src/components/wizard/ScriptLoader.vue
@@ -60,15 +60,17 @@ export default Vue.extend({
       required: true,
     },
   },
-  data: () => ({
-    all_scripts: [] as string[],
-    selected_scripts: [] as string[],
-    version: undefined as (undefined | SemVer),
-    fetch_retries: 0,
-    is_loading_scripts: false,
-    has_script_load_error: false,
-    fetch_current_board_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
-  }),
+  data() {
+    return {
+      all_scripts: [] as string[],
+      selected_scripts: [] as string[],
+      version: undefined as (undefined | SemVer),
+      fetch_retries: 0,
+      is_loading_scripts: false,
+      has_script_load_error: false,
+      fetch_current_board_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
+    }
+  },
   computed: {
     filtered_scripts(): string[] | undefined {
       // for scripts, we only check major version for now

--- a/core/frontend/src/components/zenoh-inspector/ZenohInspector.vue
+++ b/core/frontend/src/components/zenoh-inspector/ZenohInspector.vue
@@ -127,7 +127,7 @@ import {
 import { parse as parseMessageDefinition } from '@foxglove/rosmsg'
 import { MessageReader } from '@foxglove/rosmsg2-serialization'
 import axios from 'axios'
-import Vue from 'vue'
+import Vue, { markRaw } from 'vue'
 
 import zenoh from '@/libs/zenoh'
 
@@ -159,6 +159,13 @@ export default Vue.extend({
       subscriber: null as Subscriber | null,
       liveliness_subscriber: null as Subscriber | null,
       video_reader: null as MessageReader | null,
+      // markRaw: written once per arriving sample, must not be observed or we just move the cost here.
+      // Keyed by topic, so it stays bounded by topic count even when requestAnimationFrame is throttled.
+      // Null-prototype because zenoh key expressions can collide with Object.prototype keys.
+      staging: markRaw({
+        messages: Object.create(null) as { [key: string]: ZenohMessage },
+        frame_request: null as number | null,
+      }),
     }
   },
   computed: {
@@ -241,6 +248,24 @@ export default Vue.extend({
         || Object.prototype.hasOwnProperty.call(this.topic_liveliness, topic)
     },
 
+    flushStagedMessages() {
+      this.staging.frame_request = null
+      const batch = this.staging.messages
+      this.staging.messages = Object.create(null)
+
+      const new_topics: string[] = []
+      for (const topic of Object.keys(batch)) {
+        if (!this.isKnownTopic(topic)) {
+          new_topics.push(topic)
+        }
+        this.$set(this.messages, topic, batch[topic])
+      }
+
+      if (new_topics.length > 0) {
+        this.topics = [...this.topics, ...new_topics].sort()
+      }
+    },
+
     async setupZenoh() {
       try {
         this.session = await zenoh.getSession()
@@ -260,11 +285,16 @@ export default Vue.extend({
               timestamp: new Date(),
             }
 
-            // Update topics before messages, isKnownTopic reads the map that $set is about to fill
-            if (!this.isKnownTopic(topic)) {
-              this.topics = [...this.topics, topic].sort()
+            // The selected topic bypasses batching because RawVideoPlayer's decoders consume every sample
+            if (topic === this.selected_topic) {
+              delete this.staging.messages[topic]
+              this.$set(this.messages, topic, message)
+            } else {
+              this.staging.messages[topic] = message
+              if (this.staging.frame_request === null) {
+                this.staging.frame_request = requestAnimationFrame(this.flushStagedMessages)
+              }
             }
-            this.$set(this.messages, topic, message)
 
             return Promise.resolve()
           },
@@ -311,6 +341,10 @@ export default Vue.extend({
       }
     },
     async disconnectZenoh() {
+      if (this.staging.frame_request !== null) {
+        cancelAnimationFrame(this.staging.frame_request)
+        this.staging.frame_request = null
+      }
       this.subscriber?.undeclare()
       this.liveliness_subscriber?.undeclare()
       this.session = null

--- a/core/frontend/src/components/zenoh-inspector/ZenohInspector.vue
+++ b/core/frontend/src/components/zenoh-inspector/ZenohInspector.vue
@@ -234,6 +234,13 @@ export default Vue.extend({
       return JSON.stringify(formattedMessage, null, 2)
     },
 
+    // `topics` is the union of both keyed maps, so membership is a constant time lookup instead of a scan.
+    // Own properties only, otherwise a key expression named after an Object.prototype member reads as known.
+    isKnownTopic(topic: string): boolean {
+      return Object.prototype.hasOwnProperty.call(this.messages, topic)
+        || Object.prototype.hasOwnProperty.call(this.topic_liveliness, topic)
+    },
+
     async setupZenoh() {
       try {
         this.session = await zenoh.getSession()
@@ -253,11 +260,11 @@ export default Vue.extend({
               timestamp: new Date(),
             }
 
-            // Update messages and topics
-            this.$set(this.messages, topic, message)
-            if (!this.topics.includes(topic)) {
+            // Update topics before messages, isKnownTopic reads the map that $set is about to fill
+            if (!this.isKnownTopic(topic)) {
               this.topics = [...this.topics, topic].sort()
             }
+            this.$set(this.messages, topic, message)
 
             return Promise.resolve()
           },
@@ -285,15 +292,15 @@ export default Vue.extend({
 
             const isAlive = sample.kind() === SampleKind.PUT
 
+            // Add to topics if not already present, before $set fills the map isKnownTopic reads
+            if (!this.isKnownTopic(topic)) {
+              this.topics = [...this.topics, topic].sort()
+            }
+
             // Update liveliness state and type
             this.$set(this.topic_liveliness, topic, isAlive)
             this.$set(this.topic_types, topic, type)
             this.$set(this.topic_message_types, topic, messageTyp)
-
-            // Add to topics if not already present
-            if (!this.topics.includes(topic)) {
-              this.topics = [...this.topics, topic].sort()
-            }
 
             return Promise.resolve()
           },

--- a/core/frontend/src/one-more-time.ts
+++ b/core/frontend/src/one-more-time.ts
@@ -38,7 +38,7 @@ export interface OneMoreTimeOptions {
    * Reference to some object instance that can be used as a source to dispose the
    * OneMoreTime instance.
    */
-  disposeWith?: unknown
+  disposeWith?: { _isDestroyed?: boolean }
 }
 
 /**
@@ -77,6 +77,13 @@ export class OneMoreTime {
   }
 
   private watchDisposeWith(): void {
+    // A component instance always carries `_isDestroyed`, anything else (like the module scope captured by an
+    // arrow-function `data`) can never be watched and would keep the task running forever
+    // eslint-disable-next-line no-underscore-dangle
+    if ('disposeWith' in this.options && this.options.disposeWith?._isDestroyed === undefined) {
+      console.warn('OneMoreTime: disposeWith is not a component instance, task will never be disposed')
+    }
+
     if (this.options.disposeWith) {
       const ref = new WeakRef(this.options.disposeWith)
 

--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -130,12 +130,14 @@ export default Vue.extend({
     SelfHealthTest,
     GenericViewer,
   },
-  data: () => ({
-    windowHeight: window.innerHeight,
-    windowWidth: window.innerWidth,
-    fetch_streams_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
-    lastOrientation: { roll: 0, pitch: 0, yaw: 0 } as Orientation,
-  }),
+  data() {
+    return {
+      windowHeight: window.innerHeight,
+      windowWidth: window.innerWidth,
+      fetch_streams_task: new OneMoreTime({ delay: 10000, disposeWith: this }),
+      lastOrientation: { roll: 0, pitch: 0, yaw: 0 } as Orientation,
+    }
+  },
   computed: {
     apps(): AppItem[] {
       return [

--- a/core/frontend/src/views/Pings.vue
+++ b/core/frontend/src/views/Pings.vue
@@ -44,10 +44,12 @@ import Ping360Card from '../components/ping/ping360.vue'
 export default Vue.extend({
   name: 'Pings',
   components: { PingCard, Ping360Card },
-  data: () => ({
-    PingType,
-    fetch_serial_task: new OneMoreTime({ delay: 5000, disposeWith: this }),
-  }),
+  data() {
+    return {
+      PingType,
+      fetch_serial_task: new OneMoreTime({ delay: 5000, disposeWith: this }),
+    }
+  },
   computed: {
     ping_devices(): PingDevice[] {
       return ping.available_ping_devices


### PR DESCRIPTION
Helps #4434 

Improve:
- zenoh page
- one_more_time leaks
    - ping page
    - main page
    - backend status
    - wizard
- decrease video overview update rate (from 1s to 5s)

Results:

<img width="1715" height="1092" alt="solved-01-cpu-mean" src="https://github.com/user-attachments/assets/39e524ad-4d5e-4577-ab85-e4870b85c2f7" />
<img width="1733" height="1092" alt="solved-02-cpu-peak" src="https://github.com/user-attachments/assets/98f3d7a9-b0a8-4939-a5b2-7ea3adba03ab" />
<img width="2086" height="823" alt="solved-03-process-breakdown" src="https://github.com/user-attachments/assets/b1d4b28e-d981-49af-8603-1b0c658c232d" />
<img width="1715" height="1092" alt="solved-04-network-vehicle-setup" src="https://github.com/user-attachments/assets/3b43ec51-b925-4694-be0e-75341b26f6cd" />
<img width="1715" height="905" alt="solved-05-poller-leak" src="https://github.com/user-attachments/assets/7e4229c4-92ac-42b2-88c6-9d06fb8aa124" />
<img width="1715" height="1092" alt="solved-06-heap-peak" src="https://github.com/user-attachments/assets/988d89b9-e678-4df5-ace7-8c2ce984a9fb" />
<img width="1715" height="905" alt="solved-07-zenoh-invariants" src="https://github.com/user-attachments/assets/64f1d5f0-7fe8-4cab-b7e8-893553148cdc" />
<img width="1715" height="905" alt="solved-08-dev-vs-prod-calibration" src="https://github.com/user-attachments/assets/4d8e1783-2c4c-4299-bb43-e1cdccb069b1" />
<img width="1789" height="1114" alt="solved-09-summary-all-fixes" src="https://github.com/user-attachments/assets/2b390529-f3e2-4d33-8a95-f335c5613176" />
